### PR TITLE
re #41 fix: target attributes array in Payload::withoutAttribute()

### DIFF
--- a/src/Altair/Middleware/Payload.php
+++ b/src/Altair/Middleware/Payload.php
@@ -78,7 +78,7 @@ class Payload implements PayloadInterface, JsonSerializable
     public function withoutAttribute($name): PayloadInterface
     {
         $cloned = clone $this;
-        unset($cloned[$name]);
+        unset($cloned->attributes[$name]);
 
         return $cloned;
     }

--- a/tests/Middleware/PayloadTest.php
+++ b/tests/Middleware/PayloadTest.php
@@ -37,4 +37,25 @@ class PayloadTest extends TestCase
         $this->assertSame(5, $new->getAttribute('e'));
         $this->assertSame($newAttrs, $new->getAttributes());
     }
+
+    public function testWithoutAttributeReturnsCloneWithKeyRemoved(): void
+    {
+        $payload = new Payload(['a' => 1, 'b' => 2]);
+
+        $new = $payload->withoutAttribute('a');
+
+        $this->assertNotSame($new, $payload);
+        $this->assertSame(['a' => 1, 'b' => 2], $payload->getAttributes());
+        $this->assertSame(['b' => 2], $new->getAttributes());
+    }
+
+    public function testWithoutAttributeIsNoOpForMissingKey(): void
+    {
+        $payload = new Payload(['a' => 1]);
+
+        $new = $payload->withoutAttribute('does-not-exist');
+
+        $this->assertNotSame($new, $payload);
+        $this->assertSame(['a' => 1], $new->getAttributes());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #41. `Altair\Middleware\Payload` does not implement `ArrayAccess`, so the existing implementation:

\`\`\`php
public function withoutAttribute(\$name): PayloadInterface
{
    \$cloned = clone \$this;
    unset(\$cloned[\$name]);            // ← \$cloned is an object, not an array
    return \$cloned;
}
\`\`\`

…threw \`Cannot use object of type Altair\\\\Middleware\\\\Payload as array\` on every call. Empirically confirmed under PHP 8.5.

The fix targets the protected \`\$attributes\` array directly, matching the pattern already used by [withAttribute()](src/Altair/Middleware/Payload.php#L54) and [withAttributes()](src/Altair/Middleware/Payload.php#L66) in the same class.

Adds two test cases to [tests/Middleware/PayloadTest.php](tests/Middleware/PayloadTest.php) covering the remove path and the no-op-on-missing-key path. The existing suite never exercised \`withoutAttribute()\`, which is how the bug shipped.

## Test plan

- [x] Failing tests reproduce the bug on master (RED)
- [x] Tests pass after the fix (GREEN)
- [x] No other call sites of \`withoutAttribute()\` rely on the prior (broken) behaviour