### PR TITLE
re #42 fix: return cookieParams property in SessionManager::getCookieParams()

### DIFF
--- a/src/Altair/Session/SessionManager.php
+++ b/src/Altair/Session/SessionManager.php
@@ -156,7 +156,7 @@ class SessionManager implements SessionManagerInterface
     #[Override]
     public function getCookieParams(): array
     {
-        return $this->getCookieParams();
+        return $this->cookieParams;
     }
 
     /**

--- a/tests/Session/SessionManagerTest.php
+++ b/tests/Session/SessionManagerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Session;
+
+use Altair\Session\SessionManager;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+
+#[CoversClass(SessionManager::class)]
+final class SessionManagerTest extends TestCase
+{
+    public function testGetCookieParamsReturnsArrayWithoutRecursing(): void
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getCookieParams')->willReturn([]);
+
+        $manager = new SessionManager($request);
+
+        $params = $manager->getCookieParams();
+
+        self::assertIsArray($params);
+        self::assertArrayHasKey('lifetime', $params);
+        self::assertArrayHasKey('path', $params);
+        self::assertArrayHasKey('domain', $params);
+        self::assertArrayHasKey('secure', $params);
+        self::assertArrayHasKey('httponly', $params);
+    }
+
+    public function testSetCookieParamsPersistsThroughGetCookieParams(): void
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getCookieParams')->willReturn([]);
+
+        $manager = new SessionManager($request);
+        $manager->setCookieParams(['path' => '/altair', 'domain' => '.example.com']);
+
+        $params = $manager->getCookieParams();
+
+        self::assertSame('/altair', $params['path']);
+        self::assertSame('.example.com', $params['domain']);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #42. \`SessionManager::getCookieParams()\` was calling itself unconditionally — every invocation produced infinite recursion / stack overflow:

\`\`\`php
public function getCookieParams(): array
{
    return \$this->getCookieParams();
}
\`\`\`

The almost-certainly-intended behaviour is to return the protected \`\$cookieParams\` property, which is populated in the constructor from \`session_get_cookie_params()\` and merged by \`setCookieParams()\` (see [src/Altair/Session/SessionManager.php:67](src/Altair/Session/SessionManager.php#L67) and [:168](src/Altair/Session/SessionManager.php#L168)).

Adds [tests/Session/SessionManagerTest.php](tests/Session/SessionManagerTest.php) covering both the read path and the round trip through \`setCookieParams()\` + \`getCookieParams()\`. The existing suite had no \`SessionManager\` test, which is how the bug shipped.

## Test plan

- [x] Failing test reproduces the stack overflow on master (RED)
- [x] Tests pass after the fix (GREEN)
- [x] \`setCookieParams()\` round trip still merges into the existing array