### PR TITLE
re #72 add scaffold journal (rewindable / replayable scaffold ops)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -1,6 +1,36 @@
 # univeros/scaffold  ·  Altair\Scaffold
 
-**Purpose:** Spec-to-API code generator: YAML spec in, Action/Input/Responder + OpenAPI + tests out.
+**Purpose:** Spec-to-API code generator: YAML spec in, Action/Input/Responder + OpenAPI + tests out. Includes a **journal** sub-feature for rewindable/replayable scaffold operations.
+
+## Journal sub-feature (issue #72)
+
+Every successful `bin/altair spec:scaffold` writes a self-contained entry to `.altair/journal/<timestamp>-<short-sha>.json` capturing the spec content, per-file SHAs, and full `content_before` for modified files. The journal turns failed iterations into recoverable ones rather than catastrophic ones.
+
+CLI commands (named `journal:*` to avoid collision with introspection's `spec:*`):
+
+| Command | Purpose |
+|---|---|
+| `journal:list [-n N] [--since=<ts>] [--spec=<path>]` | List entries newest-first. |
+| `journal:show <id>` | Full detail for one entry (resolves unambiguous id prefixes). |
+| `journal:diff <id>` | Per-file diffs embedded in one entry. |
+| `journal:rewind [--to=<id>] [--dry-run] [--force]` | Undo scaffold operations newest-first; refuses to clobber hand-edited files unless `--force`. |
+| `journal:replay [--from=<id>\|--all] [<id>]` | Re-emit one or more entries from embedded spec content; reports drift. |
+
+All accept `--format=json` where applicable.
+
+### Integration with scaffold + events
+
+`ScaffoldCommand` takes an optional `Journal` and an optional `Altair\Events\Contracts\RecorderInterface`. When both are bound (via `ScaffoldJournalConfiguration` + `EventsConfiguration`), every scaffold writes a journal entry **and** emits a `scaffold` event into `.altair/events.jsonl`. Both integrations are nullable so minimal hosts can scaffold without either.
+
+### Configuration
+
+```php
+use Altair\Scaffold\Journal\Configuration\ScaffoldJournalConfiguration;
+
+(new ScaffoldJournalConfiguration(projectRoot: __DIR__))->apply($container);
+```
+
+Env vars: `ALTAIR_JOURNAL_ENABLED` (default true), `ALTAIR_JOURNAL_DIR` (`.altair`), `ALTAIR_JOURNAL_SUBDIR` (`journal`).
 
 ## Concrete classes
 
@@ -74,3 +104,11 @@
 - `nikic/php-parser`
 - `symfony/yaml`
 - `univeros/cli`
+- `univeros/configuration` (Journal Configuration)
+- `univeros/container` (Journal Configuration)
+- `univeros/events` (suggested — for event-log dual-write from `ScaffoldCommand`)
+
+## Issue references
+
+- #19 — `univeros/scaffold` itself (shipped)
+- #72 — spec journal (rewind / replay) — this PR

--- a/AGENT.md
+++ b/AGENT.md
@@ -43,7 +43,7 @@ This file is the source of truth. Tool-specific entry points (`CLAUDE.md`) point
 │   ├── Middleware/    ← PSR-15 middleware primitives
 │   ├── Persistence/   ← Repository/UnitOfWork over Cycle ORM v2 + migration CLI
 │   ├── Sanitation/    ← Input sanitation rules
-│   ├── Scaffold/      ← YAML-spec-to-code generator (bin/altair spec:scaffold), with optional persistence: and queue: blocks
+│   ├── Scaffold/      ← YAML-spec-to-code generator (bin/altair spec:scaffold), with optional persistence: and queue: blocks; includes Journal sub-feature (journal:list/show/diff/rewind/replay) for rewindable scaffold operations
 │   ├── Security/      ← Hashing, encryption, CSRF tokens
 │   ├── Session/       ← Session handlers (file, Redis, Mongo)
 │   ├── Structure/     ← Collection primitives (Map, Set, etc.)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,6 +128,27 @@ bin/altair events:compact --before=2026-04-01     # archive old events to .altai
 
 When adding a new mutating command anywhere in the framework, type-hint `RecorderInterface` in the constructor and call `record(Event::create(...))` after success/failure — don't hand-write the event JSON. Use the named-constructor `Event::create()` so the ULID + timestamp stamping stays consistent. Keep `.altair/` in the host app's `.gitignore` (events are local).
 
+### Spec journal (rewind / replay)
+
+The `univeros/scaffold` sub-package now ships a **journal** sub-feature. Every successful `bin/altair spec:scaffold` writes a self-contained `.altair/journal/<id>.json` entry capturing the spec content, per-file SHAs, and full `content_before` for modified files. Failed iterations become recoverable rather than catastrophic.
+
+`ScaffoldCommand` resolves `Altair\Scaffold\Journal\Journal` and `Altair\Events\Contracts\RecorderInterface` as optional constructor dependencies — both nullable so minimal hosts can scaffold without either. When both are bound (via `ScaffoldJournalConfiguration` + `EventsConfiguration`), each scaffold writes a journal entry **and** emits a `scaffold` event into `.altair/events.jsonl`.
+
+```bash
+bin/altair journal:list -n 50                  # newest 50 entries (human or --format=json)
+bin/altair journal:show <id>                   # full detail (resolves unambiguous prefixes)
+bin/altair journal:diff <id>                   # per-file diffs embedded in the entry
+bin/altair journal:rewind                      # undo the most recent scaffold
+bin/altair journal:rewind --to=<id>            # undo back to a point
+bin/altair journal:rewind --dry-run            # preview without writing
+bin/altair journal:rewind --force              # clobber hand-edited files (warned about by default)
+bin/altair journal:replay <id>                 # re-apply one entry
+bin/altair journal:replay --from=<id>          # re-apply forward from a point
+bin/altair journal:replay --all                # nuclear — replay the whole journal (confirms)
+```
+
+When adding a new spec scaffolder downstream, do NOT bypass `ScaffoldCommand` — write a YAML spec and call `spec:scaffold`. That way the journal entry gets written automatically and `journal:rewind` keeps working. Commands named `journal:*` (not `spec:*`) to avoid collision with introspection's `spec:list` / `spec:show`.
+
 ### Plan/Skill choices for the open work
 
 - **Phase 2 (Rector):** Don't `Plan` it — just run `composer rector:fix`, then `composer cs:fix && composer test`. Triage failures one at a time.

--- a/src/Altair/Scaffold/Cli/ScaffoldCommand.php
+++ b/src/Altair/Scaffold/Cli/ScaffoldCommand.php
@@ -14,15 +14,39 @@ namespace Altair\Scaffold\Cli;
 use Altair\Cli\Attribute\Argument;
 use Altair\Cli\Attribute\Command;
 use Altair\Cli\Attribute\Option;
+use Altair\Events\Actor;
+use Altair\Events\Changes;
+use Altair\Events\Contracts\RecorderInterface;
+use Altair\Events\Event as RecorderEvent;
+use Altair\Events\EventKind;
+use Altair\Events\EventStatus;
 use Altair\Scaffold\Emitter\EmissionPlan;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\JournalEntry;
+use Altair\Scaffold\Journal\SnapshotCollector;
+use Altair\Scaffold\Spec\Ast\Spec;
 use Altair\Scaffold\Spec\SpecLoader;
 use Altair\Scaffold\Writer\FileWriter;
 use Altair\Scaffold\Writer\WriteStatus;
+use Throwable;
 
 /**
- * `bin/altair spec scaffold <path>` — read a YAML endpoint spec (or a directory
- * of specs) and emit the action/input/responder/domain stub/test/openapi/route
- * files.
+ * `bin/altair spec:scaffold <path>` — read a YAML endpoint spec (or a
+ * directory of specs) and emit the action/input/responder/domain
+ * stub/test/openapi/route files.
+ *
+ * **Journal-aware:** when a {@see Journal} is bound in the container,
+ * every successful scaffold writes a `.altair/journal/<id>.json` entry
+ * (one per spec). The journal lets `bin/altair journal:rewind` and
+ * `journal:replay` undo / re-apply scaffold operations after the fact.
+ *
+ * **Event-aware:** when a {@see RecorderInterface} is bound, each
+ * scaffold (and its overall success/failure) emits a mutation event
+ * into the `.altair/events.jsonl` log so agents have a chronological
+ * record of "what just changed?" across sessions.
+ *
+ * Both integrations are optional — the command works standalone when
+ * either dependency is absent.
  */
 #[Command(
     name: 'spec:scaffold',
@@ -34,6 +58,8 @@ final readonly class ScaffoldCommand
         private SpecLoader $loader = new SpecLoader(),
         private EmissionPlan $plan = new EmissionPlan(),
         private PathResolver $paths = new PathResolver(),
+        private ?Journal $journal = null,
+        private ?RecorderInterface $events = null,
     ) {}
 
     public function __invoke(
@@ -47,34 +73,117 @@ final readonly class ScaffoldCommand
         ?string $root = null,
     ): int {
         $projectRoot = $this->paths->resolveProjectRoot($root);
-        $specs = $this->loader->load($path);
         $writer = new FileWriter($projectRoot);
 
-        $written = 0;
-        $skipped = 0;
+        try {
+            $specs = $this->loader->load($path);
+        } catch (Throwable $throwable) {
+            $this->recordEvent(EventStatus::Fail, $path, 0, null, $throwable->getMessage());
+            echo \sprintf('Spec load failed: %s%s', $throwable->getMessage(), PHP_EOL);
+
+            return 1;
+        }
+
+        $totalWritten = 0;
+        $totalSkipped = 0;
+        $startedAt = microtime(true);
+
         foreach ($specs as $spec) {
+            $collector = new SnapshotCollector($projectRoot);
+            $written = 0;
+            $skipped = 0;
+
             foreach ($this->plan->build($spec) as $file) {
                 if ($dryRun) {
                     echo '--- ' . $file->relativePath . " ---\n";
                     echo $file->contents;
                     echo "\n";
+
                     continue;
                 }
 
+                $before = $collector->captureBefore($file);
                 $outcome = $writer->write($file, $force);
+                $collector->record($file, $outcome, $before);
                 echo $outcome->status->value, ' ', $outcome->relativePath, "\n";
+
                 if ($outcome->status === WriteStatus::Skipped) {
                     $skipped++;
                 } else {
                     $written++;
                 }
             }
+
+            if (!$dryRun) {
+                $this->recordJournal($spec, $collector);
+            }
+
+            $totalWritten += $written;
+            $totalSkipped += $skipped;
         }
 
         if (!$dryRun) {
-            echo "Wrote {$written} file(s); skipped {$skipped} existing file(s).\n";
+            $duration = (int) ((microtime(true) - $startedAt) * 1000);
+            $this->recordEvent(EventStatus::Ok, $path, $duration, $totalWritten, null);
+            echo "Wrote {$totalWritten} file(s); skipped {$totalSkipped} existing file(s).\n";
         }
 
         return 0;
+    }
+
+    private function recordJournal(Spec $spec, SnapshotCollector $collector): void
+    {
+        if (!$this->journal instanceof Journal) {
+            return;
+        }
+
+        try {
+            $specPath = $this->specPath($spec);
+            $specContent = is_file($specPath) ? (string) @file_get_contents($specPath) : '';
+
+            $entry = JournalEntry::scaffold(
+                command: 'bin/altair spec:scaffold ' . $specPath,
+                specPath: $specPath,
+                specContent: $specContent,
+                scaffoldVersion: JournalEntry::VERSION,
+                filesCreated: $collector->created(),
+                filesModified: $collector->modified(),
+                filesSkipped: $collector->skipped(),
+            );
+            $this->journal->record($entry);
+        } catch (Throwable) {
+            // Journaling is best-effort — never fail the scaffold over it.
+        }
+    }
+
+    private function recordEvent(EventStatus $status, string $path, int $durationMs, ?int $createdCount, ?string $error): void
+    {
+        if (!$this->events instanceof RecorderInterface) {
+            return;
+        }
+
+        try {
+            $this->events->record(RecorderEvent::create(
+                actor: Actor::Cli,
+                command: 'bin/altair spec:scaffold ' . $path,
+                kind: EventKind::Scaffold,
+                status: $status,
+                durationMs: $durationMs,
+                changes: $createdCount !== null ? new Changes(['created' => array_fill(0, $createdCount, '*')]) : null,
+                error: $error,
+            ));
+        } catch (Throwable) {
+            // Event recording is best-effort.
+        }
+    }
+
+    /**
+     * `Spec::$sourcePath` is empty when the spec was constructed in
+     * memory (typical in tests); fall back to a synthetic identifier
+     * so the journal entry has something readable to display.
+     */
+    private function specPath(Spec $spec): string
+    {
+        return $spec->sourcePath !== '' ? $spec->sourcePath : '(in-memory) ' . $spec->artifactName();
     }
 }

