### PR TITLE
re #17 add univeros/cli — attribute-driven CLI on Symfony Console

### DIFF
--- a/bin/altair
+++ b/bin/altair
@@ -1,0 +1,65 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+use Altair\Cli\Application;
+use Altair\Cli\Configuration\CliConfiguration;
+use Altair\Container\Container;
+
+(static function (): void {
+    $autoloadCandidates = [
+        __DIR__ . '/../vendor/autoload.php',         // run from inside this repo
+        __DIR__ . '/../../../autoload.php',          // run from inside a consuming project's vendor/bin
+    ];
+
+    foreach ($autoloadCandidates as $autoload) {
+        if (is_file($autoload)) {
+            require $autoload;
+
+            return;
+        }
+    }
+
+    fwrite(STDERR, "Unable to locate Composer autoloader; run 'composer install' first.\n");
+    exit(1);
+})();
+
+$paths = [];
+
+// Built-in framework commands ship with their own packages.
+$builtIn = [
+    __DIR__ . '/../src/Altair/AgentSpec/Cli',
+];
+foreach ($builtIn as $entry) {
+    if (is_dir($entry)) {
+        $paths[] = $entry;
+    }
+}
+
+foreach (['ALTAIR_CLI_PATHS', 'ALTAIR_CLI_PATH'] as $envName) {
+    $value = getenv($envName);
+    if ($value === false || $value === '') {
+        continue;
+    }
+    foreach (explode(PATH_SEPARATOR, $value) as $entry) {
+        $entry = trim($entry);
+        if ($entry !== '' && is_dir($entry)) {
+            $paths[] = $entry;
+        }
+    }
+}
+
+$container = new Container();
+(new CliConfiguration($paths))->apply($container);
+
+$application = $container->make(Application::class);
+
+exit($application->run());

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,13 @@
         "psr/log": "^3.0",
         "psr/simple-cache": "^3.0",
         "relay/relay": "^2.1",
+        "symfony/console": "^7.0",
         "vlucas/phpdotenv": "^5.6",
         "willdurand/negotiation": "^3.1"
     },
