### PR TITLE
re #40 fix: invert FormatNegotiator::getContentTypeByFormat() isset check

### DIFF
--- a/src/Altair/Http/Support/FormatNegotiator.php
+++ b/src/Altair/Http/Support/FormatNegotiator.php
@@ -130,7 +130,7 @@ class FormatNegotiator implements FormatNegotiatorInterface
     #[Override]
     public function getContentTypeByFormat(string $format): string
     {
-        if (isset($this->formats[$format])) {
+        if (!isset($this->formats[$format])) {
             throw new InvalidArgumentException(\sprintf('Unknown format "%s"', $format));
         }
 

--- a/tests/Http/Support/FormatNegotiatorTest.php
+++ b/tests/Http/Support/FormatNegotiatorTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Http\Support;
+
+use Altair\Http\Exception\InvalidArgumentException;
+use Altair\Http\Support\FormatNegotiator;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FormatNegotiator::class)]
+final class FormatNegotiatorTest extends TestCase
+{
+    public function testReturnsPrimaryContentTypeForRegisteredFormat(): void
+    {
+        $negotiator = new FormatNegotiator();
+
+        self::assertSame('application/json', $negotiator->getContentTypeByFormat('json'));
+        self::assertSame('text/html', $negotiator->getContentTypeByFormat('html'));
+    }
+
+    public function testThrowsWhenFormatIsNotRegistered(): void
+    {
+        $negotiator = new FormatNegotiator();
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown format "definitely-not-a-format"');
+
+        $negotiator->getContentTypeByFormat('definitely-not-a-format');
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #40. The `isset()` check in `FormatNegotiator::getContentTypeByFormat()` was inverted — the method threw `InvalidArgumentException('Unknown format ...')` when the format **was** registered, and fell through to an undefined-index access (returning a stray value after two PHP warnings) when the format was **missing**.

One-character fix at [src/Altair/Http/Support/FormatNegotiator.php:133](src/Altair/Http/Support/FormatNegotiator.php#L133): `isset(...)` → `!isset(...)`.

Adds [tests/Http/Support/FormatNegotiatorTest.php](tests/Http/Support/FormatNegotiatorTest.php) covering both branches. The existing `FormatNegotiatorMiddlewareTest` exercises the request-resolution paths but not `getContentTypeByFormat()`, which is how the bug went undetected.

## Test plan

- [x] Failing tests confirm the inverted behaviour before the fix (RED)
- [x] Tests pass after the fix (GREEN)
- [x] No other call sites of `getContentTypeByFormat()` rely on the prior (broken) behaviour