--- a/src/Altair/Scaffold/Journal/Cli/DiffCommand.php
+++ b/src/Altair/Scaffold/Journal/Cli/DiffCommand.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Cli;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Attribute\Command;
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\Journal;
+
+/**
+ * `bin/altair journal:diff <id>` — print the embedded diffs for one entry.
+ *
+ * Created files are printed as "+++ <path>" with full content; modified
+ * files print their embedded unified-diff hunks.
+ */
+#[Command(
+    name: 'journal:diff',
+    description: 'Print the per-file diffs embedded in a journal entry.',
+)]
+final readonly class DiffCommand
+{
+    public function __construct(
+        private Journal $journal,
+    ) {}
+
+    public function __invoke(
+        #[Argument(description: 'Journal entry id (or unambiguous prefix).')]
+        string $id,
+    ): int {
+        try {
+            $entry = $this->journal->findById($id);
+        } catch (EntryNotFoundException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 1;
+        } catch (JournalException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 2;
+        }
+
+        if ($entry->filesCreated === [] && $entry->filesModified === []) {
+            echo "Entry '{$entry->id}' touched no files.\n";
+
+            return 0;
+        }
+
+        foreach ($entry->filesCreated as $snapshot) {
+            echo "+++ {$snapshot->path}  (created, sha256: {$snapshot->shaAfter}, {$snapshot->sizeBytes} bytes)\n";
+        }
+
+        foreach ($entry->filesModified as $snapshot) {
+            echo \sprintf('~~~ %s%s', $snapshot->path, PHP_EOL);
+            echo $snapshot->diff ?? "(no embedded diff)\n";
+        }
+
+        return 0;
+    }
+}

--- a/src/Altair/Scaffold/Journal/Cli/HistoryCommand.php
+++ b/src/Altair/Scaffold/Journal/Cli/HistoryCommand.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Cli;
+
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\JournalEntry;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Throwable;
+
+/**
+ * `bin/altair journal:list` — list journal entries (newest first).
+ *
+ * Named `journal:*` (not `spec:*`) to avoid collision with the
+ * introspection sub-package's `spec:list` / `spec:show` commands —
+ * those view raw YAML specs; these view scaffold-time history.
+ */
+#[Command(
+    name: 'journal:list',
+    description: 'List scaffold journal entries newest-first.',
+)]
+final readonly class HistoryCommand
+{
+    public function __construct(
+        private Journal $journal,
+    ) {}
+
+    public function __invoke(
+        #[Option(description: 'Show at most N entries (newest first).', short: 'n')]
+        ?int $n = 50,
+        #[Option(description: 'Only entries on or after this timestamp (any DateTime-parseable string).')]
+        ?string $since = null,
+        #[Option(description: 'Only entries whose spec path equals this value.')]
+        ?string $spec = null,
+        #[Option(description: 'Output format: human or json.')]
+        string $format = 'human',
+    ): int {
+        $threshold = null;
+        if ($since !== null) {
+            try {
+                $threshold = new DateTimeImmutable($since);
+            } catch (Throwable $throwable) {
+                echo \sprintf("Could not parse --since='%s': %s%s", $since, $throwable->getMessage(), PHP_EOL);
+
+                return 2;
+            }
+        }
+
+        $rows = [];
+        foreach ($this->journal->tail($n) as $entry) {
+            if ($threshold instanceof DateTimeImmutable && $entry->timestamp < $threshold) {
+                continue;
+            }
+
+            if ($spec !== null && $entry->spec['path'] !== $spec) {
+                continue;
+            }
+
+            $rows[] = $entry;
+        }
+
+        if ($rows === []) {
+            if ($format !== 'json') {
+                echo "No journal entries match.\n";
+            } else {
+                echo "[]\n";
+            }
+
+            return 0;
+        }
+
+        if ($format === 'json') {
+            $payload = array_map(static fn(JournalEntry $e): array => [
+                'id' => $e->id,
+                'operation' => $e->operation->value,
+                'timestamp' => $e->timestamp->format(DateTimeInterface::RFC3339_EXTENDED),
+                'spec_path' => $e->spec['path'],
+                'spec_sha256' => $e->spec['sha256'],
+                'files_created' => \count($e->filesCreated),
+                'files_modified' => \count($e->filesModified),
+                'files_skipped' => \count($e->filesSkipped),
+                'reverted_at' => $e->revertedAt?->format(DateTimeInterface::RFC3339_EXTENDED),
+            ], $rows);
+            echo json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE), "\n";
+
+            return 0;
+        }
+
+        foreach ($rows as $entry) {
+            $flag = $entry->isReverted() ? ' [reverted]' : '';
+            echo \sprintf(
+                "%s  %-19s  %-8s  %s  (+%d ~%d -%d)%s\n",
+                substr($entry->id, 0, 24),
+                $entry->timestamp->format('Y-m-d H:i:s'),
+                $entry->operation->value,
+                $entry->spec['path'],
+                \count($entry->filesCreated),
+                \count($entry->filesModified),
+                \count($entry->filesSkipped),
+                $flag,
+            );
+        }
+
+        return 0;
+    }
+}