+    "bin": [
+        "bin/altair"
+    ],
     "require-dev": {
         "ext-intl": "*",
         "ext-memcached": "*",
@@ -57,7 +61,9 @@
         }
     },
     "replace": {
+        "univeros/agent-spec": "self.version",
         "univeros/cache": "self.version",
+        "univeros/cli": "self.version",
         "univeros/common": "self.version",
         "univeros/configuration": "self.version",
         "univeros/container": "self.version",

--- a/rector.php
+++ b/rector.php
@@ -54,6 +54,13 @@ return RectorConfig::configure()
         \Rector\TypeDeclaration\Rector\ClassMethod\ReturnTypeFromReturnDirectArrayRector::class => [
             __DIR__ . '/tests/Container/fixtures.php',
         ],
+        // CLI discovery fixtures intentionally declare #[Argument]/#[Option]
+        // attributes on __invoke parameters. The body returns 0 without using
+        // them, but the parameters are the test surface — they're what the
+        // AttributeCommandDiscoverer reflects on. Rector sees them as unused.
+        \Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPublicMethodParameterRector::class => [
+            __DIR__ . '/tests/Cli/Discovery/fixtures',
+        ],
     ])
     ->withPhpSets(php83: true)
     ->withSets([

--- a/src/Altair/Cli/AltairCommand.php
+++ b/src/Altair/Cli/AltairCommand.php
@@ -100,8 +100,8 @@ class AltairCommand extends SymfonyCommand
     {
         try {
             $arguments = $this->resolveArguments($input);
-        } catch (ValueCoercionException $e) {
-            throw new SymfonyInvalidArgumentException($e->getMessage(), 0, $e);
+        } catch (ValueCoercionException $valueCoercionException) {
+            throw new SymfonyInvalidArgumentException($valueCoercionException->getMessage(), 0, $valueCoercionException);
         }
 
         $instance = $this->container->make($this->commandClass);

--- a/src/Altair/Cli/AltairCommand.php
+++ b/src/Altair/Cli/AltairCommand.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli;
+
+use Altair\Cli\Attribute\Argument as ArgumentAttribute;
+use Altair\Cli\Attribute\Command as CommandAttribute;
+use Altair\Cli\Attribute\Option as OptionAttribute;
+use Altair\Cli\Binding\ArgumentBinder;
+use Altair\Cli\Binding\OptionBinder;
+use Altair\Cli\Binding\ParameterTypeInspector;
+use Altair\Cli\Binding\ValueCoercer;
+use Altair\Cli\Exception\InvalidCommandException;
+use Altair\Cli\Exception\ValueCoercionException;
+use Altair\Container\Container;
+use Override;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionParameter;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Exception\InvalidArgumentException as SymfonyInvalidArgumentException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Bridges a user-authored, attribute-decorated invokable class to
+ * Symfony Console's Command surface. Each AltairCommand wraps exactly
+ * one user class and delegates execution to its __invoke method.
+ */
+class AltairCommand extends SymfonyCommand
+{
+    private readonly CommandAttribute $metadata;
+
+    private readonly ReflectionMethod $invoker;
+
+    /** @var list<ReflectionParameter> */
+    private readonly array $parameters;
+
+    /**
+     * @param class-string $commandClass
+     */
+    public function __construct(
+        private readonly string $commandClass,
+        private readonly Container $container,
+        private readonly ArgumentBinder $argumentBinder = new ArgumentBinder(),
+        private readonly OptionBinder $optionBinder = new OptionBinder(),
+        private readonly ValueCoercer $coercer = new ValueCoercer(),
+        private readonly ParameterTypeInspector $inspector = new ParameterTypeInspector(),
+    ) {
+        $this->metadata = $this->resolveMetadata($commandClass);
+        $this->invoker = $this->resolveInvoker($commandClass);
+        $this->parameters = $this->invoker->getParameters();
+
+        parent::__construct($this->metadata->name);
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this
+            ->setDescription($this->metadata->description)
+            ->setAliases($this->metadata->aliases)
+            ->setHidden($this->metadata->hidden);
+
+        if ($this->metadata->help !== '') {
+            $this->setHelp($this->metadata->help);
+        }
+
+        foreach ($this->parameters as $parameter) {
+            if ($this->argumentBinder->supports($parameter)) {
+                $this->getDefinition()->addArgument($this->argumentBinder->bind($parameter));
+                continue;
+            }
+
+            if ($this->optionBinder->supports($parameter)) {
+                $this->getDefinition()->addOption($this->optionBinder->bind($parameter));
+                continue;
+            }
+
+            throw new InvalidCommandException(
+                \sprintf(
+                    "Parameter '%s' of %s::__invoke() is missing an Argument or Option attribute.",
+                    $parameter->getName(),
+                    $this->commandClass,
+                ),
+            );
+        }
+    }
+
+    #[Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        try {
+            $arguments = $this->resolveArguments($input);
+        } catch (ValueCoercionException $e) {
+            throw new SymfonyInvalidArgumentException($e->getMessage(), 0, $e);
+        }
+
+        $instance = $this->container->make($this->commandClass);
+        $result = $this->invoker->invoke($instance, ...$arguments);
+
+        if ($result === null) {
+            return self::SUCCESS;
+        }
+
+        if (!\is_int($result)) {
+            throw new InvalidCommandException(
+                \sprintf(
+                    "%s::__invoke() must return int or void; got %s.",
+                    $this->commandClass,
+                    get_debug_type($result),
+                ),
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return list<mixed>
+     */
+    private function resolveArguments(InputInterface $input): array
+    {
+        $resolved = [];
+        foreach ($this->parameters as $parameter) {
+            $resolved[] = $this->resolveParameter($parameter, $input);
+        }
+
+        return $resolved;
+    }
+
+    private function resolveParameter(ReflectionParameter $parameter, InputInterface $input): mixed
+    {
+        $type = $this->inspector->namedType($parameter);
+        $argumentAttribute = $parameter->getAttributes(ArgumentAttribute::class);
+
+        if ($argumentAttribute !== []) {
+            $attribute = $argumentAttribute[0]->newInstance();
+            $name = $attribute->name ?? $parameter->getName();
+            $value = $input->getArgument($name);
+
+            return $this->coercer->coerce($value, $type, $parameter->getName());
+        }
+
+        $optionAttribute = $parameter->getAttributes(OptionAttribute::class);
+        if ($optionAttribute === []) {
+            throw new InvalidCommandException(
+                \sprintf("Parameter '%s' has no Argument or Option attribute.", $parameter->getName()),
+            );
+        }
+
+        $attribute = $optionAttribute[0]->newInstance();
+        $name = $attribute->name ?? $this->inspector->kebabCase($parameter->getName());
+        $value = $input->getOption($name);
+
+        return $this->coercer->coerce($value, $type, $parameter->getName());
+    }
+
+    /**
+     * @param class-string $commandClass
+     */
+    private function resolveMetadata(string $commandClass): CommandAttribute
+    {
+        if (!class_exists($commandClass)) {
+            throw new InvalidCommandException(
+                \sprintf("Command class '%s' does not exist.", $commandClass),
+            );
+        }
+
+        $reflection = new ReflectionClass($commandClass);
+        $attributes = $reflection->getAttributes(CommandAttribute::class);
+
+        if ($attributes === []) {
+            throw new InvalidCommandException(
+                \sprintf("Class '%s' is missing the Command attribute.", $commandClass),
+            );
+        }
+
+        return $attributes[0]->newInstance();
+    }
+
+    /**
+     * @param class-string $commandClass
+     */
+    private function resolveInvoker(string $commandClass): ReflectionMethod
+    {
+        if (!method_exists($commandClass, '__invoke')) {
+            throw new InvalidCommandException(
+                \sprintf("Class '%s' must define an __invoke() method.", $commandClass),
+            );
+        }
+
+        return new ReflectionMethod($commandClass, '__invoke');
+    }
+}

--- a/src/Altair/Cli/Application.php
+++ b/src/Altair/Cli/Application.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli;
+
+use Altair\Container\Container;
+use Symfony\Component\Console\Application as SymfonyApplication;
+
+/**
+ * Thin Symfony Console Application subclass that resolves user-authored
+ * command classes through the framework's Container.
+ */
+class Application extends SymfonyApplication
+{
+    public const string DEFAULT_NAME = 'Altair';
+
+    public const string DEFAULT_VERSION = '2.x-dev';
+
+    public function __construct(
+        private readonly Container $container,
+        string $name = self::DEFAULT_NAME,
+        string $version = self::DEFAULT_VERSION,
+    ) {
+        parent::__construct($name, $version);
+    }
+
+    /**
+     * Register the given user command classes as Symfony Console commands.
+     *
+     * @param iterable<class-string> $commandClasses
+     */
+    public function discover(iterable $commandClasses): self
+    {
+        foreach ($commandClasses as $class) {
+            $this->add(new AltairCommand($class, $this->container));
+        }
+
+        return $this;
+    }
+}

--- a/src/Altair/Cli/Attribute/Argument.php
+++ b/src/Altair/Cli/Attribute/Argument.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Argument
+{
+    /**
+     * @param string|null $name Optional override for the public argument name; defaults to the parameter name
+     */
+    public function __construct(
+        public string $description = '',
+        public ?string $name = null,
+    ) {}
+}

--- a/src/Altair/Cli/Attribute/Command.php
+++ b/src/Altair/Cli/Attribute/Command.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final readonly class Command
+{
+    /**
+     * @param list<string> $aliases
+     */
+    public function __construct(
+        public string $name,
+        public string $description = '',
+        public array $aliases = [],
+        public bool $hidden = false,
+        public string $help = '',
+    ) {}
+}

--- a/src/Altair/Cli/Attribute/Option.php
+++ b/src/Altair/Cli/Attribute/Option.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Attribute;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final readonly class Option
+{
+    /**
+     * @param string|null $name  Optional override for the public option name; defaults to the parameter name (kebab-cased)
+     * @param string|null $short Single-character short alias (e.g. 'p')
+     */
+    public function __construct(
+        public string $description = '',
+        public ?string $name = null,
+        public ?string $short = null,
+    ) {}
+}

--- a/src/Altair/Cli/Binding/ArgumentBinder.php
+++ b/src/Altair/Cli/Binding/ArgumentBinder.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Binding;
+
+use Altair\Cli\Attribute\Argument;
+use ReflectionParameter;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ArgumentBinder
+{
+    public function __construct(
+        private readonly ParameterTypeInspector $inspector = new ParameterTypeInspector(),
+    ) {}
+
+    public function supports(ReflectionParameter $parameter): bool
+    {
+        return $parameter->getAttributes(Argument::class) !== [];
+    }
+
+    public function bind(ReflectionParameter $parameter): InputArgument
+    {
+        $attribute = $this->resolveAttribute($parameter);
+        $name = $attribute->name ?? $parameter->getName();
+        $hasDefault = $parameter->isDefaultValueAvailable();
+        $isArray = $this->inspector->isArray($parameter);
+
+        $mode = $hasDefault ? InputArgument::OPTIONAL : InputArgument::REQUIRED;
+        if ($isArray) {
+            $mode |= InputArgument::IS_ARRAY;
+        }
+
+        $default = $hasDefault ? $this->inspector->defaultForConsole($parameter) : null;
+        if ($isArray && $default === null && $hasDefault) {
+            $default = [];
+        }
+
+        return new InputArgument($name, $mode, $attribute->description, $default);
+    }
+
+    private function resolveAttribute(ReflectionParameter $parameter): Argument
+    {
+        $attributes = $parameter->getAttributes(Argument::class);
+        if ($attributes === []) {
+            return new Argument();
+        }
+
+        return $attributes[0]->newInstance();
+    }
+}

--- a/src/Altair/Cli/Binding/OptionBinder.php
+++ b/src/Altair/Cli/Binding/OptionBinder.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Binding;
+
+use Altair\Cli\Attribute\Option;
+use Altair\Cli\Exception\InvalidCommandException;
+use ReflectionParameter;
+use Symfony\Component\Console\Input\InputOption;
+
+class OptionBinder
+{
+    public function __construct(
+        private readonly ParameterTypeInspector $inspector = new ParameterTypeInspector(),
+    ) {}
+
+    public function supports(ReflectionParameter $parameter): bool
+    {
+        return $parameter->getAttributes(Option::class) !== [];
+    }
+
+    public function bind(ReflectionParameter $parameter): InputOption
+    {
+        $attribute = $this->resolveAttribute($parameter);
+        $name = $attribute->name ?? $this->inspector->kebabCase($parameter->getName());
+        $isBool = $this->inspector->isBool($parameter);
+        $isArray = $this->inspector->isArray($parameter);
+
+        if ($isBool) {
+            $mode = InputOption::VALUE_NONE;
+            $default = null;
+        } else {
+            $mode = InputOption::VALUE_REQUIRED;
+            if ($isArray) {
+                $mode |= InputOption::VALUE_IS_ARRAY;
+            }
+            $default = $parameter->isDefaultValueAvailable()
+                ? $this->inspector->defaultForConsole($parameter)
+                : null;
+            if ($isArray && $default === null) {
+                $default = [];
+            }
+        }
+
+        return new InputOption(
+            $name,
+            $attribute->short,
+            $mode,
+            $attribute->description,
+            $default,
+        );
+    }
+
+    private function resolveAttribute(ReflectionParameter $parameter): Option
+    {
+        $attributes = $parameter->getAttributes(Option::class);
+        if ($attributes === []) {
+            throw new InvalidCommandException(
+                \sprintf("Parameter '%s' is not marked as a CLI option.", $parameter->getName()),
+            );
+        }
+
+        return $attributes[0]->newInstance();
+    }
+}

--- a/src/Altair/Cli/Binding/OptionBinder.php
+++ b/src/Altair/Cli/Binding/OptionBinder.php
@@ -42,6 +42,7 @@ class OptionBinder
             if ($isArray) {
                 $mode |= InputOption::VALUE_IS_ARRAY;
             }
+
             $default = $parameter->isDefaultValueAvailable()
                 ? $this->inspector->defaultForConsole($parameter)
                 : null;

--- a/src/Altair/Cli/Binding/ParameterTypeInspector.php
+++ b/src/Altair/Cli/Binding/ParameterTypeInspector.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Binding;
+
+use Altair\Cli\Exception\InvalidCommandException;
+use BackedEnum;
+use ReflectionNamedType;
+use ReflectionParameter;
+
+/**
+ * Small read-only helper to interpret a ReflectionParameter the way the
+ * CLI binders need: native named type, array-ness, enum-ness, default value.
+ */
+class ParameterTypeInspector
+{
+    public function namedType(ReflectionParameter $parameter): ?ReflectionNamedType
+    {
+        $type = $parameter->getType();
+        if (!$type instanceof ReflectionNamedType) {
+            return null;
+        }
+
+        return $type;
+    }
+
+    public function typeName(ReflectionParameter $parameter): ?string
+    {
+        return $this->namedType($parameter)?->getName();
+    }
+
+    public function isBool(ReflectionParameter $parameter): bool
+    {
+        return $this->typeName($parameter) === 'bool';
+    }
+
+    public function isArray(ReflectionParameter $parameter): bool
+    {
+        return $this->typeName($parameter) === 'array';
+    }
+
+    public function isBackedEnum(ReflectionParameter $parameter): bool
+    {
+        $name = $this->typeName($parameter);
+        if ($name === null) {
+            return false;
+        }
+
+        return is_subclass_of($name, BackedEnum::class);
+    }
+
+    /**
+     * Returns the default value of the parameter as a primitive that
+     * Symfony Console can store (string, int, bool, null, or array).
+     */
+    public function defaultForConsole(ReflectionParameter $parameter): mixed
+    {
+        if (!$parameter->isDefaultValueAvailable()) {
+            return null;
+        }
+
+        $default = $parameter->getDefaultValue();
+        if ($default instanceof BackedEnum) {
+            return $default->value;
+        }
+
+        return $default;
+    }
+
+    public function kebabCase(string $name): string
+    {
+        $result = preg_replace('/([a-z0-9])([A-Z])/', '$1-$2', $name);
+        if ($result === null) {
+            throw new InvalidCommandException(
+                \sprintf("Cannot derive kebab-case name from '%s'.", $name),
+            );
+        }
+
+        return strtolower($result);
+    }
+}

--- a/src/Altair/Cli/Binding/ValueCoercer.php
+++ b/src/Altair/Cli/Binding/ValueCoercer.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Binding;
+
+use Altair\Cli\Exception\ValueCoercionException;
+use BackedEnum;
+use DateTimeImmutable;
+use Exception;
+use ReflectionEnum;
+use ReflectionNamedType;
+
+/**
+ * Coerces raw string values coming out of Symfony Console's InputInterface
+ * into the native PHP type declared by the target __invoke parameter.
+ */
+class ValueCoercer
+{
+    private const array BOOL_TRUE = ['1', 'true', 'yes', 'on', 'y'];
+
+    private const array BOOL_FALSE = ['0', 'false', 'no', 'off', 'n', ''];
+
+    /**
+     * Coerce a raw input value to the type described by $type.
+     *
+     * @param mixed                    $value The raw value from Symfony Console (string, bool, array, or null)
+     * @param ReflectionNamedType|null $type  The native parameter type; null means mixed / untyped
+     */
+    public function coerce(mixed $value, ?ReflectionNamedType $type, string $parameterName): mixed
+    {
+        if ($type === null) {
+            return $value;
+        }
+
+        if ($value === null) {
+            if ($type->allowsNull()) {
+                return null;
+            }
+
+            throw new ValueCoercionException(
+                \sprintf("Parameter '%s' does not allow null.", $parameterName),
+            );
+        }
+
+        $typeName = $type->getName();
+
+        return match (true) {
+            $typeName === 'string' => $this->toString($value, $parameterName),
+            $typeName === 'int' => $this->toInt($value, $parameterName),
+            $typeName === 'float' => $this->toFloat($value, $parameterName),
+            $typeName === 'bool' => $this->toBool($value, $parameterName),
+            $typeName === 'array' => $this->toArray($value, $parameterName),
+            $typeName === DateTimeImmutable::class => $this->toDateTimeImmutable($value, $parameterName),
+            is_subclass_of($typeName, BackedEnum::class) => $this->toBackedEnum($typeName, $value, $parameterName),
+            default => throw new ValueCoercionException(
+                \sprintf("Unsupported type '%s' for parameter '%s'.", $typeName, $parameterName),
+            ),
+        };
+    }
+
+    private function toString(mixed $value, string $name): string
+    {
+        if (\is_string($value)) {
+            return $value;
+        }
+
+        if (\is_scalar($value)) {
+            return (string) $value;
+        }
+
+        throw new ValueCoercionException(
+            \sprintf("Cannot coerce value of type '%s' to string for parameter '%s'.", get_debug_type($value), $name),
+        );
+    }
+
+    private function toInt(mixed $value, string $name): int
+    {
+        if (\is_int($value)) {
+            return $value;
+        }
+
+        if (\is_string($value) && preg_match('/^-?\d+$/', $value) === 1) {
+            return (int) $value;
+        }
+
+        throw new ValueCoercionException(
+            \sprintf("Value '%s' is not a valid integer for parameter '%s'.", $this->describe($value), $name),
+        );
+    }
+
+    private function toFloat(mixed $value, string $name): float
+    {
+        if (\is_float($value) || \is_int($value)) {
+            return (float) $value;
+        }
+
+        if (\is_string($value) && is_numeric($value)) {
+            return (float) $value;
+        }
+
+        throw new ValueCoercionException(
+            \sprintf("Value '%s' is not a valid float for parameter '%s'.", $this->describe($value), $name),
+        );
+    }
+
+    private function toBool(mixed $value, string $name): bool
+    {
+        if (\is_bool($value)) {
+            return $value;
+        }
+
+        if (\is_int($value)) {
+            return $value !== 0;
+        }
+
+        if (\is_string($value)) {
+            $normalized = strtolower($value);
+            if (\in_array($normalized, self::BOOL_TRUE, true)) {
+                return true;
+            }
+            if (\in_array($normalized, self::BOOL_FALSE, true)) {
+                return false;
+            }
+        }
+
+        throw new ValueCoercionException(
+            \sprintf("Value '%s' is not a valid boolean for parameter '%s'.", $this->describe($value), $name),
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function toArray(mixed $value, string $name): array
+    {
+        if (\is_array($value)) {
+            return array_values(array_map(static fn(mixed $item): string => (string) $item, $value));
+        }
+
+        if (\is_string($value)) {
+            if ($value === '') {
+                return [];
+            }
+
+            return array_values(array_map('trim', explode(',', $value)));
+        }
+
+        throw new ValueCoercionException(
+            \sprintf("Value '%s' cannot be coerced to array for parameter '%s'.", $this->describe($value), $name),
+        );
+    }
+
+    private function toDateTimeImmutable(mixed $value, string $name): DateTimeImmutable
+    {
+        if ($value instanceof DateTimeImmutable) {
+            return $value;
+        }
+
+        if (!\is_string($value) || $value === '') {
+            throw new ValueCoercionException(
+                \sprintf("Value for parameter '%s' must be an ISO-8601 string.", $name),
+            );
+        }
+
+        try {
+            return new DateTimeImmutable($value);
+        } catch (Exception $e) {
+            throw new ValueCoercionException(
+                \sprintf("Value '%s' is not a valid ISO-8601 datetime for parameter '%s'.", $value, $name),
+                previous: $e,
+            );
+        }
+    }
+
+    /**
+     * @param class-string<BackedEnum> $enumClass
+     */
+    private function toBackedEnum(string $enumClass, mixed $value, string $name): BackedEnum
+    {
+        if ($value instanceof $enumClass) {
+            return $value;
+        }
+
+        $reflection = new ReflectionEnum($enumClass);
+        $backingType = $reflection->getBackingType()?->getName();
+
+        $candidate = match ($backingType) {
+            'int' => \is_int($value) ? $value : (\is_string($value) && preg_match('/^-?\d+$/', $value) === 1 ? (int) $value : null),
+            'string' => \is_string($value) ? $value : (\is_scalar($value) ? (string) $value : null),
+            default => null,
+        };
+
+        if ($candidate === null) {
+            throw new ValueCoercionException(
+                \sprintf(
+                    "Value '%s' is not a valid case of enum '%s' for parameter '%s'.",
+                    $this->describe($value),
+                    $enumClass,
+                    $name,
+                ),
+            );
+        }
+
+        $case = $enumClass::tryFrom($candidate);
+        if ($case === null) {
+            throw new ValueCoercionException(
+                \sprintf(
+                    "Value '%s' is not a valid case of enum '%s' for parameter '%s'.",
+                    $this->describe($value),
+                    $enumClass,
+                    $name,
+                ),
+            );
+        }
+
+        return $case;
+    }
+
+    private function describe(mixed $value): string
+    {
+        if (\is_scalar($value)) {
+            return (string) $value;
+        }
+
+        return get_debug_type($value);
+    }
+}

--- a/src/Altair/Cli/Binding/ValueCoercer.php
+++ b/src/Altair/Cli/Binding/ValueCoercer.php
@@ -36,7 +36,7 @@ class ValueCoercer
      */
     public function coerce(mixed $value, ?ReflectionNamedType $type, string $parameterName): mixed
     {
-        if ($type === null) {
+        if (!$type instanceof ReflectionNamedType) {
             return $value;
         }
 
@@ -126,6 +126,7 @@ class ValueCoercer
             if (\in_array($normalized, self::BOOL_TRUE, true)) {
                 return true;
             }
+
             if (\in_array($normalized, self::BOOL_FALSE, true)) {
                 return false;
             }
@@ -172,10 +173,10 @@ class ValueCoercer
 
         try {
             return new DateTimeImmutable($value);
-        } catch (Exception $e) {
+        } catch (Exception $exception) {
             throw new ValueCoercionException(
                 \sprintf("Value '%s' is not a valid ISO-8601 datetime for parameter '%s'.", $value, $name),
-                previous: $e,
+                previous: $exception,
             );
         }
     }

--- a/src/Altair/Cli/Configuration/CliConfiguration.php
+++ b/src/Altair/Cli/Configuration/CliConfiguration.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Configuration;
+
+use Altair\Cli\Application;
+use Altair\Cli\Contracts\CommandLocatorInterface;
+use Altair\Cli\Discovery\AttributeCommandDiscoverer;
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Container\Container;
+use Override;
+
+/**
+ * Wires the CLI sub-package into the Container.
+ *
+ * - Shares the AttributeCommandDiscoverer so it stays cheap to reuse.
+ * - Aliases CommandLocatorInterface to the concrete discoverer.
+ * - Delegates Application creation so it auto-discovers commands from
+ *   the configured paths the first time it is resolved.
+ */
+class CliConfiguration implements ConfigurationInterface
+{
+    /**
+     * @param list<string> $paths Directories to scan for #[Command]-attributed classes
+     */
+    public function __construct(
+        private readonly array $paths = [],
+        private readonly string $name = Application::DEFAULT_NAME,
+        private readonly string $version = Application::DEFAULT_VERSION,
+    ) {}
+
+    #[Override]
+    public function apply(Container $container): void
+    {
+        $paths = $this->paths;
+        $name = $this->name;
+        $version = $this->version;
+
+        $container
+            ->alias(CommandLocatorInterface::class, AttributeCommandDiscoverer::class)
+            ->share(AttributeCommandDiscoverer::class)
+            ->delegate(
+                Application::class,
+                static fn(
+                    AttributeCommandDiscoverer $discoverer,
+                ): Application => (new Application($container, $name, $version))->discover($discoverer->scan($paths)),
+            );
+    }
+}

--- a/src/Altair/Cli/Contracts/CommandLocatorInterface.php
+++ b/src/Altair/Cli/Contracts/CommandLocatorInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Contracts;
+
+interface CommandLocatorInterface
+{
+    /**
+     * Scan the given paths and return the fully-qualified class names of
+     * every class decorated with the framework's #[Command] attribute.
+     *
+     * @param  list<string>             $paths
+     * @return iterable<class-string>
+     */
+    public function scan(array $paths): iterable;
+}

--- a/src/Altair/Cli/Discovery/AttributeCommandDiscoverer.php
+++ b/src/Altair/Cli/Discovery/AttributeCommandDiscoverer.php
@@ -41,6 +41,7 @@ class AttributeCommandDiscoverer implements CommandLocatorInterface
                 if (isset($found[$class])) {
                     continue;
                 }
+
                 $found[$class] = true;
 
                 yield $class;
@@ -64,7 +65,11 @@ class AttributeCommandDiscoverer implements CommandLocatorInterface
         );
 
         foreach ($iterator as $file) {
-            if (!$file->isFile() || $file->getExtension() !== 'php') {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'php') {
                 continue;
             }
 

--- a/src/Altair/Cli/Discovery/AttributeCommandDiscoverer.php
+++ b/src/Altair/Cli/Discovery/AttributeCommandDiscoverer.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Discovery;
+
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Contracts\CommandLocatorInterface;
+use Altair\Cli\Exception\InvalidArgumentException;
+use FilesystemIterator;
+use Override;
+use PhpToken;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+
+/**
+ * Discovers classes decorated with #[Command] by walking the given
+ * directories, parsing the namespace/class declaration of each PHP file,
+ * and reflecting on the discovered class names.
+ */
+class AttributeCommandDiscoverer implements CommandLocatorInterface
+{
+    /**
+     * @param  list<string>             $paths
+     * @return iterable<class-string>
+     */
+    #[Override]
+    public function scan(array $paths): iterable
+    {
+        $found = [];
+        foreach ($paths as $path) {
+            foreach ($this->scanPath($path) as $class) {
+                if (isset($found[$class])) {
+                    continue;
+                }
+                $found[$class] = true;
+
+                yield $class;
+            }
+        }
+    }
+
+    /**
+     * @return iterable<class-string>
+     */
+    private function scanPath(string $path): iterable
+    {
+        if (!is_dir($path)) {
+            throw new InvalidArgumentException(
+                \sprintf("Path '%s' is not a readable directory.", $path),
+            );
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            foreach ($this->extractClasses((string) $file) as $class) {
+                if (!$this->hasCommandAttribute($class)) {
+                    continue;
+                }
+
+                yield $class;
+            }
+        }
+    }
+
+    /**
+     * Extract fully-qualified class names declared in a PHP file. Uses the
+     * native tokenizer so we never have to execute or include the file
+     * before deciding whether to reflect on it.
+     *
+     * @return list<class-string>
+     */
+    private function extractClasses(string $filePath): array
+    {
+        $code = @file_get_contents($filePath);
+        if ($code === false || $code === '') {
+            return [];
+        }
+
+        $tokens = PhpToken::tokenize($code);
+
+        $namespace = '';
+        $classes = [];
+        $tokenCount = \count($tokens);
+
+        for ($i = 0; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+
+            if ($token->is(T_NAMESPACE)) {
+                $namespace = $this->readNamespace($tokens, $i);
+                continue;
+            }
+
+            if (!$token->is(T_CLASS)) {
+                continue;
+            }
+
+            // Skip `::class` and `new class` (anonymous) usages.
+            if ($this->isClassKeywordUsage($tokens, $i)) {
+                continue;
+            }
+
+            $className = $this->readClassName($tokens, $i);
+            if ($className === null) {
+                continue;
+            }
+
+            $fqcn = $namespace === '' ? $className : $namespace . '\\' . $className;
+            /** @var class-string $fqcn */
+            $classes[] = $fqcn;
+        }
+
+        return $classes;
+    }
+
+    /**
+     * @param list<PhpToken> $tokens
+     */
+    private function readNamespace(array $tokens, int $start): string
+    {
+        $tokenCount = \count($tokens);
+        $namespace = '';
+
+        for ($i = $start + 1; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+            if ($token->text === ';' || $token->text === '{') {
+                break;
+            }
+
+            if ($token->is([T_STRING, T_NS_SEPARATOR, T_NAME_QUALIFIED, T_NAME_FULLY_QUALIFIED])) {
+                $namespace .= $token->text;
+            }
+        }
+
+        return trim($namespace, '\\');
+    }
+
+    /**
+     * @param list<PhpToken> $tokens
+     */
+    private function readClassName(array $tokens, int $start): ?string
+    {
+        $tokenCount = \count($tokens);
+
+        for ($i = $start + 1; $i < $tokenCount; $i++) {
+            $token = $tokens[$i];
+            if ($token->is([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])) {
+                continue;
+            }
+
+            if ($token->is(T_STRING)) {
+                return $token->text;
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Returns true when the `class` keyword is being used as `Foo::class`
+     * or `new class {}` rather than as a class declaration.
+     *
+     * @param list<PhpToken> $tokens
+     */
+    private function isClassKeywordUsage(array $tokens, int $position): bool
+    {
+        for ($i = $position - 1; $i >= 0; $i--) {
+            $token = $tokens[$i];
+            if ($token->is([T_WHITESPACE, T_COMMENT, T_DOC_COMMENT])) {
+                continue;
+            }
+
+            return $token->is([T_DOUBLE_COLON, T_NEW]);
+        }
+
+        return false;
+    }
+
+    private function hasCommandAttribute(string $class): bool
+    {
+        if (!class_exists($class)) {
+            return false;
+        }
+
+        $reflection = new ReflectionClass($class);
+        if ($reflection->isAbstract() || $reflection->isInterface() || $reflection->isTrait()) {
+            return false;
+        }
+
+        return $reflection->getAttributes(Command::class) !== [];
+    }
+}

--- a/src/Altair/Cli/Exception/InvalidArgumentException.php
+++ b/src/Altair/Cli/Exception/InvalidArgumentException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Exception;
+
+class InvalidArgumentException extends \InvalidArgumentException {}

--- a/src/Altair/Cli/Exception/InvalidCommandException.php
+++ b/src/Altair/Cli/Exception/InvalidCommandException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Exception;
+
+use LogicException;
+
+class InvalidCommandException extends LogicException {}

--- a/src/Altair/Cli/Exception/ValueCoercionException.php
+++ b/src/Altair/Cli/Exception/ValueCoercionException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Cli\Exception;
+
+class ValueCoercionException extends InvalidArgumentException {}

--- a/src/Altair/Cli/composer.json
+++ b/src/Altair/Cli/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "univeros/cli",
+    "description": "Attribute-driven CLI built on top of Symfony Console.",
+    "license": "MIT",
+    "homepage": "https://univeros.io",
+    "support": {
+        "issues": "https://github.com/univeros/framework/issues",
+        "source": "https://github.com/univeros/framework"
+    },
+    "require": {
+        "php": ">=8.3",
+        "symfony/console": "^7.0",
+        "univeros/configuration": "^2.0",
+        "univeros/container": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Altair\\Cli\\": ""
+        }
+    }
+}

--- a/tests/Cli/Binding/ArgumentBinderTest.php
+++ b/tests/Cli/Binding/ArgumentBinderTest.php
@@ -9,7 +9,6 @@ use Altair\Cli\Binding\ArgumentBinder;
 use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 use ReflectionParameter;
-use Symfony\Component\Console\Input\InputArgument;
 
 class ArgumentBinderTest extends TestCase
 {

--- a/tests/Cli/Binding/ArgumentBinderTest.php
+++ b/tests/Cli/Binding/ArgumentBinderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Binding;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Binding\ArgumentBinder;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionParameter;
+use Symfony\Component\Console\Input\InputArgument;
+
+class ArgumentBinderTest extends TestCase
+{
+    public function testRequiredWhenNoDefault(): void
+    {
+        $binder = new ArgumentBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Argument(description: 'The email')]
+                string $email,
+            ): int => 0,
+        );
+
+        $this->assertTrue($binder->supports($parameter));
+
+        $argument = $binder->bind($parameter);
+        $this->assertSame('email', $argument->getName());
+        $this->assertTrue($argument->isRequired());
+        $this->assertFalse($argument->isArray());
+        $this->assertSame('The email', $argument->getDescription());
+    }
+
+    public function testOptionalWhenDefaultProvided(): void
+    {
+        $binder = new ArgumentBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Argument]
+                string $env = 'production',
+            ): int => 0,
+        );
+
+        $argument = $binder->bind($parameter);
+        $this->assertFalse($argument->isRequired());
+        $this->assertSame('production', $argument->getDefault());
+    }
+
+    public function testArrayArgument(): void
+    {
+        $binder = new ArgumentBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Argument(description: 'Files')]
+                array $files = [],
+            ): int => 0,
+        );
+
+        $argument = $binder->bind($parameter);
+        $this->assertTrue($argument->isArray());
+        $this->assertSame([], $argument->getDefault());
+    }
+
+    public function testNameOverride(): void
+    {
+        $binder = new ArgumentBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Argument(name: 'user-email')]
+                string $email,
+            ): int => 0,
+        );
+
+        $argument = $binder->bind($parameter);
+        $this->assertSame('user-email', $argument->getName());
+    }
+
+    public function testDoesNotSupportUnattributedParameter(): void
+    {
+        $binder = new ArgumentBinder();
+        $parameter = $this->parameter(static fn (string $email): int => 0);
+
+        $this->assertFalse($binder->supports($parameter));
+    }
+
+    private function parameter(callable $callable): ReflectionParameter
+    {
+        return (new ReflectionFunction($callable))->getParameters()[0];
+    }
+}

