### PR TITLE
re #44 fix: correct SanitationConfiguration namespace (PSR-4 violation)

### DIFF
--- a/src/Altair/Sanitation/Configuration/SanitationConfiguration.php
+++ b/src/Altair/Sanitation/Configuration/SanitationConfiguration.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Altair\Validation\Configuration;
+namespace Altair\Sanitation\Configuration;
 
 use Altair\Configuration\Contracts\ConfigurationInterface;
 use Altair\Container\Container;

--- a/tests/Sanitation/Configuration/SanitationConfigurationTest.php
+++ b/tests/Sanitation/Configuration/SanitationConfigurationTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Sanitation\Configuration;
+
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Container\Container;
+use Altair\Sanitation\Configuration\SanitationConfiguration;
+use Altair\Sanitation\Contracts\FiltersRunnerInterface;
+use Altair\Sanitation\Contracts\ResolverInterface;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SanitationConfiguration::class)]
+final class SanitationConfigurationTest extends TestCase
+{
+    public function testClassExistsUnderSanitationNamespace(): void
+    {
+        self::assertTrue(
+            class_exists(SanitationConfiguration::class),
+            'SanitationConfiguration must be reachable via Altair\\Sanitation\\Configuration\\* (PSR-4).',
+        );
+    }
+
+    public function testImplementsConfigurationInterface(): void
+    {
+        self::assertInstanceOf(ConfigurationInterface::class, new SanitationConfiguration());
+    }
+
+    public function testApplyWiresSanitationContractsToConcretes(): void
+    {
+        $container = new Container();
+        (new SanitationConfiguration())->apply($container);
+
+        self::assertInstanceOf(ResolverInterface::class, $container->make(ResolverInterface::class));
+        self::assertInstanceOf(FiltersRunnerInterface::class, $container->make(FiltersRunnerInterface::class));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #44. The file at \`src/Altair/Sanitation/Configuration/SanitationConfiguration.php\` (which the Sanitation composer.json maps to \`Altair\\Sanitation\\*\`) declared \`namespace Altair\\Validation\\Configuration;\`. PSR-4 violation: asking for \`Altair\\Sanitation\\Configuration\\SanitationConfiguration\` made the autoloader locate the file correctly, but the file declared a different class name, triggering a fatal \`Cannot redeclare class\` when both names were touched in one run.

Fix: change the namespace declaration to \`Altair\\Sanitation\\Configuration\` — the body already uses \`Altair\\Sanitation\\*\` classes (\`FiltersRunner\`, \`FilterResolver\`, etc.), so this is clearly the intended owner.

Adds [tests/Sanitation/Configuration/SanitationConfigurationTest.php](tests/Sanitation/Configuration/SanitationConfigurationTest.php) covering class existence, contract conformance, and the \`apply()\` wiring.

## Test plan

- [x] Failing test reproduces the PSR-4 mismatch on master (RED — fatal class redeclaration)
- [x] Tests pass after the fix (GREEN)
- [x] No callers reference the old \`Altair\\Validation\\Configuration\\SanitationConfiguration\` FQN