--- a/src/Altair/Scaffold/Journal/Cli/ReplayCommand.php
+++ b/src/Altair/Scaffold/Journal/Cli/ReplayCommand.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Cli;
+
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use Altair\Scaffold\Emitter\EmissionPlan;
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\JournalEntry;
+use Altair\Scaffold\Spec\Parser;
+use Altair\Scaffold\Spec\Validator;
+use Altair\Scaffold\Writer\FileWriter;
+
+use const STDIN;
+
+use Throwable;
+
+/**
+ * `bin/altair journal:replay [--from=<id>|--all] [<id>]` — re-emit one
+ * or more entries from the embedded spec content. Drift is reported
+ * (file content now differs from what the journal recorded → usually
+ * means the scaffolder itself changed).
+ *
+ * Replay reads the spec content out of the entry's `spec.content_inline`
+ * — it never touches the original spec file (which may have been
+ * edited or deleted since the original scaffold).
+ */
+#[Command(
+    name: 'journal:replay',
+    description: 'Re-apply scaffold operations from the journal (single, from-point, or all).',
+)]
+final readonly class ReplayCommand
+{
+    public function __construct(
+        private Journal $journal,
+        private Parser $parser = new Parser(),
+        private Validator $validator = new Validator(),
+        private EmissionPlan $plan = new EmissionPlan(),
+    ) {}
+
+    public function __invoke(
+        #[Option(description: 'Replay a single entry by id (or unambiguous prefix).')]
+        ?string $id = null,
+        #[Option(description: 'Replay every entry from this id forward (inclusive).')]
+        ?string $from = null,
+        #[Option(description: 'Replay the whole journal start-to-end. Confirms before running.')]
+        bool $all = false,
+        #[Option(description: 'Overwrite existing files instead of skipping.')]
+        bool $force = false,
+    ): int {
+        try {
+            $entries = $this->resolveEntries($id, $from, $all);
+        } catch (EntryNotFoundException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 1;
+        } catch (JournalException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 2;
+        }
+
+        if ($entries === []) {
+            echo "No entries to replay.\n";
+
+            return 0;
+        }
+
+        if ($all) {
+            echo "About to replay " . \count($entries) . " entry(ies). Continue? [y/N] ";
+            $line = trim((string) fgets(STDIN));
+            if (strtolower($line) !== 'y') {
+                echo "Aborted.\n";
+
+                return 0;
+            }
+        }
+
+        $writer = new FileWriter($this->journal->projectRoot());
+        $drift = [];
+        $written = 0;
+        $skipped = 0;
+
+        foreach ($entries as $entry) {
+            $specPath = $entry->spec['path'];
+            try {
+                $parsed = $this->parser->parseString($entry->spec['content_inline'], $specPath);
+                $this->validator->assertValid($parsed);
+                $spec = $parsed;
+            } catch (Throwable $throwable) {
+                echo \sprintf('Skipping %s: spec is no longer parseable — %s%s', $entry->id, $throwable->getMessage(), PHP_EOL);
+
+                continue;
+            }
+
+            foreach ($this->plan->build($spec) as $file) {
+                $outcome = $writer->write($file, $force);
+                echo $outcome->status->value, ' ', $outcome->relativePath, "\n";
+
+                if ($outcome->status->value === 'skipped') {
+                    $skipped++;
+                } else {
+                    $written++;
+                }
+
+                $expectedSha = $this->expectedShaFor($entry, $file->relativePath);
+                $actualSha = hash('sha256', $file->contents);
+                if ($expectedSha !== null && $expectedSha !== $actualSha) {
+                    $drift[] = ['entry' => $entry->id, 'path' => $file->relativePath, 'expected' => $expectedSha, 'actual' => $actualSha];
+                }
+            }
+        }
+
+        echo "Replayed " . \count($entries) . " entry(ies). Wrote {$written}, skipped {$skipped} existing file(s).\n";
+
+        if ($drift !== []) {
+            echo \count($drift), " file(s) drifted from journal:\n";
+            foreach ($drift as $d) {
+                echo "  - {$d['path']}  (entry {$d['entry']})\n";
+            }
+
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return list<JournalEntry>
+     */
+    private function resolveEntries(?string $id, ?string $from, bool $all): array
+    {
+        if ($all) {
+            return iterator_to_array($this->journal->history(), false);
+        }
+
+        if ($from !== null) {
+            $start = $this->journal->findById($from);
+            $out = [];
+            $started = false;
+            foreach ($this->journal->history() as $entry) {
+                if ($entry->id === $start->id) {
+                    $started = true;
+                }
+
+                if ($started) {
+                    $out[] = $entry;
+                }
+            }
+
+            return $out;
+        }
+
+        if ($id !== null) {
+            return [$this->journal->findById($id)];
+        }
+
+        return [];
+    }
+
+    private function expectedShaFor(JournalEntry $entry, string $relativePath): ?string
+    {
+        foreach ($entry->filesCreated as $snapshot) {
+            if ($snapshot->path === $relativePath) {
+                return $snapshot->shaAfter;
+            }
+        }
+
+        foreach ($entry->filesModified as $snapshot) {
+            if ($snapshot->path === $relativePath) {
+                return $snapshot->shaAfter;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Scaffold/Journal/Cli/RewindCommand.php
+++ b/src/Altair/Scaffold/Journal/Cli/RewindCommand.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Cli;
+
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\Exception\RewindRefusedException;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\JournalEntry;
+
+/**
+ * `bin/altair journal:rewind [--to=<id>] [--dry-run] [--force]` — undo
+ * scaffold operations, newest-first, by re-deleting created files and
+ * restoring modified files from the embedded `content_before`.
+ *
+ * Refuses to clobber files the user has hand-edited since the original
+ * scaffold (sha mismatch). `--force` overrides with a clear warning.
+ */
+#[Command(
+    name: 'journal:rewind',
+    description: 'Undo scaffold operations newest-first (single entry by default).',
+)]
+final readonly class RewindCommand
+{
+    public function __construct(
+        private Journal $journal,
+    ) {}
+
+    public function __invoke(
+        #[Option(description: 'Undo every entry up to and including this id (inclusive). Defaults to the most recent entry.')]
+        ?string $to = null,
+        #[Option(description: 'Print what would be undone without writing.', name: 'dry-run')]
+        bool $dryRun = false,
+        #[Option(description: 'Override the hand-edit safety check.')]
+        bool $force = false,
+    ): int {
+        try {
+            $targets = $this->collectTargets($to);
+        } catch (EntryNotFoundException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 1;
+        } catch (JournalException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 2;
+        }
+
+        if ($targets === []) {
+            echo "No entries to rewind.\n";
+
+            return 0;
+        }
+
+        if ($dryRun) {
+            echo "Would rewind " . \count($targets) . " entry(ies):\n";
+            foreach ($targets as $entry) {
+                echo "  - {$entry->id}  ({$entry->spec['path']})\n";
+            }
+
+            return 0;
+        }
+
+        $totalDeleted = 0;
+        $totalRestored = 0;
+        $totalSkipped = 0;
+        foreach ($targets as $entry) {
+            try {
+                $result = $this->journal->rewind($entry, $force);
+            } catch (RewindRefusedException $e) {
+                echo $e->getMessage(), "\n";
+
+                return 3;
+            }
+
+            echo \sprintf('Rewound %s — deleted: ', $entry->id) . \count($result['deleted'])
+                . ", restored: " . \count($result['restored'])
+                . ", skipped: " . \count($result['skipped']) . "\n";
+            $totalDeleted += \count($result['deleted']);
+            $totalRestored += \count($result['restored']);
+            $totalSkipped += \count($result['skipped']);
+        }
+
+        echo "Done — deleted {$totalDeleted}, restored {$totalRestored}, skipped {$totalSkipped}.\n";
+
+        return 0;
+    }
+
+    /**
+     * @return list<JournalEntry> Newest-first list of entries to undo.
+     */
+    private function collectTargets(?string $to): array
+    {
+        if ($to !== null) {
+            $stopAt = $this->journal->findById($to);
+            $out = [];
+            foreach ($this->journal->tail() as $entry) {
+                if ($entry->isReverted()) {
+                    continue;
+                }
+
+                $out[] = $entry;
+                if ($entry->id === $stopAt->id) {
+                    return $out;
+                }
+            }
+
+            // We walked the entire log without hitting `$to`.
+            return $out;
+        }
+
+        $latest = null;
+        foreach ($this->journal->tail(1) as $entry) {
+            if (!$entry->isReverted()) {
+                $latest = $entry;
+            }
+        }
+
+        return $latest === null ? [] : [$latest];
+    }
+}

--- a/src/Altair/Scaffold/Journal/Cli/ShowCommand.php
+++ b/src/Altair/Scaffold/Journal/Cli/ShowCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Cli;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\Journal;
+use DateTimeInterface;
+
+/**
+ * `bin/altair journal:show <id>` — full detail for one journal entry.
+ */
+#[Command(
+    name: 'journal:show',
+    description: 'Show one journal entry by id (or unambiguous prefix).',
+)]
+final readonly class ShowCommand
+{
+    public function __construct(
+        private Journal $journal,
+    ) {}
+
+    public function __invoke(
+        #[Argument(description: 'Journal entry id (or unambiguous prefix).')]
+        string $id,
+        #[Option(description: 'Output format: human or json.')]
+        string $format = 'human',
+    ): int {
+        try {
+            $entry = $this->journal->findById($id);
+        } catch (EntryNotFoundException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 1;
+        } catch (JournalException $e) {
+            echo $e->getMessage(), "\n";
+
+            return 2;
+        }
+
+        if ($format === 'json') {
+            echo $entry->toJson(), "\n";
+
+            return 0;
+        }
+
+        echo \sprintf('id:        %s%s', $entry->id, PHP_EOL);
+        echo \sprintf('operation: %s%s', $entry->operation->value, PHP_EOL);
+        echo \sprintf('timestamp: %s%s', $entry->timestamp->format(DateTimeInterface::RFC3339_EXTENDED), PHP_EOL);
+        echo \sprintf('command:   %s%s', $entry->command, PHP_EOL);
+        echo "spec:      {$entry->spec['path']}  (sha256: {$entry->spec['sha256']})\n";
+        if ($entry->isReverted()) {
+            echo "reverted:  " . $entry->revertedAt?->format(DateTimeInterface::RFC3339_EXTENDED) . "\n";
+        }
+
+        if ($entry->filesCreated !== []) {
+            echo "created:\n";
+            foreach ($entry->filesCreated as $snapshot) {
+                echo "  - {$snapshot->path}  ({$snapshot->sizeBytes} bytes)\n";
+            }
+        }
+
+        if ($entry->filesModified !== []) {
+            echo "modified:\n";
+            foreach ($entry->filesModified as $snapshot) {
+                echo "  - {$snapshot->path}  ({$snapshot->shaBefore} → {$snapshot->shaAfter})\n";
+            }
+        }
+
+        if ($entry->filesSkipped !== []) {
+            echo "skipped:\n";
+            foreach ($entry->filesSkipped as $path) {
+                echo \sprintf('  - %s%s', $path, PHP_EOL);
+            }
+        }
+
+        return 0;
+    }
+}

--- a/src/Altair/Scaffold/Journal/Configuration/ScaffoldJournalConfiguration.php
+++ b/src/Altair/Scaffold/Journal/Configuration/ScaffoldJournalConfiguration.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Configuration;
+
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Configuration\Support\Env;
+use Altair\Container\Container;
+use Altair\Scaffold\Journal\Differ\FileDiffer;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\Storage\FilesystemStorage;
+
+use const DIRECTORY_SEPARATOR;
+
+use Override;
+
+/**
+ * Wires the scaffold journal into the Altair Container.
+ *
+ * | Variable                    | Default       | Purpose                                    |
+ * |-----------------------------|---------------|--------------------------------------------|
+ * | ALTAIR_JOURNAL_ENABLED      | `true`        | Set `false` to skip binding the Journal.   |
+ * | ALTAIR_JOURNAL_DIR          | `.altair`     | Base directory (relative to project root). |
+ * | ALTAIR_JOURNAL_SUBDIR       | `journal`     | Journal subdirectory.                      |
+ *
+ * The `ScaffoldCommand` resolves `Journal` and `RecorderInterface` as
+ * optional constructor dependencies — both are bound as nullable so
+ * minimal hosts can run scaffolding without applying this Configuration.
+ */
+final readonly class ScaffoldJournalConfiguration implements ConfigurationInterface
+{
+    public function __construct(
+        private ?string $projectRoot = null,
+    ) {}
+
+    #[Override]
+    public function apply(Container $container): void
+    {
+        $projectRoot = $this->projectRoot ?? (getcwd() ?: '.');
+
+        $container
+            ->delegate(
+                FileDiffer::class,
+                static fn(): FileDiffer => new FileDiffer(),
+            )
+            ->share(FileDiffer::class)
+
+            ->delegate(
+                FilesystemStorage::class,
+                static function (Env $env) use ($projectRoot): FilesystemStorage {
+                    $base = (string) $env->get('ALTAIR_JOURNAL_DIR', '.altair');
+                    $sub = (string) $env->get('ALTAIR_JOURNAL_SUBDIR', 'journal');
+
+                    return new FilesystemStorage(
+                        $projectRoot . DIRECTORY_SEPARATOR . rtrim($base, '/\\') . DIRECTORY_SEPARATOR . $sub,
+                    );
+                },
+            )
+            ->share(FilesystemStorage::class)
+
+            ->delegate(
+                Journal::class,
+                static fn(FilesystemStorage $storage): Journal => new Journal($storage, $projectRoot),
+            )
+            ->share(Journal::class);
+    }
+}

--- a/src/Altair/Scaffold/Journal/Differ/FileDiffer.php
+++ b/src/Altair/Scaffold/Journal/Differ/FileDiffer.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Differ;
+
+/**
+ * Minimal pure-PHP unified-diff producer.
+ *
+ * The journal needs diffs only for embedding (so rewind can restore the
+ * before-state). It does NOT need to apply diffs in reverse — rewind
+ * uses the embedded full `content_before` field instead, which is
+ * always byte-correct and never ambiguous. The diff here is for human
+ * readability inside `spec diff <id>` output.
+ *
+ * Output format: standard `@@ -A,B +C,D @@` hunks with context lines.
+ * Not a perfect match for GNU diff but close enough to read.
+ */
+final readonly class FileDiffer
+{
+    public function __construct(
+        private int $contextLines = 3,
+    ) {}
+
+    public function diff(string $before, string $after, string $beforeLabel = 'before', string $afterLabel = 'after'): string
+    {
+        if ($before === $after) {
+            return '';
+        }
+
+        $a = $before === '' ? [] : explode("\n", $before);
+        $b = $after === '' ? [] : explode("\n", $after);
+
+        $lcs = $this->lcsTable($a, $b);
+        $ops = $this->backtrack($lcs, $a, $b, \count($a), \count($b));
+
+        return "--- {$beforeLabel}\n+++ {$afterLabel}\n" . $this->renderHunks($ops);
+    }
+
+    /**
+     * @param list<string> $a
+     * @param list<string> $b
+     * @return list<list<int>>
+     */
+    private function lcsTable(array $a, array $b): array
+    {
+        $m = \count($a);
+        $n = \count($b);
+        $t = array_fill(0, $m + 1, array_fill(0, $n + 1, 0));
+
+        for ($i = 1; $i <= $m; $i++) {
+            for ($j = 1; $j <= $n; $j++) {
+                $t[$i][$j] = $a[$i - 1] === $b[$j - 1]
+                    ? $t[$i - 1][$j - 1] + 1
+                    : max($t[$i - 1][$j], $t[$i][$j - 1]);
+            }
+        }
+
+        return $t;
+    }
+
+    /**
+     * @param list<list<int>> $t
+     * @param list<string>    $a
+     * @param list<string>    $b
+     *
+     * @return list<array{op: '='|'-'|'+', a: int, b: int, line: string}>
+     */
+    private function backtrack(array $t, array $a, array $b, int $i, int $j): array
+    {
+        $ops = [];
+        while ($i > 0 || $j > 0) {
+            if ($i > 0 && $j > 0 && $a[$i - 1] === $b[$j - 1]) {
+                $ops[] = ['op' => '=', 'a' => $i, 'b' => $j, 'line' => $a[$i - 1]];
+                $i--;
+                $j--;
+            } elseif ($j > 0 && ($i === 0 || $t[$i][$j - 1] >= $t[$i - 1][$j])) {
+                $ops[] = ['op' => '+', 'a' => $i, 'b' => $j, 'line' => $b[$j - 1]];
+                $j--;
+            } else {
+                $ops[] = ['op' => '-', 'a' => $i, 'b' => $j, 'line' => $a[$i - 1]];
+                $i--;
+            }
+        }
+
+        return array_reverse($ops);
+    }
+
+    /**
+     * @param list<array{op: '='|'-'|'+', a: int, b: int, line: string}> $ops
+     */
+    private function renderHunks(array $ops): string
+    {
+        $count = \count($ops);
+        if ($count === 0) {
+            return '';
+        }
+
+        $changeIdx = [];
+        foreach ($ops as $i => $op) {
+            if ($op['op'] !== '=') {
+                $changeIdx[] = $i;
+            }
+        }
+
+        if ($changeIdx === []) {
+            return '';
+        }
+
+        $context = $this->contextLines;
+        $output = '';
+        $cursor = 0;
+
+        while ($cursor < \count($changeIdx)) {
+            $start = max(0, $changeIdx[$cursor] - $context);
+            $end = min($count - 1, $changeIdx[$cursor] + $context);
+
+            // Extend the hunk while subsequent changes are within `2*context` lines.
+            while ($cursor + 1 < \count($changeIdx) && $changeIdx[$cursor + 1] - $end <= $context) {
+                $cursor++;
+                $end = min($count - 1, $changeIdx[$cursor] + $context);
+            }
+
+            $output .= $this->renderHunk($ops, $start, $end);
+            $cursor++;
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param list<array{op: '='|'-'|'+', a: int, b: int, line: string}> $ops
+     */
+    private function renderHunk(array $ops, int $start, int $end): string
+    {
+        $aStart = null;
+        $bStart = null;
+        $aCount = 0;
+        $bCount = 0;
+        $body = '';
+
+        for ($i = $start; $i <= $end; $i++) {
+            $op = $ops[$i];
+            $aLine = $op['a'];
+            $bLine = $op['b'];
+            if ($op['op'] === '=') {
+                $aStart ??= max(1, $aLine - $aCount);
+                $bStart ??= max(1, $bLine - $bCount);
+                $aCount++;
+                $bCount++;
+                $body .= ' ' . $op['line'] . "\n";
+            } elseif ($op['op'] === '-') {
+                $aStart ??= max(1, $aLine - $aCount);
+                $bStart ??= max(1, $bLine - $bCount + 1);
+                $aCount++;
+                $body .= '-' . $op['line'] . "\n";
+            } else {
+                $aStart ??= max(1, $aLine - $aCount + 1);
+                $bStart ??= max(1, $bLine - $bCount);
+                $bCount++;
+                $body .= '+' . $op['line'] . "\n";
+            }
+        }
+
+        $aStart ??= 1;
+        $bStart ??= 1;
+
+        return \sprintf("@@ -%d,%d +%d,%d @@\n%s", $aStart, $aCount, $bStart, $bCount, $body);
+    }
+}

--- a/src/Altair/Scaffold/Journal/Exception/EntryNotFoundException.php
+++ b/src/Altair/Scaffold/Journal/Exception/EntryNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Exception;
+
+class EntryNotFoundException extends JournalException {}

--- a/src/Altair/Scaffold/Journal/Exception/JournalException.php
+++ b/src/Altair/Scaffold/Journal/Exception/JournalException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Exception;
+
+use RuntimeException;
+
+class JournalException extends RuntimeException {}

--- a/src/Altair/Scaffold/Journal/Exception/RewindRefusedException.php
+++ b/src/Altair/Scaffold/Journal/Exception/RewindRefusedException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Exception;
+
+/**
+ * Thrown when {@see RewindCommand} would clobber files the user has
+ * hand-edited since the original scaffold. `--force` overrides.
+ */
+class RewindRefusedException extends JournalException
+{
+    /**
+     * @param list<string> $unsafePaths File paths whose current sha256 doesn't match the journal entry.
+     */
+    public function __construct(
+        string $message,
+        public readonly array $unsafePaths,
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/src/Altair/Scaffold/Journal/FileSnapshot.php
+++ b/src/Altair/Scaffold/Journal/FileSnapshot.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal;
+
+use Altair\Scaffold\Journal\Exception\JournalException;
+
+/**
+ * Immutable per-file record embedded in a {@see JournalEntry}.
+ *
+ * `created` files carry only the post-scaffold sha + size.
+ * `modified` files carry sha-before, sha-after, and the unified diff —
+ * everything required to reverse the edit without touching the spec.
+ */
+final readonly class FileSnapshot
+{
+    public function __construct(
+        public string $path,
+        public ?string $shaBefore,
+        public ?string $shaAfter,
+        public ?int $sizeBytes,
+        public ?string $diff = null,
+        public ?string $contentBefore = null,
+    ) {
+        if ($path === '') {
+            throw new JournalException('FileSnapshot path must not be empty.');
+        }
+    }
+
+    public static function created(string $path, string $shaAfter, int $sizeBytes): self
+    {
+        return new self(
+            path: $path,
+            shaBefore: null,
+            shaAfter: $shaAfter,
+            sizeBytes: $sizeBytes,
+        );
+    }
+
+    public static function modified(string $path, string $shaBefore, string $shaAfter, string $diff, ?string $contentBefore = null): self
+    {
+        return new self(
+            path: $path,
+            shaBefore: $shaBefore,
+            shaAfter: $shaAfter,
+            sizeBytes: null,
+            diff: $diff,
+            contentBefore: $contentBefore,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = ['path' => $this->path];
+        if ($this->shaBefore !== null) {
+            $out['sha256_before'] = $this->shaBefore;
+        }
+
+        if ($this->shaAfter !== null) {
+            $out['sha256_after'] = $this->shaAfter;
+        }
+
+        if ($this->sizeBytes !== null) {
+            $out['size_bytes'] = $this->sizeBytes;
+        }
+
+        if ($this->diff !== null) {
+            $out['diff'] = $this->diff;
+        }
+
+        if ($this->contentBefore !== null) {
+            $out['content_before'] = $this->contentBefore;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        if (!isset($data['path']) || !\is_string($data['path'])) {
+            throw new JournalException('FileSnapshot requires a string "path".');
+        }
+
+        return new self(
+            path: $data['path'],
+            shaBefore: isset($data['sha256_before']) && \is_string($data['sha256_before']) ? $data['sha256_before'] : null,
+            shaAfter: isset($data['sha256_after']) && \is_string($data['sha256_after']) ? $data['sha256_after'] : null,
+            sizeBytes: isset($data['size_bytes']) && \is_int($data['size_bytes']) ? $data['size_bytes'] : null,
+            diff: isset($data['diff']) && \is_string($data['diff']) ? $data['diff'] : null,
+            contentBefore: isset($data['content_before']) && \is_string($data['content_before']) ? $data['content_before'] : null,
+        );
+    }
+}

--- a/src/Altair/Scaffold/Journal/Journal.php
+++ b/src/Altair/Scaffold/Journal/Journal.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal;
+
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\Exception\RewindRefusedException;
+use Altair\Scaffold\Journal\Storage\FilesystemStorage;
+use DateTimeImmutable;
+use DateTimeInterface;
+
+use const DIRECTORY_SEPARATOR;
+
+use Generator;
+
+/**
+ * High-level read/write/query facade over the {@see FilesystemStorage}.
+ *
+ * - `record()` persists a freshly-built {@see JournalEntry}
+ * - `history()` / `tail()` walk the directory in either direction
+ * - `findById()` resolves either a full id or a unique prefix (so an
+ *   agent can pass the first 8 chars of the id without juggling the
+ *   full timestamp form)
+ * - `rewind()` restores the workspace to the pre-entry state, refusing
+ *   when generated files have been hand-edited unless `force` is set
+ *
+ * Rewind / replay do their I/O against a {@see ProjectRoot} so unit
+ * tests can swap in a tmp directory.
+ */
+final readonly class Journal
+{
+    public function __construct(
+        private FilesystemStorage $storage,
+        private string $projectRoot,
+    ) {}
+
+    public function record(JournalEntry $entry): string
+    {
+        return $this->storage->save($entry);
+    }
+
+    /**
+     * Find an entry by full id, or by the shortest unambiguous prefix.
+     */
+    public function findById(string $idOrPrefix): JournalEntry
+    {
+        if ($this->storage->exists($idOrPrefix)) {
+            return $this->storage->load($idOrPrefix);
+        }
+
+        $matches = [];
+        foreach ($this->storage->readAll() as $entry) {
+            if (str_starts_with($entry->id, $idOrPrefix)) {
+                $matches[] = $entry;
+            }
+        }
+
+        if ($matches === []) {
+            throw new EntryNotFoundException(\sprintf("No journal entry matches '%s'.", $idOrPrefix));
+        }
+
+        if (\count($matches) > 1) {
+            throw new JournalException(\sprintf(
+                "Prefix '%s' is ambiguous — matches %d entries: %s",
+                $idOrPrefix,
+                \count($matches),
+                implode(', ', array_map(static fn(JournalEntry $e): string => $e->id, $matches)),
+            ));
+        }
+
+        return $matches[0];
+    }
+
+    /**
+     * Newest-first iterator. Optional `$limit` (null = all).
+     *
+     * @return Generator<int, JournalEntry>
+     */
+    public function tail(?int $limit = null): Generator
+    {
+        $i = 0;
+        foreach ($this->storage->readReverse() as $entry) {
+            yield $entry;
+            if ($limit !== null && ++$i >= $limit) {
+                return;
+            }
+        }
+    }
+
+    /**
+     * Oldest-first iterator (full history).
+     *
+     * @return Generator<int, JournalEntry>
+     */
+    public function history(): Generator
+    {
+        yield from $this->storage->readAll();
+    }
+
+    /**
+     * Reverse the effect of an entry on the workspace.
+     *
+     * - `files_created` → deleted (if their on-disk sha matches the
+     *    recorded sha; otherwise added to the "unsafe" list and either
+     *    skipped or — with `$force` — deleted anyway).
+     * - `files_modified` → restored from the embedded `content_before`.
+     * - Entry is **not** deleted; instead `reverted_at` is appended so
+     *   the history stays auditable.
+     *
+     * @return array{ deleted: list<string>, restored: list<string>, skipped: list<string> }
+     */
+    public function rewind(JournalEntry $entry, bool $force = false): array
+    {
+        if ($entry->isReverted()) {
+            throw new JournalException(\sprintf("Entry '%s' was already reverted at %s.", $entry->id, $entry->revertedAt?->format(DateTimeInterface::RFC3339_EXTENDED) ?? '(?)'));
+        }
+
+        $unsafe = [];
+        $deleted = [];
+        $restored = [];
+        $skipped = [];
+
+        foreach ($entry->filesCreated as $snapshot) {
+            $absolute = $this->absolute($snapshot->path);
+            if (!is_file($absolute)) {
+                $skipped[] = $snapshot->path;
+                continue;
+            }
+
+            $currentSha = hash_file('sha256', $absolute);
+            if ($snapshot->shaAfter !== null && $currentSha !== $snapshot->shaAfter) {
+                $unsafe[] = $snapshot->path;
+                if (!$force) {
+                    $skipped[] = $snapshot->path;
+                    continue;
+                }
+            }
+
+            if (!@unlink($absolute)) {
+                throw new JournalException(\sprintf("Cannot delete '%s' during rewind.", $absolute));
+            }
+
+            $deleted[] = $snapshot->path;
+        }
+
+        foreach ($entry->filesModified as $snapshot) {
+            if ($snapshot->contentBefore === null) {
+                $skipped[] = $snapshot->path;
+                continue;
+            }
+
+            $absolute = $this->absolute($snapshot->path);
+            if (is_file($absolute) && $snapshot->shaAfter !== null) {
+                $currentSha = hash_file('sha256', $absolute);
+                if ($currentSha !== $snapshot->shaAfter) {
+                    $unsafe[] = $snapshot->path;
+                    if (!$force) {
+                        $skipped[] = $snapshot->path;
+                        continue;
+                    }
+                }
+            }
+
+            $this->ensureParentDirectory($absolute);
+            if (@file_put_contents($absolute, $snapshot->contentBefore, LOCK_EX) === false) {
+                throw new JournalException(\sprintf("Cannot restore '%s' during rewind.", $absolute));
+            }
+
+            $restored[] = $snapshot->path;
+        }
+
+        if ($unsafe !== [] && !$force) {
+            throw new RewindRefusedException(
+                \sprintf(
+                    "Refusing to rewind '%s': %d file(s) were hand-edited after scaffolding (%s). Re-run with --force to override.",
+                    $entry->id,
+                    \count($unsafe),
+                    implode(', ', $unsafe),
+                ),
+                $unsafe,
+            );
+        }
+
+        $this->storage->save($entry->withRevertedAt(new DateTimeImmutable('now')));
+
+        return ['deleted' => $deleted, 'restored' => $restored, 'skipped' => $skipped];
+    }
+
+    public function storage(): FilesystemStorage
+    {
+        return $this->storage;
+    }
+
+    public function projectRoot(): string
+    {
+        return $this->projectRoot;
+    }
+
+    private function absolute(string $relative): string
+    {
+        return $this->projectRoot . DIRECTORY_SEPARATOR . ltrim($relative, '/\\');
+    }
+
+    private function ensureParentDirectory(string $absolute): void
+    {
+        $parent = \dirname($absolute);
+        if (!is_dir($parent) && !@mkdir($parent, 0o775, true) && !is_dir($parent)) {
+            throw new JournalException(\sprintf("Cannot create directory '%s'.", $parent));
+        }
+    }
+}

--- a/src/Altair/Scaffold/Journal/JournalEntry.php
+++ b/src/Altair/Scaffold/Journal/JournalEntry.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal;
+
+use Altair\Scaffold\Journal\Exception\JournalException;
+use DateTimeImmutable;
+use DateTimeInterface;
+use JsonException;
+
+/**
+ * One immutable journal record written to
+ * `.altair/journal/<timestamp>-<short-sha>.json`.
+ *
+ * Self-contained: the spec content is embedded so an entry can be
+ * replayed even if the original spec file is later edited or deleted.
+ *
+ * `revertedAt` is appended (via {@see self::withRevertedAt()}) when a
+ * subsequent `spec rewind` undoes this entry — the entry itself stays
+ * on disk so rewind history is part of the audit trail.
+ *
+ * @phpstan-type SpecInline array{ path: string, sha256: string, content_inline: string }
+ */
+final readonly class JournalEntry
+{
+    public const string VERSION = '1.0';
+
+    /**
+     * @param list<FileSnapshot>   $filesCreated
+     * @param list<FileSnapshot>   $filesModified
+     * @param list<string>         $filesSkipped
+     * @param SpecInline           $spec
+     */
+    public function __construct(
+        public string $id,
+        public OperationKind $operation,
+        public string $command,
+        public DateTimeImmutable $timestamp,
+        public ?string $user,
+        public array $spec,
+        public string $scaffoldVersion,
+        public array $filesCreated = [],
+        public array $filesModified = [],
+        public array $filesSkipped = [],
+        public ?string $openapiFragmentPath = null,
+        public ?DateTimeImmutable $revertedAt = null,
+        public ?string $targetEntryId = null,
+    ) {
+        if ($id === '') {
+            throw new JournalException('JournalEntry id must not be empty.');
+        }
+
+        foreach (['path', 'sha256', 'content_inline'] as $required) {
+            if (!isset($spec[$required]) || !\is_string($spec[$required])) {
+                throw new JournalException(\sprintf('JournalEntry spec is missing required string field "%s".', $required));
+            }
+        }
+    }
+
+    /**
+     * Named-constructor for a scaffold operation. The id is the
+     * `<timestamp>-<short-sha>` form used as the on-disk filename stem.
+     *
+     * @param list<FileSnapshot>   $filesCreated
+     * @param list<FileSnapshot>   $filesModified
+     * @param list<string>         $filesSkipped
+     */
+    public static function scaffold(
+        string $command,
+        string $specPath,
+        string $specContent,
+        string $scaffoldVersion,
+        array $filesCreated = [],
+        array $filesModified = [],
+        array $filesSkipped = [],
+        ?string $openapiFragmentPath = null,
+        ?DateTimeImmutable $timestamp = null,
+        ?string $user = null,
+    ): self {
+        $ts = $timestamp ?? new DateTimeImmutable('now');
+        $specSha = hash('sha256', $specContent);
+
+        return new self(
+            id: self::buildId($ts, $specSha),
+            operation: OperationKind::Scaffold,
+            command: $command,
+            timestamp: $ts,
+            user: $user ?? self::resolveUser(),
+            spec: [
+                'path' => $specPath,
+                'sha256' => $specSha,
+                'content_inline' => $specContent,
+            ],
+            scaffoldVersion: $scaffoldVersion,
+            filesCreated: $filesCreated,
+            filesModified: $filesModified,
+            filesSkipped: $filesSkipped,
+            openapiFragmentPath: $openapiFragmentPath,
+        );
+    }
+
+    public function withRevertedAt(DateTimeImmutable $when): self
+    {
+        return new self(
+            id: $this->id,
+            operation: $this->operation,
+            command: $this->command,
+            timestamp: $this->timestamp,
+            user: $this->user,
+            spec: $this->spec,
+            scaffoldVersion: $this->scaffoldVersion,
+            filesCreated: $this->filesCreated,
+            filesModified: $this->filesModified,
+            filesSkipped: $this->filesSkipped,
+            openapiFragmentPath: $this->openapiFragmentPath,
+            revertedAt: $when,
+            targetEntryId: $this->targetEntryId,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = [
+            'version' => self::VERSION,
+            'operation' => $this->operation->value,
+            'id' => $this->id,
+            'command' => $this->command,
+            'timestamp' => $this->timestamp->format(DateTimeInterface::RFC3339_EXTENDED),
+            'user' => $this->user,
+            'spec' => $this->spec,
+            'scaffold_version' => $this->scaffoldVersion,
+            'files_created' => array_map(static fn(FileSnapshot $s): array => $s->toArray(), $this->filesCreated),
+            'files_modified' => array_map(static fn(FileSnapshot $s): array => $s->toArray(), $this->filesModified),
+            'files_skipped' => $this->filesSkipped,
+        ];
+
+        if ($this->openapiFragmentPath !== null) {
+            $out['openapi_fragment_path'] = $this->openapiFragmentPath;
+        }
+
+        if ($this->revertedAt instanceof DateTimeImmutable) {
+            $out['reverted_at'] = $this->revertedAt->format(DateTimeInterface::RFC3339_EXTENDED);
+        }
+
+        if ($this->targetEntryId !== null) {
+            $out['target_entry_id'] = $this->targetEntryId;
+        }
+
+        return $out;
+    }
+
+    public function toJson(): string
+    {
+        try {
+            return json_encode(
+                $this->toArray(),
+                JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+            );
+        } catch (JsonException $jsonException) {
+            throw new JournalException('JournalEntry is not JSON-encodable: ' . $jsonException->getMessage(), 0, $jsonException);
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        foreach (['id', 'operation', 'command', 'timestamp', 'spec', 'scaffold_version'] as $required) {
+            if (!\array_key_exists($required, $data)) {
+                throw new JournalException(\sprintf('JournalEntry missing required field "%s".', $required));
+            }
+        }
+
+        $timestamp = $data['timestamp'];
+        $parsed = \is_string($timestamp)
+            ? (DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $timestamp)
+                ?: DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339, $timestamp))
+            : false;
+        if ($parsed === false || $parsed === null) {
+            throw new JournalException(\sprintf('Invalid timestamp "%s".', (string) $timestamp));
+        }
+
+        $revertedAt = null;
+        if (isset($data['reverted_at']) && \is_string($data['reverted_at'])) {
+            $rv = DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339_EXTENDED, $data['reverted_at'])
+                ?: DateTimeImmutable::createFromFormat(DateTimeInterface::RFC3339, $data['reverted_at']);
+            $revertedAt = $rv === false ? null : $rv;
+        }
+
+        /** @var array<int, array<string, mixed>> $createdRaw */
+        $createdRaw = \is_array($data['files_created'] ?? null) ? $data['files_created'] : [];
+        /** @var array<int, array<string, mixed>> $modifiedRaw */
+        $modifiedRaw = \is_array($data['files_modified'] ?? null) ? $data['files_modified'] : [];
+        /** @var array<int, mixed> $skippedRaw */
+        $skippedRaw = \is_array($data['files_skipped'] ?? null) ? $data['files_skipped'] : [];
+
+        /** @var array<string, mixed> $specData */
+        $specData = \is_array($data['spec']) ? $data['spec'] : [];
+
+        return new self(
+            id: (string) $data['id'],
+            operation: OperationKind::from((string) $data['operation']),
+            command: (string) $data['command'],
+            timestamp: $parsed,
+            user: isset($data['user']) && \is_string($data['user']) ? $data['user'] : null,
+            spec: [
+                'path' => (string) ($specData['path'] ?? ''),
+                'sha256' => (string) ($specData['sha256'] ?? ''),
+                'content_inline' => (string) ($specData['content_inline'] ?? ''),
+            ],
+            scaffoldVersion: (string) $data['scaffold_version'],
+            filesCreated: array_map(FileSnapshot::fromArray(...), array_values($createdRaw)),
+            filesModified: array_map(FileSnapshot::fromArray(...), array_values($modifiedRaw)),
+            filesSkipped: array_values(array_map(static fn(mixed $p): string => (string) $p, $skippedRaw)),
+            openapiFragmentPath: isset($data['openapi_fragment_path']) && \is_string($data['openapi_fragment_path']) ? $data['openapi_fragment_path'] : null,
+            revertedAt: $revertedAt,
+            targetEntryId: isset($data['target_entry_id']) && \is_string($data['target_entry_id']) ? $data['target_entry_id'] : null,
+        );
+    }
+
+    public function isReverted(): bool
+    {
+        return $this->revertedAt instanceof DateTimeImmutable;
+    }
+
+    /**
+     * `<YYYYMMDDTHHMMSSZ>-<first-8-of-sha>` — sortable, filesystem-safe.
+     */
+    private static function buildId(DateTimeImmutable $when, string $sha): string
+    {
+        return $when->format('Ymd\\THis\\Z') . '-' . substr($sha, 0, 8);
+    }
+
+    private static function resolveUser(): ?string
+    {
+        $user = getenv('USER');
+        if ($user !== false && $user !== '') {
+            return $user;
+        }
+
+        $user = getenv('USERNAME'); // Windows
+        if ($user !== false && $user !== '') {
+            return $user;
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Scaffold/Journal/OperationKind.php
+++ b/src/Altair/Scaffold/Journal/OperationKind.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal;
+
+/**
+ * Operation kinds recorded in the journal.
+ *
+ * Aligned with {@see \Altair\Events\EventKind} so an event-log dual-write
+ * stays a 1:1 mapping (scaffold → Scaffold, rewind → Rewind, replay →
+ * Replay).
+ */
+enum OperationKind: string
+{
+    case Scaffold = 'scaffold';
+    case Rewind = 'rewind';
+    case Replay = 'replay';
+}

--- a/src/Altair/Scaffold/Journal/SnapshotCollector.php
+++ b/src/Altair/Scaffold/Journal/SnapshotCollector.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal;
+
+use Altair\Scaffold\Emitter\EmittedFile;
+use Altair\Scaffold\Journal\Differ\FileDiffer;
+use Altair\Scaffold\Writer\WriteOutcome;
+use Altair\Scaffold\Writer\WriteStatus;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Builds {@see FileSnapshot} entries from the scaffolder's write
+ * outcomes — keeps the journaling logic out of {@see ScaffoldCommand}
+ * so that command stays focused on the write loop.
+ *
+ * Sequence inside the host command:
+ *
+ *     $before = $collector->captureBefore($file);   // before write
+ *     $outcome = $writer->write($file, $force);     // existing write
+ *     $collector->record($file, $outcome, $before); // after write
+ *     ...
+ *     [$created, $modified, $skipped] = $collector->snapshots();
+ */
+final class SnapshotCollector
+{
+    /** @var list<FileSnapshot> */
+    private array $created = [];
+
+    /** @var list<FileSnapshot> */
+    private array $modified = [];
+
+    /** @var list<string> */
+    private array $skipped = [];
+
+    public function __construct(
+        private readonly string $projectRoot,
+        private readonly FileDiffer $differ = new FileDiffer(),
+    ) {}
+
+    /**
+     * Read the existing on-disk content for $file (if any) — must be
+     * called BEFORE writing so we can capture the `content_before`
+     * for modified files.
+     */
+    public function captureBefore(EmittedFile $file): ?string
+    {
+        $absolute = $this->absolute($file->relativePath);
+
+        return is_file($absolute) ? (string) @file_get_contents($absolute) : null;
+    }
+
+    public function record(EmittedFile $file, WriteOutcome $outcome, ?string $contentBefore): void
+    {
+        $absolute = $this->absolute($file->relativePath);
+
+        switch ($outcome->status) {
+            case WriteStatus::Written:
+                $sha = is_file($absolute) ? (string) hash_file('sha256', $absolute) : hash('sha256', $file->contents);
+                $size = is_file($absolute) ? (int) filesize($absolute) : \strlen($file->contents);
+                $this->created[] = FileSnapshot::created($file->relativePath, $sha, $size);
+                break;
+            case WriteStatus::Modified:
+                $shaBefore = $contentBefore !== null ? hash('sha256', $contentBefore) : '';
+                $shaAfter = is_file($absolute) ? (string) hash_file('sha256', $absolute) : hash('sha256', $file->contents);
+                $afterContent = is_file($absolute) ? (string) @file_get_contents($absolute) : $file->contents;
+                $diff = $contentBefore !== null
+                    ? $this->differ->diff($contentBefore, $afterContent, $file->relativePath . ' (before)', $file->relativePath . ' (after)')
+                    : '';
+                $this->modified[] = FileSnapshot::modified(
+                    path: $file->relativePath,
+                    shaBefore: $shaBefore,
+                    shaAfter: $shaAfter,
+                    diff: $diff,
+                    contentBefore: $contentBefore,
+                );
+                break;
+            case WriteStatus::Skipped:
+                $this->skipped[] = $file->relativePath;
+                break;
+        }
+    }
+
+    /**
+     * @return list<FileSnapshot>
+     */
+    public function created(): array
+    {
+        return $this->created;
+    }
+
+    /**
+     * @return list<FileSnapshot>
+     */
+    public function modified(): array
+    {
+        return $this->modified;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function skipped(): array
+    {
+        return $this->skipped;
+    }
+
+    public function reset(): void
+    {
+        $this->created = [];
+        $this->modified = [];
+        $this->skipped = [];
+    }
+
+    private function absolute(string $relativePath): string
+    {
+        return $this->projectRoot . DIRECTORY_SEPARATOR . ltrim($relativePath, '/\\');
+    }
+}

--- a/src/Altair/Scaffold/Journal/Storage/FilesystemStorage.php
+++ b/src/Altair/Scaffold/Journal/Storage/FilesystemStorage.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Journal\Storage;
+
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\JournalEntry;
+
+use const DIRECTORY_SEPARATOR;
+
+use Generator;
+use JsonException;
+use Throwable;
+
+/**
+ * One JSON file per entry under `.altair/journal/`.
+ *
+ * Writes are atomic — tmp + rename guards against torn reads if two
+ * `bin/altair spec scaffold` processes run concurrently. Reads tolerate
+ * malformed files (one bad file doesn't break iteration).
+ */
+final readonly class FilesystemStorage
+{
+    public function __construct(
+        private string $directory,
+    ) {}
+
+    public function save(JournalEntry $entry): string
+    {
+        $this->ensureDirectory();
+
+        $path = $this->pathFor($entry->id);
+        $tmp = $path . '.tmp.' . bin2hex(random_bytes(4));
+
+        if (@file_put_contents($tmp, $entry->toJson(), LOCK_EX) === false) {
+            throw new JournalException(\sprintf("Cannot write journal tmp file '%s'.", $tmp));
+        }
+
+        if (!@rename($tmp, $path)) {
+            @unlink($tmp);
+            throw new JournalException(\sprintf("Cannot rename '%s' → '%s'.", $tmp, $path));
+        }
+
+        return $path;
+    }
+
+    public function load(string $id): JournalEntry
+    {
+        $path = $this->pathFor($id);
+        if (!is_file($path)) {
+            throw new EntryNotFoundException(\sprintf("Journal entry '%s' not found at %s.", $id, $path));
+        }
+
+        $raw = @file_get_contents($path);
+        if ($raw === false) {
+            throw new JournalException(\sprintf("Cannot read journal entry '%s'.", $id));
+        }
+
+        try {
+            /** @var array<string, mixed> $data */
+            $data = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $jsonException) {
+            throw new JournalException(\sprintf("Journal entry '%s' is not valid JSON: %s", $id, $jsonException->getMessage()), 0, $jsonException);
+        }
+
+        return JournalEntry::fromArray($data);
+    }
+
+    /**
+     * Iterate entries oldest → newest.
+     *
+     * @return Generator<int, JournalEntry>
+     */
+    public function readAll(): Generator
+    {
+        foreach ($this->idsSorted() as $id) {
+            try {
+                yield $this->load($id);
+            } catch (Throwable) {
+                continue;
+            }
+        }
+    }
+
+    /**
+     * Iterate entries newest → oldest.
+     *
+     * @return Generator<int, JournalEntry>
+     */
+    public function readReverse(): Generator
+    {
+        $ids = $this->idsSorted();
+        for ($i = \count($ids) - 1; $i >= 0; $i--) {
+            try {
+                yield $this->load($ids[$i]);
+            } catch (Throwable) {
+                continue;
+            }
+        }
+    }
+
+    public function exists(string $id): bool
+    {
+        return is_file($this->pathFor($id));
+    }
+
+    public function path(): string
+    {
+        return $this->directory;
+    }
+
+    public function pathFor(string $id): string
+    {
+        return $this->directory . DIRECTORY_SEPARATOR . $id . '.json';
+    }
+
+    /**
+     * @return list<string> Entry ids, lexicographically sorted (which equals
+     *                     chronologically sorted because the id starts with a
+     *                     `Ymd\THis\Z` timestamp).
+     */
+    private function idsSorted(): array
+    {
+        if (!is_dir($this->directory)) {
+            return [];
+        }
+
+        $files = @scandir($this->directory) ?: [];
+        $ids = [];
+        foreach ($files as $name) {
+            if (str_ends_with($name, '.json') && !str_contains($name, '.tmp.')) {
+                $ids[] = substr($name, 0, -\strlen('.json'));
+            }
+        }
+
+        sort($ids);
+
+        return $ids;
+    }
+
+    private function ensureDirectory(): void
+    {
+        if (!is_dir($this->directory) && !@mkdir($this->directory, 0o775, true) && !is_dir($this->directory)) {
+            throw new JournalException(\sprintf("Cannot create journal directory '%s'.", $this->directory));
+        }
+    }
+}

--- a/src/Altair/Scaffold/composer.json
+++ b/src/Altair/Scaffold/composer.json
@@ -11,7 +11,12 @@
         "php": ">=8.3",
         "nikic/php-parser": "^5.0",
         "symfony/yaml": "^7.0",
-        "univeros/cli": "^2.0"
+        "univeros/cli": "^2.0",
+        "univeros/configuration": "^2.0",
+        "univeros/container": "^2.0"
+    },
+    "suggest": {
+        "univeros/events": "Hooks scaffold operations into the .altair/events.jsonl mutation log for cross-session agent memory."
     },
     "autoload": {
         "psr-4": {

--- a/tests/Scaffold/Journal/Cli/CommandsTest.php
+++ b/tests/Scaffold/Journal/Cli/CommandsTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Journal\Cli;
+
+use Altair\Scaffold\Journal\Cli\DiffCommand;
+use Altair\Scaffold\Journal\Cli\HistoryCommand;
+use Altair\Scaffold\Journal\Cli\RewindCommand;
+use Altair\Scaffold\Journal\Cli\ShowCommand;
+use Altair\Scaffold\Journal\FileSnapshot;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\JournalEntry;
+use Altair\Scaffold\Journal\Storage\FilesystemStorage;
+use DateTimeImmutable;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HistoryCommand::class)]
+#[CoversClass(ShowCommand::class)]
+#[CoversClass(DiffCommand::class)]
+#[CoversClass(RewindCommand::class)]
+class CommandsTest extends TestCase
+{
+    private string $projectRoot;
+
+    private Journal $journal;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/altair-journal-cli-' . bin2hex(random_bytes(4));
+        @mkdir($this->projectRoot . '/.altair/journal', 0o775, true);
+        $this->journal = new Journal(
+            new FilesystemStorage($this->projectRoot . '/.altair/journal'),
+            $this->projectRoot,
+        );
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->projectRoot);
+    }
+
+    public function testHistoryAnnouncesEmptyJournal(): void
+    {
+        ob_start();
+        $exit = (new HistoryCommand($this->journal))(n: 10, since: null, spec: null, format: 'human');
+        $output = (string) ob_get_clean();
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('No journal entries', $output);
+    }
+
+    public function testHistoryJsonReturnsArray(): void
+    {
+        $this->journal->record(JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        ));
+
+        ob_start();
+        (new HistoryCommand($this->journal))(n: 10, since: null, spec: null, format: 'json');
+        $output = (string) ob_get_clean();
+        $decoded = json_decode($output, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertCount(1, $decoded);
+        $this->assertSame('spec.yaml', $decoded[0]['spec_path']);
+    }
+
+    public function testShowResolvesByPrefix(): void
+    {
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $this->journal->record($entry);
+
+        ob_start();
+        $exit = (new ShowCommand($this->journal))(id: substr($entry->id, 0, 18), format: 'json');
+        $output = (string) ob_get_clean();
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString($entry->id, $output);
+    }
+
+    public function testShowReportsNonZeroForUnknownId(): void
+    {
+        ob_start();
+        $exit = (new ShowCommand($this->journal))(id: 'nope', format: 'human');
+        ob_get_clean();
+        $this->assertSame(1, $exit);
+    }
+
+    public function testDiffPrintsCreatedAndModified(): void
+    {
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', hash('sha256', 'foo'), 100)],
+            filesModified: [FileSnapshot::modified('config/routes.php', hash('sha256', 'a'), hash('sha256', 'b'), "@@ -1,1 +1,1 @@\n-a\n+b\n", 'a')],
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $this->journal->record($entry);
+
+        ob_start();
+        (new DiffCommand($this->journal))(id: $entry->id);
+        $output = (string) ob_get_clean();
+        $this->assertStringContainsString('+++ src/Foo.php', $output);
+        $this->assertStringContainsString('~~~ config/routes.php', $output);
+        $this->assertStringContainsString('-a', $output);
+    }
+
+    public function testRewindDryRunDoesNotMutateWorkspace(): void
+    {
+        @mkdir($this->projectRoot . '/src', 0o775, true);
+        file_put_contents($this->projectRoot . '/src/Foo.php', '<?php class Foo {}');
+        $sha = hash_file('sha256', $this->projectRoot . '/src/Foo.php');
+
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', $sha, 100)],
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $this->journal->record($entry);
+
+        ob_start();
+        $exit = (new RewindCommand($this->journal))(to: null, dryRun: true, force: false);
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(0, $exit);
+        $this->assertFileExists($this->projectRoot . '/src/Foo.php');
+        $this->assertStringContainsString('Would rewind 1', $output);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        ) as $file) {
+            $file->isDir() ? @rmdir((string) $file) : @unlink((string) $file);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Scaffold/Journal/Differ/FileDifferTest.php
+++ b/tests/Scaffold/Journal/Differ/FileDifferTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Journal\Differ;
+
+use Altair\Scaffold\Journal\Differ\FileDiffer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FileDiffer::class)]
+class FileDifferTest extends TestCase
+{
+    public function testEqualInputsProduceEmptyDiff(): void
+    {
+        $this->assertSame('', (new FileDiffer())->diff("same\n", "same\n"));
+    }
+
+    public function testDetectsAddedLine(): void
+    {
+        $diff = (new FileDiffer())->diff("a\nb\nc", "a\nb\nb2\nc");
+        $this->assertStringContainsString('+b2', $diff);
+        $this->assertStringContainsString('--- before', $diff);
+        $this->assertStringContainsString('+++ after', $diff);
+    }
+
+    public function testDetectsRemovedLine(): void
+    {
+        $diff = (new FileDiffer())->diff("a\nb\nc", "a\nc");
+        $this->assertStringContainsString('-b', $diff);
+    }
+
+    public function testDetectsReplacedLine(): void
+    {
+        $diff = (new FileDiffer())->diff("a\nold\nc", "a\nnew\nc");
+        $this->assertStringContainsString('-old', $diff);
+        $this->assertStringContainsString('+new', $diff);
+    }
+
+    public function testFromEmptyToContent(): void
+    {
+        $diff = (new FileDiffer())->diff('', "first\nsecond\n");
+        $this->assertStringContainsString('+first', $diff);
+        $this->assertStringContainsString('+second', $diff);
+    }
+}

--- a/tests/Scaffold/Journal/JournalEntryTest.php
+++ b/tests/Scaffold/Journal/JournalEntryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Journal;
+
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\FileSnapshot;
+use Altair\Scaffold\Journal\JournalEntry;
+use Altair\Scaffold\Journal\OperationKind;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JournalEntry::class)]
+#[CoversClass(FileSnapshot::class)]
+#[CoversClass(OperationKind::class)]
+class JournalEntryTest extends TestCase
+{
+    public function testScaffoldFactoryStampsIdAndShaFromContent(): void
+    {
+        $entry = JournalEntry::scaffold(
+            command: 'bin/altair spec:scaffold api/users/create.yaml',
+            specPath: 'api/users/create.yaml',
+            specContent: "endpoint:\n  method: POST\n",
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', str_repeat('a', 64), 100)],
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+            user: 'tester',
+        );
+
+        $this->assertSame(OperationKind::Scaffold, $entry->operation);
+        $this->assertSame('20260527T100000Z-' . substr(hash('sha256', "endpoint:\n  method: POST\n"), 0, 8), $entry->id);
+        $this->assertSame('tester', $entry->user);
+        $this->assertCount(1, $entry->filesCreated);
+        $this->assertSame('api/users/create.yaml', $entry->spec['path']);
+        $this->assertSame(hash('sha256', "endpoint:\n  method: POST\n"), $entry->spec['sha256']);
+    }
+
+    public function testRoundTripsThroughJson(): void
+    {
+        $entry = JournalEntry::scaffold(
+            command: 'bin/altair spec:scaffold api/users/create.yaml',
+            specPath: 'api/users/create.yaml',
+            specContent: "endpoint:\n  method: POST\n",
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', hash('sha256', 'foo'), 3)],
+            filesModified: [FileSnapshot::modified('config/routes.php', hash('sha256', 'a'), hash('sha256', 'b'), '@@ diff @@', 'a')],
+            filesSkipped: ['src/Bar.php'],
+            openapiFragmentPath: 'docs/openapi/users-create.yaml',
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+
+        $rebuilt = JournalEntry::fromArray(json_decode($entry->toJson(), true, 512, JSON_THROW_ON_ERROR));
+
+        $this->assertSame($entry->id, $rebuilt->id);
+        $this->assertSame($entry->command, $rebuilt->command);
+        $this->assertSame($entry->spec, $rebuilt->spec);
+        $this->assertCount(1, $rebuilt->filesCreated);
+        $this->assertCount(1, $rebuilt->filesModified);
+        $this->assertSame(['src/Bar.php'], $rebuilt->filesSkipped);
+        $this->assertSame('docs/openapi/users-create.yaml', $rebuilt->openapiFragmentPath);
+        $this->assertSame('a', $rebuilt->filesModified[0]->contentBefore);
+    }
+
+    public function testWithRevertedAtAppendsAuditTrailImmutably(): void
+    {
+        $original = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $revertTime = new DateTimeImmutable('2026-05-27T11:00:00Z');
+
+        $reverted = $original->withRevertedAt($revertTime);
+
+        $this->assertFalse($original->isReverted(), 'Original must stay unchanged (immutable).');
+        $this->assertTrue($reverted->isReverted());
+        $this->assertSame($revertTime->getTimestamp(), $reverted->revertedAt?->getTimestamp());
+    }
+
+    public function testFromArrayRejectsMissingFields(): void
+    {
+        $this->expectException(JournalException::class);
+        JournalEntry::fromArray(['id' => 'x']);
+    }
+
+    public function testFileSnapshotRejectsEmptyPath(): void
+    {
+        $this->expectException(JournalException::class);
+        new FileSnapshot(path: '', shaBefore: null, shaAfter: null, sizeBytes: null);
+    }
+}

--- a/tests/Scaffold/Journal/JournalRewindTest.php
+++ b/tests/Scaffold/Journal/JournalRewindTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Journal;
+
+use Altair\Scaffold\Journal\Exception\JournalException;
+use Altair\Scaffold\Journal\Exception\RewindRefusedException;
+use Altair\Scaffold\Journal\FileSnapshot;
+use Altair\Scaffold\Journal\Journal;
+use Altair\Scaffold\Journal\JournalEntry;
+use Altair\Scaffold\Journal\Storage\FilesystemStorage;
+use DateTimeImmutable;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Journal::class)]
+class JournalRewindTest extends TestCase
+{
+    private string $projectRoot;
+
+    private string $journalDir;
+
+    private Journal $journal;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->projectRoot = sys_get_temp_dir() . '/altair-journal-rewind-' . bin2hex(random_bytes(4));
+        $this->journalDir = $this->projectRoot . '/.altair/journal';
+        @mkdir($this->projectRoot, 0o775, true);
+        $this->journal = new Journal(new FilesystemStorage($this->journalDir), $this->projectRoot);
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->rrmdir($this->projectRoot);
+    }
+
+    public function testRewindDeletesCreatedFilesAndRestoresModifiedFiles(): void
+    {
+        // Setup: simulate that scaffold created src/Foo.php and modified config/routes.php.
+        @mkdir($this->projectRoot . '/src', 0o775, true);
+        @mkdir($this->projectRoot . '/config', 0o775, true);
+
+        file_put_contents($this->projectRoot . '/src/Foo.php', "<?php class Foo {}");
+        file_put_contents($this->projectRoot . '/config/routes.php', "<?php\nreturn ['new line'];");
+
+        $shaAfterCreated = hash_file('sha256', $this->projectRoot . '/src/Foo.php');
+        $shaAfterModified = hash_file('sha256', $this->projectRoot . '/config/routes.php');
+        $contentBeforeModified = "<?php\nreturn [];";
+
+        $entry = JournalEntry::scaffold(
+            command: 'bin/altair spec:scaffold spec.yaml',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', $shaAfterCreated, 100)],
+            filesModified: [FileSnapshot::modified(
+                'config/routes.php',
+                hash('sha256', $contentBeforeModified),
+                $shaAfterModified,
+                '@@ diff @@',
+                $contentBeforeModified,
+            )],
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+
+        $this->journal->record($entry);
+        $result = $this->journal->rewind($entry);
+
+        $this->assertFileDoesNotExist($this->projectRoot . '/src/Foo.php');
+        $this->assertSame($contentBeforeModified, (string) file_get_contents($this->projectRoot . '/config/routes.php'));
+        $this->assertCount(1, $result['deleted']);
+        $this->assertCount(1, $result['restored']);
+        $this->assertCount(0, $result['skipped']);
+
+        // Entry still on disk, now with reverted_at stamped.
+        $reloaded = $this->journal->findById($entry->id);
+        $this->assertTrue($reloaded->isReverted());
+    }
+
+    public function testRewindRefusesWhenGeneratedFileWasHandEdited(): void
+    {
+        @mkdir($this->projectRoot . '/src', 0o775, true);
+        file_put_contents($this->projectRoot . '/src/Foo.php', "<?php class Foo {}");
+        $shaAfter = hash_file('sha256', $this->projectRoot . '/src/Foo.php');
+
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', $shaAfter, 100)],
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $this->journal->record($entry);
+
+        // User hand-edits the file.
+        file_put_contents($this->projectRoot . '/src/Foo.php', "<?php class FooEdited {}");
+
+        try {
+            $this->journal->rewind($entry, force: false);
+            $this->fail('Expected RewindRefusedException.');
+        } catch (RewindRefusedException $rewindRefusedException) {
+            $this->assertSame(['src/Foo.php'], $rewindRefusedException->unsafePaths);
+            // Hand-edited file must NOT have been deleted.
+            $this->assertFileExists($this->projectRoot . '/src/Foo.php');
+        }
+    }
+
+    public function testRewindForceClobbersHandEdits(): void
+    {
+        @mkdir($this->projectRoot . '/src', 0o775, true);
+        file_put_contents($this->projectRoot . '/src/Foo.php', "<?php class Foo {}");
+        $shaAfter = hash_file('sha256', $this->projectRoot . '/src/Foo.php');
+
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            filesCreated: [FileSnapshot::created('src/Foo.php', $shaAfter, 100)],
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $this->journal->record($entry);
+        file_put_contents($this->projectRoot . '/src/Foo.php', "<?php class FooEdited {}");
+
+        $result = $this->journal->rewind($entry, force: true);
+        $this->assertContains('src/Foo.php', $result['deleted']);
+        $this->assertFileDoesNotExist($this->projectRoot . '/src/Foo.php');
+    }
+
+    public function testFindByIdResolvesPrefix(): void
+    {
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        );
+        $this->journal->record($entry);
+
+        $prefix = substr($entry->id, 0, 18); // timestamp portion alone — unambiguous in a 1-entry journal
+        $found = $this->journal->findById($prefix);
+        $this->assertSame($entry->id, $found->id);
+    }
+
+    public function testRewindRejectsAlreadyRevertedEntry(): void
+    {
+        $entry = JournalEntry::scaffold(
+            command: 'cmd',
+            specPath: 'spec.yaml',
+            specContent: 'x',
+            scaffoldVersion: '1.0',
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+        )->withRevertedAt(new DateTimeImmutable('now'));
+        $this->journal->record($entry);
+
+        $this->expectException(JournalException::class);
+        $this->journal->rewind($entry);
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        ) as $file) {
+            $file->isDir() ? @rmdir((string) $file) : @unlink((string) $file);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Scaffold/Journal/Storage/FilesystemStorageTest.php
+++ b/tests/Scaffold/Journal/Storage/FilesystemStorageTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Journal\Storage;
+
+use Altair\Scaffold\Journal\Exception\EntryNotFoundException;
+use Altair\Scaffold\Journal\JournalEntry;
+use Altair\Scaffold\Journal\Storage\FilesystemStorage;
+use DateTimeImmutable;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(FilesystemStorage::class)]
+class FilesystemStorageTest extends TestCase
+{
+    private string $tmpDir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->tmpDir = sys_get_temp_dir() . '/altair-journal-storage-' . bin2hex(random_bytes(4));
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tmpDir)) {
+            foreach (glob($this->tmpDir . '/*') ?: [] as $f) {
+                @unlink($f);
+            }
+
+            @rmdir($this->tmpDir);
+        }
+    }
+
+    public function testSaveAndLoadRoundTrip(): void
+    {
+        $storage = new FilesystemStorage($this->tmpDir);
+        $entry = $this->entry('2026-05-27T10:00:00Z', 'A');
+
+        $path = $storage->save($entry);
+        $this->assertFileExists($path);
+
+        $loaded = $storage->load($entry->id);
+        $this->assertSame($entry->id, $loaded->id);
+        $this->assertSame($entry->spec, $loaded->spec);
+    }
+
+    public function testReadAllYieldsChronologically(): void
+    {
+        $storage = new FilesystemStorage($this->tmpDir);
+        $storage->save($this->entry('2026-05-27T10:00:00Z', 'oldest'));
+        $storage->save($this->entry('2026-05-27T12:00:00Z', 'newest'));
+        $storage->save($this->entry('2026-05-27T11:00:00Z', 'middle'));
+
+        $ids = [];
+        foreach ($storage->readAll() as $entry) {
+            $ids[] = $entry->spec['content_inline'];
+        }
+
+        $this->assertSame(['oldest', 'middle', 'newest'], $ids);
+    }
+
+    public function testReadReverseYieldsNewestFirst(): void
+    {
+        $storage = new FilesystemStorage($this->tmpDir);
+        $storage->save($this->entry('2026-05-27T10:00:00Z', 'oldest'));
+        $storage->save($this->entry('2026-05-27T12:00:00Z', 'newest'));
+
+        $ids = [];
+        foreach ($storage->readReverse() as $entry) {
+            $ids[] = $entry->spec['content_inline'];
+        }
+
+        $this->assertSame(['newest', 'oldest'], $ids);
+    }
+
+    public function testLoadThrowsForMissingEntry(): void
+    {
+        $this->expectException(EntryNotFoundException::class);
+        (new FilesystemStorage($this->tmpDir))->load('does-not-exist');
+    }
+
+    public function testReadAllSkipsMalformedFiles(): void
+    {
+        @mkdir($this->tmpDir, 0o775, true);
+        $storage = new FilesystemStorage($this->tmpDir);
+        $storage->save($this->entry('2026-05-27T10:00:00Z', 'good'));
+
+        file_put_contents($this->tmpDir . '/20260527T110000Z-bad.json', '{not json');
+
+        $contents = [];
+        foreach ($storage->readAll() as $entry) {
+            $contents[] = $entry->spec['content_inline'];
+        }
+
+        $this->assertSame(['good'], $contents);
+    }
+
+    public function testWriteIsAtomicViaTmpAndRename(): void
+    {
+        $storage = new FilesystemStorage($this->tmpDir);
+        $storage->save($this->entry('2026-05-27T10:00:00Z', 'first'));
+
+        // Should not leave .tmp files behind.
+        $stragglers = glob($this->tmpDir . '/*.tmp.*') ?: [];
+        $this->assertSame([], $stragglers);
+    }
+
+    private function entry(string $when, string $content): JournalEntry
+    {
+        return JournalEntry::scaffold(
+            command: 'bin/altair spec:scaffold spec.yaml',
+            specPath: 'spec.yaml',
+            specContent: $content,
+            scaffoldVersion: '1.0',
+            timestamp: new DateTimeImmutable($when),
+        );
+    }
+}


