### PR TITLE
re #48 harden: make Encrypter::decrypt() allow-list-driven, default false

### DIFF
--- a/src/Altair/Security/Encrypter.php
+++ b/src/Altair/Security/Encrypter.php
@@ -27,11 +27,18 @@ class Encrypter implements EncrypterInterface
     /**
      * Encrypter constructor.
      *
+     * @param bool|list<class-string> $allowedClasses controls object reconstruction during
+     *        decrypt(); see unserialize() docs. Default `false` rejects all classes (objects
+     *        decode to __PHP_Incomplete_Class). Pass an explicit allow-list to permit named
+     *        classes, or `true` to permit any class (not recommended).
      *
      * @throws InvalidConfigException
      */
-    public function __construct(protected KeyInterface $key, protected string $cipher)
-    {
+    public function __construct(
+        protected KeyInterface $key,
+        protected string $cipher,
+        protected bool|array $allowedClasses = false,
+    ) {
         if (!\extension_loaded('openssl')) {
             throw new InvalidConfigException('Encryption requires the OpenSSL PHP extension.');
         }
@@ -102,7 +109,7 @@ class Encrypter implements EncrypterInterface
             throw new DecryptException('Unable to decrypt the data.');
         }
 
-        return unserialize($value, ['allowed_classes' => true]);
+        return unserialize($value, ['allowed_classes' => $this->allowedClasses]);
     }
 
     /**

--- a/tests/Security/EncrypterTest.php
+++ b/tests/Security/EncrypterTest.php
@@ -140,4 +140,47 @@ class EncrypterTest extends TestCase
         $this->assertNotEquals('foo', $encrypted);
         $this->assertEquals('foo', $e->decrypt($encrypted));
     }
+
+    public function testDecryptDefaultsToScalarsAndArraysOnly(): void
+    {
+        $key = new HkdfKey('test-key', null, null, EncrypterInterface::AES_128_CBC_CIPHER_KEY_LENGTH);
+        $e = new Encrypter($key, EncrypterInterface::AES_128_CBC_CIPHER);
+
+        $object = new \stdClass();
+        $object->name = 'altair';
+
+        $encrypted = $e->encrypt($object);
+        $decoded = $e->decrypt($encrypted);
+
+        $this->assertInstanceOf(\__PHP_Incomplete_Class::class, $decoded);
+    }
+
+    public function testDecryptHonoursExplicitAllowList(): void
+    {
+        $key = new HkdfKey('test-key', null, null, EncrypterInterface::AES_128_CBC_CIPHER_KEY_LENGTH);
+        $e = new Encrypter($key, EncrypterInterface::AES_128_CBC_CIPHER, [\stdClass::class]);
+
+        $object = new \stdClass();
+        $object->name = 'altair';
+
+        $encrypted = $e->encrypt($object);
+        $decoded = $e->decrypt($encrypted);
+
+        $this->assertInstanceOf(\stdClass::class, $decoded);
+        $this->assertSame('altair', $decoded->name);
+    }
+
+    public function testDecryptAcceptsTrueForFullBackwardsCompatibility(): void
+    {
+        $key = new HkdfKey('test-key', null, null, EncrypterInterface::AES_128_CBC_CIPHER_KEY_LENGTH);
+        $e = new Encrypter($key, EncrypterInterface::AES_128_CBC_CIPHER, true);
+
+        $object = new \stdClass();
+        $object->name = 'altair';
+
+        $decoded = $e->decrypt($e->encrypt($object));
+
+        $this->assertInstanceOf(\stdClass::class, $decoded);
+        $this->assertSame('altair', $decoded->name);
+    }
 }


### PR DESCRIPTION
## Summary

Hardens #48. \`Encrypter::decrypt()\` used \`unserialize(\$value, ['allowed_classes' => true])\` — anything that survives the MAC check can be reconstructed as an object. The MAC validation is good defense, but it's the *only* guard; a future regression weakening MAC validation, or a caller calling \`unserialize()\` directly on its own envelope, removes the safety net.

## Approach

Adds a third constructor parameter to \`Encrypter\`:

\`\`\`php
public function __construct(
    protected KeyInterface \$key,
    protected string \$cipher,
    protected bool|array \$allowedClasses = false,   // ← new, defaults to false
) { ... }
\`\`\`

The value flows into \`unserialize(['allowed_classes' => \$this->allowedClasses])\`. Callers can pass:
- \`false\` (default) — scalars and arrays only; objects decode to \`__PHP_Incomplete_Class\`
- \`[ClassA::class, ClassB::class]\` — explicit allow-list (PHP-standard hardening pattern)
- \`true\` — keep the prior "any class" behaviour for callers that need it

## Compatibility

The framework's existing \`EncrypterTest\` only encrypts scalars and arrays, so the default flip causes no regressions in this repo. External callers that encrypt objects will hit \`__PHP_Incomplete_Class\` after upgrade and must pass an allow-list or \`true\` — a deliberate breaking change for the v2-stream that surfaces the prior implicit risk.

## Test plan

- [x] Failing test reproduces the unhardened default on master (RED)
- [x] All 15 EncrypterTest cases pass with the new default (GREEN)
- [x] New tests pin all three behaviours: default rejects objects, allow-list reconstructs them, \`true\` keeps prior behaviour