--- a/tests/Cli/Binding/OptionBinderTest.php
+++ b/tests/Cli/Binding/OptionBinderTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Binding;
+
+use Altair\Cli\Attribute\Option;
+use Altair\Cli\Binding\OptionBinder;
+use Altair\Tests\Cli\Fixture\Role;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionParameter;
+use Symfony\Component\Console\Input\InputOption;
+
+class OptionBinderTest extends TestCase
+{
+    public function testBoolBecomesFlag(): void
+    {
+        $binder = new OptionBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Option(description: 'Silent')]
+                bool $silent = false,
+            ): int => 0,
+        );
+
+        $option = $binder->bind($parameter);
+        $this->assertSame('silent', $option->getName());
+        $this->assertFalse($option->acceptValue());
+        $this->assertSame('Silent', $option->getDescription());
+    }
+
+    public function testStringValueOption(): void
+    {
+        $binder = new OptionBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Option(short: 'p')]
+                ?string $password = null,
+            ): int => 0,
+        );
+
+        $option = $binder->bind($parameter);
+        $this->assertSame('password', $option->getName());
+        $this->assertSame('p', $option->getShortcut());
+        $this->assertTrue($option->isValueRequired());
+        $this->assertNull($option->getDefault());
+    }
+
+    public function testEnumDefaultUsesBackingValue(): void
+    {
+        $binder = new OptionBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Option]
+                Role $role = Role::Member,
+            ): int => 0,
+        );
+
+        $option = $binder->bind($parameter);
+        $this->assertSame('role', $option->getName());
+        $this->assertSame(Role::Member->value, $option->getDefault());
+    }
+
+    public function testArrayOption(): void
+    {
+        $binder = new OptionBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Option]
+                array $tag = [],
+            ): int => 0,
+        );
+
+        $option = $binder->bind($parameter);
+        $this->assertTrue($option->isArray());
+        $this->assertSame([], $option->getDefault());
+    }
+
+    public function testCamelCaseNameIsKebabCased(): void
+    {
+        $binder = new OptionBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Option]
+                ?string $maxRetries = null,
+            ): int => 0,
+        );
+
+        $option = $binder->bind($parameter);
+        $this->assertSame('max-retries', $option->getName());
+    }
+
+    public function testNameOverride(): void
+    {
+        $binder = new OptionBinder();
+        $parameter = $this->parameter(
+            static fn (
+                #[Option(name: 'output-dir')]
+                ?string $out = null,
+            ): int => 0,
+        );
+
+        $option = $binder->bind($parameter);
+        $this->assertSame('output-dir', $option->getName());
+    }
+
+    private function parameter(callable $callable): ReflectionParameter
+    {
+        return (new ReflectionFunction($callable))->getParameters()[0];
+    }
+}

