### PR TITLE
re #47 rename: LogMessageTrait::withLogMessage() -> setLogMessage()

### DIFF
--- a/src/Altair/Courier/Contracts/CommandMessageInterface.php
+++ b/src/Altair/Courier/Contracts/CommandMessageInterface.php
@@ -24,10 +24,10 @@ interface CommandMessageInterface
     public function getLogMessage(): ?LogMessageInterface;
 
     /**
-     * Returns a copy of the of the instance with a LogMessageInterface $message so user can extract its log information
-     * to use it on its logger system.
-     *
-     *
+     * Stores a LogMessageInterface on the command message so middleware downstream
+     * of the command's execution (notably CommandLoggerMiddleware) can surface it
+     * via getLogMessage(). Mutating-by-design: the command bus assumes a single
+     * message instance flows through the middleware chain.
      */
-    public function withLogMessage(LogMessageInterface $message): CommandMessageInterface;
+    public function setLogMessage(LogMessageInterface $message): void;
 }

--- a/src/Altair/Courier/Traits/LogMessageTrait.php
+++ b/src/Altair/Courier/Traits/LogMessageTrait.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Altair\Courier\Traits;
 
-use Altair\Courier\Contracts\CommandMessageInterface;
 use Altair\Courier\Contracts\LogMessageInterface;
 
 trait LogMessageTrait
@@ -27,15 +26,15 @@ trait LogMessageTrait
     }
 
     /**
-     * Returns the instance with a LogMessageInterface $message so user can extract its log information
-     * to use it on its logger system.
+     * Stores a LogMessageInterface $message on the command message so downstream
+     * middleware (notably CommandLoggerMiddleware) can surface it via getLogMessage().
      *
-     *
+     * Named setLogMessage, not withLogMessage, because the command-bus dispatch is
+     * mutation-based: CommandInterface::exec() returns void, and middleware reads
+     * the log message from the same instance after $next() returns.
      */
-    public function withLogMessage(LogMessageInterface $message): CommandMessageInterface
+    public function setLogMessage(LogMessageInterface $message): void
     {
         $this->logMessage = $message;
-
-        return $this;
     }
 }

--- a/tests/Courier/LogMessageTraitTest.php
+++ b/tests/Courier/LogMessageTraitTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Courier;
+
+use Altair\Courier\Contracts\CommandMessageInterface;
+use Altair\Courier\Support\LogMessage;
+use Altair\Courier\Traits\LogMessageTrait;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+
+require_once __DIR__ . '/fixtures.php';
+
+final class LogMessageTraitTest extends TestCase
+{
+    public function testGetLogMessageReturnsNullByDefault(): void
+    {
+        $message = new TestCommandMessage();
+
+        self::assertNull($message->getLogMessage());
+    }
+
+    public function testSetLogMessageMutatesInPlaceAndIsReadable(): void
+    {
+        $message = new TestCommandMessage();
+        $log = new LogMessage('boom', LogLevel::ERROR);
+
+        $message->setLogMessage($log);
+
+        self::assertSame($log, $message->getLogMessage());
+    }
+
+    public function testInterfaceContractIsSetterNotWither(): void
+    {
+        $reflection = new \ReflectionClass(CommandMessageInterface::class);
+
+        self::assertTrue(
+            $reflection->hasMethod('setLogMessage'),
+            'CommandMessageInterface must expose setLogMessage (mutator) per the bus dispatch contract.',
+        );
+        self::assertFalse(
+            $reflection->hasMethod('withLogMessage'),
+            'withLogMessage was renamed in #47 — it misused the framework with* immutability idiom.',
+        );
+
+        $method = $reflection->getMethod('setLogMessage');
+        self::assertSame('void', (string) $method->getReturnType());
+    }
+}

--- a/tests/Courier/LogMessageTraitTest.php
+++ b/tests/Courier/LogMessageTraitTest.php
@@ -13,7 +13,6 @@ namespace Altair\Tests\Courier;
 
 use Altair\Courier\Contracts\CommandMessageInterface;
 use Altair\Courier\Support\LogMessage;
-use Altair\Courier\Traits\LogMessageTrait;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 

--- a/tests/Courier/fixtures.php
+++ b/tests/Courier/fixtures.php
@@ -25,7 +25,7 @@ class TestCommandInjectsErrorLogMessage implements CommandInterface
     #[\Override]
     public function exec(CommandMessageInterface $message): void
     {
-        $message->withLogMessage(new LogMessage('test message', LogLevel::ERROR));
+        $message->setLogMessage(new LogMessage('test message', LogLevel::ERROR));
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #47. \`LogMessageTrait::withLogMessage()\` mutated \`\$this\` and returned the receiver — a setter wearing the framework's \`with*\` idiom. The contract's docblock even claimed "Returns a copy", contradicting the body.

The issue offered two acceptable fixes: rename to \`setLogMessage()\` (truthful as a mutator) or make it real clone-and-modify. I went with **rename** because the command bus architecture is fundamentally mutation-based — [CommandInterface::exec()](src/Altair/Courier/Contracts/CommandInterface.php) returns \`void\`, and [CommandLoggerMiddleware](src/Altair/Courier/Middleware/CommandLoggerMiddleware.php#L40) reads \`\$message->getLogMessage()\` from the same instance after \`\$next(\$message)\`. Retrofitting immutability would cascade across 4 middleware classes plus the strategy interface, which exceeds the bug-fix scope.

## Changes

- Trait: renamed method, dropped the \`return \$this\`, return type now \`void\`.
- Interface ([CommandMessageInterface](src/Altair/Courier/Contracts/CommandMessageInterface.php)): method renamed, docblock corrected to acknowledge the mutation-by-design.
- Fixture ([tests/Courier/fixtures.php:28](tests/Courier/fixtures.php#L28)): single call site updated.
- New test ([tests/Courier/LogMessageTraitTest.php](tests/Courier/LogMessageTraitTest.php)) pinning the new contract: mutator returning void, no \`withLogMessage\` on the interface.

## Breaking change

External implementers of \`CommandMessageInterface\` must rename their method. The framework is pre-v2 (see active version-constraint tightening in [#14](https://github.com/univeros/framework/issues/14)) so the contract correction is intentional.

## Test plan

- [x] All 13 Courier tests pass (no regressions in CommandBus dispatch)
- [x] New \`LogMessageTraitTest\` confirms setter contract via reflection