### PR TITLE
re #43 fix: correct SESSION_MONGO_URI default from 12.0.0.1 to 127.0.0.1

### DIFF
--- a/src/Altair/Session/Configuration/MongoSessionHandlerConfiguration.php
+++ b/src/Altair/Session/Configuration/MongoSessionHandlerConfiguration.php
@@ -28,7 +28,7 @@ class MongoSessionHandlerConfiguration implements ConfigurationInterface
     public function apply(Container $container): void
     {
         $factory = fn(): Collection => (new Client(
-            $this->env->get('SESSION_MONGO_URI', 'mongodb://12.0.0.1/')
+            $this->env->get('SESSION_MONGO_URI', 'mongodb://127.0.0.1/')
         ))->selectCollection(
             $this->env->get('SESSION_MONGO_DB', 'session_db'),
             $this->env->get('SESSION_MONGO_COLLECTION', 'session_collection')


### PR DESCRIPTION
## Summary

Fixes #43. The fallback for \`SESSION_MONGO_URI\` in [MongoSessionHandlerConfiguration](src/Altair/Session/Configuration/MongoSessionHandlerConfiguration.php#L31) was \`mongodb://12.0.0.1/\` — not a meaningful address. Changed to \`mongodb://127.0.0.1/\` (loopback), matching the conventional dev fallback.

One-character change to a default literal. No new test added — any test would just re-assert the literal value.

## Test plan

- [x] No callers depend on the broken value (env vars override the default in production)