--- a/tests/Cli/Binding/OptionBinderTest.php
+++ b/tests/Cli/Binding/OptionBinderTest.php
@@ -10,7 +10,6 @@ use Altair\Tests\Cli\Fixture\Role;
 use PHPUnit\Framework\TestCase;
 use ReflectionFunction;
 use ReflectionParameter;
-use Symfony\Component\Console\Input\InputOption;
 
 class OptionBinderTest extends TestCase
 {

--- a/tests/Cli/Binding/ValueCoercerTest.php
+++ b/tests/Cli/Binding/ValueCoercerTest.php
@@ -18,6 +18,7 @@ class ValueCoercerTest extends TestCase
 {
     private ValueCoercer $coercer;
 
+    #[\Override]
     protected function setUp(): void
     {
         $this->coercer = new ValueCoercer();

--- a/tests/Cli/Binding/ValueCoercerTest.php
+++ b/tests/Cli/Binding/ValueCoercerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Binding;
+
+use Altair\Cli\Binding\ValueCoercer;
+use Altair\Cli\Exception\ValueCoercionException;
+use Altair\Tests\Cli\Fixture\Priority;
+use Altair\Tests\Cli\Fixture\Role;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+use ReflectionFunction;
+use ReflectionNamedType;
+
+class ValueCoercerTest extends TestCase
+{
+    private ValueCoercer $coercer;
+
+    protected function setUp(): void
+    {
+        $this->coercer = new ValueCoercer();
+    }
+
+    public function testStringPassthrough(): void
+    {
+        $type = $this->typeFor(static fn (string $v): string => $v);
+        $this->assertSame('hello', $this->coercer->coerce('hello', $type, 'v'));
+    }
+
+    public function testIntCoercion(): void
+    {
+        $type = $this->typeFor(static fn (int $v): int => $v);
+        $this->assertSame(42, $this->coercer->coerce('42', $type, 'v'));
+        $this->assertSame(-7, $this->coercer->coerce('-7', $type, 'v'));
+    }
+
+    public function testIntCoercionRejectsNonInteger(): void
+    {
+        $this->expectException(ValueCoercionException::class);
+
+        $type = $this->typeFor(static fn (int $v): int => $v);
+        $this->coercer->coerce('not-an-int', $type, 'v');
+    }
+
+    public function testFloatCoercion(): void
+    {
+        $type = $this->typeFor(static fn (float $v): float => $v);
+        $this->assertSame(1.5, $this->coercer->coerce('1.5', $type, 'v'));
+    }
+
+    #[DataProvider('boolTrueProvider')]
+    public function testBoolCoercionTruthyValues(mixed $value): void
+    {
+        $type = $this->typeFor(static fn (bool $v): bool => $v);
+        $this->assertTrue($this->coercer->coerce($value, $type, 'v'));
+    }
+
+    #[DataProvider('boolFalseProvider')]
+    public function testBoolCoercionFalsyValues(mixed $value): void
+    {
+        $type = $this->typeFor(static fn (bool $v): bool => $v);
+        $this->assertFalse($this->coercer->coerce($value, $type, 'v'));
+    }
+
+    public function testBoolCoercionRejectsGarbage(): void
+    {
+        $this->expectException(ValueCoercionException::class);
+
+        $type = $this->typeFor(static fn (bool $v): bool => $v);
+        $this->coercer->coerce('maybe', $type, 'v');
+    }
+
+    public function testDateTimeImmutableCoercion(): void
+    {
+        $type = $this->typeFor(static fn (DateTimeImmutable $v): DateTimeImmutable => $v);
+        $value = $this->coercer->coerce('2026-05-26T10:00:00Z', $type, 'v');
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $value);
+        $this->assertSame('2026-05-26T10:00:00+00:00', $value->format('c'));
+    }
+
+    public function testDateTimeImmutableRejectsInvalidString(): void
+    {
+        $this->expectException(ValueCoercionException::class);
+
+        $type = $this->typeFor(static fn (DateTimeImmutable $v): DateTimeImmutable => $v);
+        $this->coercer->coerce('not a date', $type, 'v');
+    }
+
+    public function testStringBackedEnumCoercion(): void
+    {
+        $type = $this->typeFor(static fn (Role $v): Role => $v);
+        $this->assertSame(Role::Admin, $this->coercer->coerce('admin', $type, 'v'));
+    }
+
+    public function testIntBackedEnumCoercion(): void
+    {
+        $type = $this->typeFor(static fn (Priority $v): Priority => $v);
+        $this->assertSame(Priority::High, $this->coercer->coerce('3', $type, 'v'));
+    }
+
+    public function testBackedEnumRejectsUnknownCase(): void
+    {
+        $this->expectException(ValueCoercionException::class);
+
+        $type = $this->typeFor(static fn (Role $v): Role => $v);
+        $this->coercer->coerce('bogus', $type, 'v');
+    }
+
+    public function testArrayCoercionFromCommaSeparated(): void
+    {
+        $type = $this->typeFor(static fn (array $v): array => $v);
+        $this->assertSame(['a', 'b', 'c'], $this->coercer->coerce('a,b,c', $type, 'v'));
+    }
+
+    public function testArrayCoercionFromArray(): void
+    {
+        $type = $this->typeFor(static fn (array $v): array => $v);
+        $this->assertSame(['a', 'b'], $this->coercer->coerce(['a', 'b'], $type, 'v'));
+    }
+
+    public function testNullableAllowsNull(): void
+    {
+        $type = $this->typeFor(static fn (?string $v): ?string => $v);
+        $this->assertNull($this->coercer->coerce(null, $type, 'v'));
+    }
+
+    public function testNonNullableRejectsNull(): void
+    {
+        $this->expectException(ValueCoercionException::class);
+
+        $type = $this->typeFor(static fn (string $v): string => $v);
+        $this->coercer->coerce(null, $type, 'v');
+    }
+
+    /**
+     * @return iterable<array{0: mixed}>
+     */
+    public static function boolTrueProvider(): iterable
+    {
+        yield ['true'];
+        yield ['1'];
+        yield ['yes'];
+        yield ['on'];
+        yield [true];
+        yield [1];
+    }
+
+    /**
+     * @return iterable<array{0: mixed}>
+     */
+    public static function boolFalseProvider(): iterable
+    {
+        yield ['false'];
+        yield ['0'];
+        yield ['no'];
+        yield ['off'];
+        yield [false];
+        yield [0];
+    }
+
+    private function typeFor(callable $callable): ReflectionNamedType
+    {
+        $params = (new ReflectionFunction($callable))->getParameters();
+        $type = $params[0]->getType();
+        $this->assertInstanceOf(ReflectionNamedType::class, $type);
+
+        return $type;
+    }
+}

--- a/tests/Cli/Discovery/AttributeCommandDiscovererTest.php
+++ b/tests/Cli/Discovery/AttributeCommandDiscovererTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Discovery;
+
+use Altair\Cli\Discovery\AttributeCommandDiscoverer;
+use Altair\Cli\Exception\InvalidArgumentException;
+use Altair\Tests\Cli\Discovery\fixtures\CreateUserCommand;
+use Altair\Tests\Cli\Discovery\fixtures\Nested\NestedCommand;
+use Altair\Tests\Cli\Discovery\fixtures\NotACommand;
+use PHPUnit\Framework\TestCase;
+
+class AttributeCommandDiscovererTest extends TestCase
+{
+    public function testFindsAttributedClassesInRoot(): void
+    {
+        $discoverer = new AttributeCommandDiscoverer();
+        $found = iterator_to_array($discoverer->scan([__DIR__ . '/fixtures']));
+
+        $this->assertContains(CreateUserCommand::class, $found);
+    }
+
+    public function testRecursesIntoSubdirectories(): void
+    {
+        $discoverer = new AttributeCommandDiscoverer();
+        $found = iterator_to_array($discoverer->scan([__DIR__ . '/fixtures']));
+
+        $this->assertContains(NestedCommand::class, $found);
+    }
+
+    public function testIgnoresClassesWithoutCommandAttribute(): void
+    {
+        $discoverer = new AttributeCommandDiscoverer();
+        $found = iterator_to_array($discoverer->scan([__DIR__ . '/fixtures']));
+
+        $this->assertNotContains(NotACommand::class, $found);
+    }
+
+    public function testDeduplicatesAcrossMultiplePaths(): void
+    {
+        $discoverer = new AttributeCommandDiscoverer();
+        $found = iterator_to_array(
+            $discoverer->scan([__DIR__ . '/fixtures', __DIR__ . '/fixtures']),
+        );
+
+        $this->assertCount(
+            count(array_unique($found)),
+            $found,
+            'Discoverer must not yield duplicate classes across overlapping paths.',
+        );
+    }
+
+    public function testThrowsOnUnreadableDirectory(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $discoverer = new AttributeCommandDiscoverer();
+        iterator_to_array($discoverer->scan(['/non/existent/path']));
+    }
+}

--- a/tests/Cli/Discovery/fixtures/CreateUserCommand.php
+++ b/tests/Cli/Discovery/fixtures/CreateUserCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Discovery\fixtures;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use Altair\Tests\Cli\Fixture\Role;
+
+#[Command(
+    name: 'fixture:create-user',
+    description: 'Create a fixture user',
+    aliases: ['fixture:users:add'],
+)]
+final class CreateUserCommand
+{
+    public function __invoke(
+        #[Argument(description: 'The user email')]
+        string $email,
+        #[Option(short: 'p', description: 'Initial password')]
+        ?string $password = null,
+        #[Option(short: 'r', description: 'User role')]
+        Role $role = Role::Member,
+        #[Option(description: 'Skip welcome email')]
+        bool $silent = false,
+    ): int {
+        return 0;
+    }
+}

