### PR TITLE
re #46 fix: declare lcobucci/jwt and lcobucci/clock in Http composer.json

### DIFF
--- a/src/Altair/Http/composer.json
+++ b/src/Altair/Http/composer.json
@@ -10,6 +10,8 @@
     "require": {
         "php": ">=8.3",
         "laminas/laminas-diactoros": "^3.5",
+        "lcobucci/clock": "^3.2",
+        "lcobucci/jwt": "^5.3",
         "neomerx/cors-psr7": "^3.0",
         "nikic/fast-route": "^1.3",
         "psr/cache": "^3.0",


### PR DESCRIPTION
## Summary

Fixes #46. The Http sub-package imports \`Lcobucci\\JWT\\*\` and \`Lcobucci\\Clock\\*\` directly from:

- [src/Altair/Http/Jwt/LcobucciTokenParser.php](src/Altair/Http/Jwt/LcobucciTokenParser.php)
- [src/Altair/Http/Jwt/LcobucciTokenGenerator.php](src/Altair/Http/Jwt/LcobucciTokenGenerator.php)
- [src/Altair/Http/Configuration/LcobucciTokenConfiguration.php](src/Altair/Http/Configuration/LcobucciTokenConfiguration.php)

…but [src/Altair/Http/composer.json](src/Altair/Http/composer.json) did not declare \`lcobucci/jwt\` or \`lcobucci/clock\` in its \`require\` block. The deps were satisfied only by the root \`composer.json\` (\`lcobucci/jwt: ^5.3\`), so anyone installing \`univeros/http\` standalone got class-not-found errors on every JWT code path.

Adds:
- \`lcobucci/jwt: ^5.3\` — matches the root constraint
- \`lcobucci/clock: ^3.2\` — matches what \`lcobucci/jwt\` itself requires (no version override)

## Out of scope (will file separately)

While verifying this, I noticed that \`LcobucciTokenConfiguration::apply()\` still references \`Lcobucci\\Jose\\Parsing\\{Decoder,Encoder,Parser}\` — those classes were bundled in \`lcobucci/jwt\` v3 but removed in v4. The class is currently unused (no caller, no test), so the broken imports never resolve at runtime, but it'd be cleaner to either prune the dead class or rewire it against the v5 API. Out of scope for this PR.

## Test plan

- [x] \`composer.json\` parses as valid JSON
- [x] New constraints are compatible with the lock file (\`lcobucci/jwt 5.6.0\` and \`lcobucci/clock 3.x\` already installed)