### PR TITLE
re #49 drop unused psr/http-server-middleware from Middleware composer.json

### DIFF
--- a/src/Altair/Middleware/composer.json
+++ b/src/Altair/Middleware/composer.json
@@ -9,7 +9,6 @@
     },
     "require": {
         "php": ">=8.3",
-        "psr/http-server-middleware": "^1.0",
         "univeros/structure": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
## Summary

Fixes #49. Removes \`psr/http-server-middleware: ^1.0\` from [src/Altair/Middleware/composer.json](src/Altair/Middleware/composer.json) — it was declared but never imported.

## Evidence

- \`grep -rln "use Psr\\\\Http\\\\Server" src/Altair/Middleware/\` returns **zero** matches.
- The package's [MiddlewareInterface](src/Altair/Middleware/Contracts/MiddlewareInterface.php#L22) defines \`__invoke(PayloadInterface \$payload, callable \$next)\` — a generic substrate with no relation to PSR-15's \`process(ServerRequestInterface, RequestHandlerInterface): ResponseInterface\`.
- All PSR-15 usage in the framework lives under [src/Altair/Http/](src/Altair/Http/), where \`psr/http-server-middleware\` is correctly declared in [src/Altair/Http/composer.json:19](src/Altair/Http/composer.json#L19).
- The dep first appeared in commit \`682ae8c re #1 phase 1 modernization\` with no accompanying source import — a copy-paste from the Http package while the modernization commit was bumping PHP version constraints.

## Test plan

- [x] No PSR-15 imports under \`src/Altair/Middleware/\`
- [x] The Http package still declares the dep where it is actually used
- [x] No existing tests depend on the dep being present in Middleware's composer.json