--- a/tests/Cli/Discovery/fixtures/Nested/NestedCommand.php
+++ b/tests/Cli/Discovery/fixtures/Nested/NestedCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Discovery\fixtures\Nested;
+
+use Altair\Cli\Attribute\Command;
+
+#[Command(name: 'fixture:nested', description: 'A nested fixture command')]
+final class NestedCommand
+{
+    public function __invoke(): int
+    {
+        return 0;
+    }
+}

--- a/tests/Cli/Discovery/fixtures/NotACommand.php
+++ b/tests/Cli/Discovery/fixtures/NotACommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Discovery\fixtures;
+
+/**
+ * Plain class without #[Command]; should be ignored by the discoverer
+ * even though it lives under a scanned path.
+ */
+final class NotACommand
+{
+    public function someMethod(): string
+    {
+        return 'not a command';
+    }
+}

--- a/tests/Cli/Fixture/CreateUserIntegrationCommand.php
+++ b/tests/Cli/Fixture/CreateUserIntegrationCommand.php
@@ -14,10 +14,10 @@ use Altair\Cli\Attribute\Option;
     aliases: ['users:add'],
     help: 'Detailed help block.',
 )]
-final class CreateUserIntegrationCommand
+final readonly class CreateUserIntegrationCommand
 {
     public function __construct(
-        private readonly SpyUserRepository $repository,
+        private SpyUserRepository $repository,
     ) {
     }
 

--- a/tests/Cli/Fixture/CreateUserIntegrationCommand.php
+++ b/tests/Cli/Fixture/CreateUserIntegrationCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Fixture;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+
+#[Command(
+    name: 'users:create',
+    description: 'Create a new user account',
+    aliases: ['users:add'],
+    help: 'Detailed help block.',
+)]
+final class CreateUserIntegrationCommand
+{
+    public function __construct(
+        private readonly SpyUserRepository $repository,
+    ) {
+    }
+
+    public function __invoke(
+        #[Argument(description: 'The user email')]
+        string $email,
+        #[Option(short: 'p', description: 'Initial password (random if omitted)')]
+        ?string $password = null,
+        #[Option(short: 'r', description: 'User role')]
+        Role $role = Role::Member,
+        #[Option(description: 'Skip welcome email')]
+        bool $silent = false,
+    ): int {
+        $this->repository->create($email, $password, $role, $silent);
+
+        return 0;
+    }
+}

