### PR TITLE
re #50 fix: RedisCacheItemStorageConfiguration genuinely wires ext-redis

### DIFF
--- a/src/Altair/Cache/Configuration/RedisCacheItemStorageConfiguration.php
+++ b/src/Altair/Cache/Configuration/RedisCacheItemStorageConfiguration.php
@@ -12,13 +12,17 @@ declare(strict_types=1);
 namespace Altair\Cache\Configuration;
 
 use Altair\Cache\Contracts\CacheItemStorageInterface;
-use Altair\Cache\Storage\PredisCacheItemStorage;
+use Altair\Cache\Storage\RedisCacheItemStorage;
 use Altair\Configuration\Contracts\ConfigurationInterface;
 use Altair\Configuration\Traits\EnvAwareTrait;
 use Altair\Container\Container;
 use Override;
-use Predis\Client;
+use Redis;
 
+/**
+ * Wires the ext-redis backed CacheItemStorageInterface implementation. For the userland
+ * Predis library, use {@see PredisCacheItemStorageConfiguration}.
+ */
 class RedisCacheItemStorageConfiguration implements ConfigurationInterface
 {
     use EnvAwareTrait;
@@ -26,19 +30,31 @@ class RedisCacheItemStorageConfiguration implements ConfigurationInterface
     #[Override]
     public function apply(Container $container): void
     {
-        $factory = function (): PredisCacheItemStorage {
-            $client = new Client(
-                [
-                    'host' => $this->env->get('CACHE_REDIS_HOST', 'localhost'),
-                    'port' => $this->env->get('CACHE_REDIS_PORT', 6379),
-                ]
+        $factory = function (): RedisCacheItemStorage {
+            $client = new Redis();
+            $client->connect(
+                (string) $this->env->get('CACHE_REDIS_HOST', 'localhost'),
+                (int) $this->env->get('CACHE_REDIS_PORT', 6379),
             );
 
-            return new PredisCacheItemStorage($client);
+            $password = $this->env->get('CACHE_REDIS_PASSWORD');
+            if (\is_string($password) && $password !== '') {
+                $client->auth($password);
+            }
+
+            $database = $this->env->get('CACHE_REDIS_DATABASE');
+            if ($database !== null && $database !== '') {
+                $client->select((int) $database);
+            }
+
+            return new RedisCacheItemStorage(
+                $client,
+                (string) $this->env->get('CACHE_REDIS_NAMESPACE', ''),
+            );
         };
 
         $container
-            ->delegate(PredisCacheItemStorage::class, $factory)
-            ->alias(CacheItemStorageInterface::class, PredisCacheItemStorage::class);
+            ->delegate(RedisCacheItemStorage::class, $factory)
+            ->alias(CacheItemStorageInterface::class, RedisCacheItemStorage::class);
     }
 }

--- a/tests/Cache/Configuration/RedisCacheItemStorageConfigurationTest.php
+++ b/tests/Cache/Configuration/RedisCacheItemStorageConfigurationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Cache\Configuration;
+
+use Altair\Cache\Configuration\RedisCacheItemStorageConfiguration;
+use Altair\Cache\Contracts\CacheItemStorageInterface;
+use Altair\Cache\Storage\PredisCacheItemStorage;
+use Altair\Cache\Storage\RedisCacheItemStorage;
+use Altair\Configuration\Support\Env;
+use Altair\Container\Container;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+#[CoversClass(RedisCacheItemStorageConfiguration::class)]
+final class RedisCacheItemStorageConfigurationTest extends TestCase
+{
+    public function testAliasesCacheItemStorageInterfaceToRedisNotPredis(): void
+    {
+        $container = new Container();
+        (new RedisCacheItemStorageConfiguration(new Env([])))->apply($container);
+
+        $aliases = (new ReflectionClass($container))->getProperty('aliases')->getValue($container);
+        [$resolved] = $aliases->resolve(CacheItemStorageInterface::class);
+
+        self::assertSame(
+            RedisCacheItemStorage::class,
+            ltrim((string) $resolved, '\\'),
+            'RedisCacheItemStorageConfiguration must wire the ext-redis storage, not Predis.',
+        );
+        self::assertNotSame(PredisCacheItemStorage::class, ltrim((string) $resolved, '\\'));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #50. \`Altair\\Cache\\Configuration\\RedisCacheItemStorageConfiguration\` was a misnamed byte-for-byte clone of \`PredisCacheItemStorageConfiguration\` — same Predis\\Client imports, same body delegating \`PredisCacheItemStorage\` and aliasing \`CacheItemStorageInterface\` to it. The name advertised ext-redis; the body delivered userland Predis.

Per the issue's preferred option (rename to truth), this PR rewrites the configuration body to genuinely wire the [RedisCacheItemStorage](src/Altair/Cache/Storage/RedisCacheItemStorage.php) ext-redis backend:

- Connect via \`\\Redis\` (ext-redis class)
- Standard env vars: \`CACHE_REDIS_HOST\` (default \`localhost\`), \`CACHE_REDIS_PORT\` (default \`6379\`)
- Optional \`CACHE_REDIS_PASSWORD\`, \`CACHE_REDIS_DATABASE\`, \`CACHE_REDIS_NAMESPACE\`

The truthful Predis wiring already lives in [PredisCacheItemStorageConfiguration](src/Altair/Cache/Configuration/PredisCacheItemStorageConfiguration.php) — callers who want Predis use that, callers who want ext-redis use this one.

Adds [tests/Cache/Configuration/RedisCacheItemStorageConfigurationTest.php](tests/Cache/Configuration/RedisCacheItemStorageConfigurationTest.php) that resolves the \`CacheItemStorageInterface\` alias through the container and asserts the chain terminates at \`RedisCacheItemStorage\`, not \`PredisCacheItemStorage\`. The test never invokes the factory, so it does not require ext-redis to be loaded in CI.

## Breaking change

Anyone who instantiated this class believing it wired Redis but who actually got Predis: they now genuinely get ext-redis, which requires the extension to be loaded. The fix surfaces an honest dependency. Callers who want the userland Predis path should pick \`PredisCacheItemStorageConfiguration\`.

## Test plan

- [x] New test passes (alias resolves to Redis, not Predis)
- [x] All 40 Cache tests pass; ext-redis-specific tests skip gracefully when the extension is absent