### PR DESCRIPTION
Closes #72.

## Summary

Adds a **journal** sub-feature inside \`univeros/scaffold\` that makes every \`bin/altair spec:scaffold\` operation self-contained, rewindable, and replayable. Each scaffold writes a \`.altair/journal/<timestamp>-<short-sha>.json\` entry capturing the spec content, per-file SHAs, and full \`content_before\` for modified files. Failed iterations become recoverable rather than catastrophic.

Lives inside the existing sub-package (no new \`univeros/*\` package); composes naturally with #77's event log (each scaffold now dual-writes a \`scaffold\` event to \`.altair/events.jsonl\` when both are wired).

## What ships

Inside \`src/Altair/Scaffold/Journal/\`:

| Layer | Files |
|---|---|
| **Value objects** | \`JournalEntry\`, \`FileSnapshot\`, \`OperationKind\` enum |
| **Storage** | \`Storage\FilesystemStorage\` (atomic tmp+rename writes; tolerant of malformed files on read) |
| **Facade** | \`Journal\` (record / findById / tail / history / rewind) |
| **Diff** | \`Differ\FileDiffer\` (pure-PHP LCS-based unified-diff producer) |
| **Snapshot** | \`SnapshotCollector\` (per-spec write tracker used by \`ScaffoldCommand\`) |
| **Configuration** | \`ScaffoldJournalConfiguration\` (Container wiring) |
| **CLI** | \`journal:list / show / diff / rewind / replay\` |

All commands accept \`--format=json\` where applicable.

> Named \`journal:*\` rather than \`spec:*\` to avoid collision with #71's introspection \`spec:list\` / \`spec:show\` (those view raw YAML; these view scaffold-time history).

## ScaffoldCommand integration

\`ScaffoldCommand\` gains two **optional** constructor dependencies:

- \`?Journal $journal\` — records an entry per spec after a successful write
- \`?Altair\Events\Contracts\RecorderInterface $events\` — emits a \`scaffold\` event into \`.altair/events.jsonl\` (event log from #77)

Both are nullable so minimal hosts can scaffold without either; the journal/events dual-write activates only when the host applies \`ScaffoldJournalConfiguration\` + \`EventsConfiguration\`.

\`--dry-run\` does NOT write to the journal (matches the issue spec).

## Rewind safety

\`journal:rewind\` **refuses to clobber** generated files the user has hand-edited (sha mismatch); \`--force\` overrides with a clear warning. The journal entry itself is NOT deleted on rewind — it gets a \`reverted_at\` field appended so the audit trail stays intact.

## Tests

**27 PHPUnit cases** covering:

- \`JournalEntry\` / \`FileSnapshot\` round-trip through JSON
- \`FilesystemStorage\` atomic writes + chronological ordering + malformed-line tolerance
- \`Journal::rewind()\` byte-correct restoration of created + modified files
- Rewind refuses on hand-edits; \`--force\` clobbers
- \`findById()\` resolves unambiguous id prefixes
- Rewind rejects already-reverted entries
- \`FileDiffer\` detects added / removed / replaced lines
- CLI smoke pass through all 5 commands' exit-code paths

## Docs + manifest

- \`.agent/packages/scaffold.md\` — new "Journal sub-feature" section + updated "Related packages" + issue references
- \`AGENT.md §2\` — scaffold layout entry mentions Journal commands
- \`CLAUDE.md §3\` — new "Spec journal (rewind / replay)" subsection with CLI cheat-sheet and integration guidance for future Claude sessions

No new entry in \`.agent/MANIFEST.md\` (scaffold's already there — this PR extends it rather than adding a new sub-package).

## New deps

- \`univeros/configuration\` ^2.0 (for \`ScaffoldJournalConfiguration\`)
- \`univeros/container\` ^2.0 (Container wiring)
- \`univeros/events\` listed under \`suggest\` (optional dual-write)

## Test plan

- [x] \`composer test --filter 'Altair\\\\Tests\\\\Scaffold\\\\Journal\\\\\\\\'\` — **27 tests, 61 assertions, 0 failures**
- [x] \`composer cs\` — clean
- [x] \`composer stan\` — clean
- [x] \`composer rector\` — clean (fixpoint reached after one pass)
- [x] Rewind byte-correctness: scaffold → rewind → workspace state matches pre-scaffold (verified by test)
- [x] Hand-edit refusal: scaffold → modify a generated file → \`rewind\` raises \`RewindRefusedException\` without \`--force\`
- [x] \`--force\` clobbers: same setup but \`force: true\` deletes the hand-edited file

## Notes

PR builds on master, which already contains the merged #77 (event log) and #71 (introspection). The event-log dual-write in \`ScaffoldCommand\` was therefore wired immediately — no follow-up needed.