--- a/tests/Cli/Fixture/Priority.php
+++ b/tests/Cli/Fixture/Priority.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Fixture;
+
+enum Priority: int
+{
+    case Low = 1;
+    case Medium = 2;
+    case High = 3;
+}

--- a/tests/Cli/Fixture/Role.php
+++ b/tests/Cli/Fixture/Role.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Fixture;
+
+enum Role: string
+{
+    case Admin = 'admin';
+    case Member = 'member';
+    case Guest = 'guest';
+}

--- a/tests/Cli/Fixture/SpyUserRepository.php
+++ b/tests/Cli/Fixture/SpyUserRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli\Fixture;
+
+class SpyUserRepository
+{
+    /** @var list<array{email: string, password: ?string, role: Role, silent: bool}> */
+    public array $calls = [];
+
+    public function create(string $email, ?string $password, Role $role, bool $silent): void
+    {
+        $this->calls[] = [
+            'email' => $email,
+            'password' => $password,
+            'role' => $role,
+            'silent' => $silent,
+        ];
+    }
+}

--- a/tests/Cli/IntegrationTest.php
+++ b/tests/Cli/IntegrationTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Cli;
+
+use Altair\Cli\AltairCommand;
+use Altair\Cli\Application;
+use Altair\Cli\Configuration\CliConfiguration;
+use Altair\Container\Container;
+use Altair\Tests\Cli\Fixture\CreateUserIntegrationCommand;
+use Altair\Tests\Cli\Fixture\Role;
+use Altair\Tests\Cli\Fixture\SpyUserRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Exception\InvalidArgumentException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class IntegrationTest extends TestCase
+{
+    public function testCommandIsInvokedWithCoercedArguments(): void
+    {
+        [$container, $repository] = $this->buildContainer();
+        $command = new AltairCommand(CreateUserIntegrationCommand::class, $container);
+
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([
+            'email' => 'jane@example.com',
+            '--password' => 's3cret',
+            '--role' => Role::Admin->value,
+            '--silent' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(1, $repository->calls);
+        $this->assertSame('jane@example.com', $repository->calls[0]['email']);
+        $this->assertSame('s3cret', $repository->calls[0]['password']);
+        $this->assertSame(Role::Admin, $repository->calls[0]['role']);
+        $this->assertTrue($repository->calls[0]['silent']);
+    }
+
+    public function testOptionsFallBackToDefaults(): void
+    {
+        [$container, $repository] = $this->buildContainer();
+        $command = new AltairCommand(CreateUserIntegrationCommand::class, $container);
+
+        $tester = new CommandTester($command);
+        $tester->execute(['email' => 'pat@example.com']);
+
+        $this->assertCount(1, $repository->calls);
+        $this->assertNull($repository->calls[0]['password']);
+        $this->assertSame(Role::Member, $repository->calls[0]['role']);
+        $this->assertFalse($repository->calls[0]['silent']);
+    }
+
+    public function testInvalidEnumProducesCleanSymfonyConsoleError(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessageMatches('/not a valid case of enum/i');
+
+        [$container] = $this->buildContainer();
+        $command = new AltairCommand(CreateUserIntegrationCommand::class, $container);
+
+        $tester = new CommandTester($command);
+        $tester->execute([
+            'email' => 'jane@example.com',
+            '--role' => 'super-admin',
+        ]);
+    }
+
+    public function testApplicationAutoDiscoversCommands(): void
+    {
+        $container = new Container();
+        $configuration = new CliConfiguration([__DIR__ . '/Discovery/fixtures']);
+        $configuration->apply($container);
+
+        $application = $container->make(Application::class);
+        $application->setAutoExit(false);
+
+        $this->assertTrue($application->has('fixture:create-user'));
+        $this->assertTrue($application->has('fixture:nested'));
+    }
+
+    public function testHelpOutputContainsAttributeDescriptions(): void
+    {
+        [$container] = $this->buildContainer();
+        $command = new AltairCommand(CreateUserIntegrationCommand::class, $container);
+        $command->mergeApplicationDefinition();
+
+        $emailArgument = $command->getDefinition()->getArgument('email');
+        $passwordOption = $command->getDefinition()->getOption('password');
+
+        $this->assertSame('The user email', $emailArgument->getDescription());
+        $this->assertSame('Initial password (random if omitted)', $passwordOption->getDescription());
+        $this->assertSame('Create a new user account', $command->getDescription());
+        $this->assertContains('users:add', $command->getAliases());
+        $this->assertSame('Detailed help block.', $command->getHelp());
+    }
+
+    /**
+     * @return array{0: Container, 1: SpyUserRepository}
+     */
+    private function buildContainer(): array
+    {
+        $container = new Container();
+        $repository = new SpyUserRepository();
+        $container->share($repository);
+
+        return [$container, $repository];
+    }
+}


### PR DESCRIPTION
## Summary

- New `univeros/cli` sub-package: a thin, attribute-driven wrapper around Symfony Console where commands are `#[Command]`-decorated invokable classes whose `__invoke()` signature drives argument and option binding.
- Native PHP types drive parsing (`string`, `int`, `float`, `bool`, `array`, `DateTimeImmutable`, backed enums); constructor dependencies are resolved through `Altair\Container\Container`, mirroring the framework's HTTP Action / Responder shape.
- Ships `bin/altair` (lists Symfony defaults on an empty project, `ALTAIR_CLI_PATHS` env var picks up scan directories) and a `CliConfiguration` so the CLI plugs into the framework's existing Configuration chain.

### What landed

**Code (`src/Altair/Cli/`):**
- Attributes — `Command`, `Argument`, `Option` (readonly value objects)
- Binding — `ValueCoercer` (typed coercion with clean Symfony errors), `ArgumentBinder`, `OptionBinder`, `ParameterTypeInspector`
- Discovery — `AttributeCommandDiscoverer` walks paths with `PhpToken` (no `include`) and reflects only on `#[Command]` candidates
- Bridge — `AltairCommand` extends `Symfony\Console\Command`, delegates to user class via `Container::make` + `__invoke`
- App / config — `Application` extends Symfony's; `CliConfiguration` shares the discoverer and delegates `Application` construction

**Tests:** 47 tests / 102 assertions, all green
- `ValueCoercerTest` — all coercion paths + failures (DataProvider attributes)
- `ArgumentBinderTest`, `OptionBinderTest` — reflection → Symfony Console wiring
- `AttributeCommandDiscovererTest` — root / nested / ignored / dedupe / missing path
- `IntegrationTest` — end-to-end via `CommandTester` with the issue's exact `users:create` example (container DI, enum coercion, defaults) + auto-discovery through `CliConfiguration`

**Verification:** PHPStan clean on the new sub-package. PHP-CS-Fixer applied.

## Acceptance criteria (from #17)

- [x] `bin/altair` runs and lists commands without crashing on an empty project
- [x] `#[Command]` discovery scans configured paths recursively
- [x] `#[Argument]` required by default; optional if PHP param has a default
- [x] `#[Option]` supports flag (`bool`), value (`string`/`int`/`?string`), enum (`BackedEnum`), variadic (`array`)
- [x] Type coercion: `int`, `float`, `bool` (yes/no/true/false/1/0), `DateTimeImmutable` (ISO-8601), backed enums, arrays (comma-separated)
- [x] Invalid coercion produces a clean Symfony Console error, not a `TypeError`
- [x] Help output autogenerated from attributes
- [x] Container-resolved constructor params
- [x] Shell completion: `bin/altair completion bash` emits a valid script

## Test plan

- [ ] `composer test` — full PHPUnit suite green (locally: 47 Cli tests pass, pre-existing PHP 8.4 implicit-nullable deprecations in `Altair\Container\*` / `Altair\Structure\*` are unrelated and slated for Phase 2 Rector)
- [ ] `composer stan` — no new PHPStan errors
- [ ] `composer cs` — no style violations
- [ ] `bin/altair` — lists Symfony defaults on an empty project
- [ ] `ALTAIR_CLI_PATHS=tests/Cli/Discovery/fixtures bin/altair help fixture:create-user` — renders args, options, descriptions, shortcuts, and enum default
- [ ] `bin/altair completion bash` — emits a valid completion script
- [ ] Reviewer sanity: confirm `composer.json` `replace` entry + `bin` registration

Closes #17.