### PR TITLE
re #83 add container:inspect --realized — show instantiated services

### DIFF
--- a/src/Altair/Introspection/Cli/ContainerInspectCommand.php
+++ b/src/Altair/Introspection/Cli/ContainerInspectCommand.php
@@ -43,15 +43,27 @@ final readonly class ContainerInspectCommand
         ?string $filter = null,
         #[Option(description: 'Output format: human or json.')]
         string $format = 'human',
+        #[Option(description: 'Only show services the Container has actually instantiated (realised view).')]
+        bool $realized = false,
     ): int {
         try {
-            $table = $id !== null
-                ? $this->inspector->inspectOne($id)
-                : $this->inspector->inspectAll(sharedOnly: $shared, filter: $filter);
+            $table = match (true) {
+                $id !== null => $this->inspector->inspectOne($id),
+                $realized => $this->inspector->inspectRealized(filter: $filter),
+                default => $this->inspector->inspectAll(sharedOnly: $shared, filter: $filter),
+            };
         } catch (NotFoundException $notFoundException) {
             echo $notFoundException->getMessage(), "\n";
 
             return 1;
+        }
+
+        // Human mode gets an explicit "nothing realised yet" line; JSON mode
+        // already conveys it as an empty `rows` array, which agents parse.
+        if ($realized && $id === null && $table->isEmpty() && $format !== 'json') {
+            echo "No services realised yet.\n";
+
+            return 0;
         }
 
         try {

--- a/src/Altair/Introspection/Inspector/ContainerInspector.php
+++ b/src/Altair/Introspection/Inspector/ContainerInspector.php
@@ -25,9 +25,12 @@ use Throwable;
  * instantiation — so it's safe to run against a project whose database
  * is down or whose Configuration `prepare` hooks would have side effects.
  *
- * Reports definitions (what *would* be built), not realised instances
- * (what *has* been built). The follow-up issue #83 covers the realised
- * view for long-running-process introspection.
+ * `inspectAll()` / `inspectOne()` report definitions (what *would* be
+ * built). `inspectRealized()` reports the complementary view — instances
+ * the Container has actually constructed so far — for long-running-process
+ * introspection (worker memory growth, surprised-by-singleton, prepare-hook
+ * ordering). It still never instantiates: it only reads the already-built
+ * objects sitting in the shares collection.
  */
 final readonly class ContainerInspector
 {
@@ -64,6 +67,55 @@ final readonly class ContainerInspector
         return new InspectionTable(
             title: 'Container bindings',
             columns: ['id', 'kind', 'target', 'shared'],
+            rows: $rows,
+            extras: ['total' => \count($rows)],
+        );
+    }
+
+    /**
+     * Realised view: only the singletons the Container has actually
+     * constructed so far.
+     *
+     * The shares collection holds a `null` placeholder for a singleton
+     * that has been registered but not yet built (see
+     * `SharesCollection::shareClass()`), and the constructed object once
+     * `make()` (or `share($instance)`) has run. So a non-null value is the
+     * "has been instantiated" signal — we filter on exactly that.
+     *
+     * Safe by construction: we read instances that already exist and only
+     * call `::class` on them. We never `make()`, and never serialise (which
+     * would fire `__sleep` / `__serialize` side effects).
+     *
+     * @param string|null $filter Case-insensitive substring match on the binding name.
+     */
+    public function inspectRealized(?string $filter = null): InspectionTable
+    {
+        $needle = $filter !== null && $filter !== '' ? strtolower($filter) : null;
+        $rows = [];
+
+        foreach ($this->container->getShares() as $name => $instance) {
+            if (!\is_object($instance)) {
+                continue; // null placeholder — registered but not yet built.
+            }
+
+            $id = $this->displayName((string) $name);
+
+            if ($needle !== null && !str_contains(strtolower($id), $needle)) {
+                continue;
+            }
+
+            $rows[] = [
+                'id' => $id,
+                'kind' => 'share',
+                'class' => $instance::class,
+            ];
+        }
+
+        usort($rows, static fn(array $a, array $b): int => strcmp($a['id'], $b['id']));
+
+        return new InspectionTable(
+            title: 'Realised container services',
+            columns: ['id', 'kind', 'class'],
             rows: $rows,
             extras: ['total' => \count($rows)],
         );

--- a/tests/Introspection/Cli/CommandsSmokeTest.php
+++ b/tests/Introspection/Cli/CommandsSmokeTest.php
@@ -78,6 +78,34 @@ class CommandsSmokeTest extends TestCase
         $this->assertJson(trim($output));
     }
 
+    public function testContainerInspectRealizedListsInstantiatedServices(): void
+    {
+        $container = new Container();
+        $container->share(new \ArrayObject());
+
+        $command = new ContainerInspectCommand(new ContainerInspector($container), $this->renderers);
+
+        ob_start();
+        $exit = $command(id: null, shared: false, filter: null, format: 'json', realized: true);
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(0, $exit);
+        $this->assertJson(trim($output));
+        $this->assertStringContainsString('ArrayObject', $output);
+    }
+
+    public function testContainerInspectRealizedReportsEmptyInHumanMode(): void
+    {
+        $command = new ContainerInspectCommand(new ContainerInspector(new Container()), $this->renderers);
+
+        ob_start();
+        $exit = $command(id: null, shared: false, filter: null, format: 'human', realized: true);
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('No services realised yet.', $output);
+    }
+
     public function testContainerInspectReportsUnknownBinding(): void
     {
         $command = new ContainerInspectCommand(new ContainerInspector(new Container()), $this->renderers);

--- a/tests/Introspection/Inspector/ContainerInspectorTest.php
+++ b/tests/Introspection/Inspector/ContainerInspectorTest.php
@@ -82,4 +82,59 @@ class ContainerInspectorTest extends TestCase
         $this->expectException(NotFoundException::class);
         (new ContainerInspector(new Container()))->inspectOne('Nonexistent\\Class');
     }
+
+    public function testInspectRealizedIncludesBuiltInstancesAndExcludesUnbuiltShares(): void
+    {
+        $container = new Container();
+        // Registered as a singleton but never constructed → null placeholder, not realized.
+        $container->share(NullLogger::class);
+        // Sharing an existing instance realizes it immediately (shareInstance path).
+        $container->share(new \ArrayObject());
+
+        $before = (new ContainerInspector($container))->inspectRealized();
+        $idsBefore = array_map('strtolower', array_column($before->rows, 'id'));
+
+        $this->assertContains(strtolower(\ArrayObject::class), $idsBefore, 'instance-shared services are realized at once');
+        $this->assertNotContains(strtolower(NullLogger::class), $idsBefore, 'registered-but-unbuilt shares are not realized');
+
+        // Constructing the logger via make() flips it to realized.
+        $container->make(NullLogger::class);
+
+        $after = (new ContainerInspector($container))->inspectRealized();
+        $idsAfter = array_map('strtolower', array_column($after->rows, 'id'));
+        $this->assertContains(strtolower(NullLogger::class), $idsAfter);
+
+        $loggerRows = array_values(array_filter(
+            $after->rows,
+            static fn(array $row): bool => strtolower((string) $row['id']) === strtolower(NullLogger::class),
+        ));
+        $this->assertCount(1, $loggerRows);
+        $this->assertSame(NullLogger::class, $loggerRows[0]['class'], 'class column carries the concrete runtime class');
+        $this->assertSame(\count($after->rows), $after->extras['total']);
+    }
+
+    public function testInspectRealizedIsEmptyBeforeAnyInstantiation(): void
+    {
+        $container = new Container();
+        $container->share(NullLogger::class); // placeholder only — nothing built yet
+
+        $table = (new ContainerInspector($container))->inspectRealized();
+
+        $this->assertTrue($table->isEmpty());
+        $this->assertSame([], $table->rows);
+        $this->assertSame(0, $table->extras['total']);
+    }
+
+    public function testInspectRealizedAppliesFilter(): void
+    {
+        $container = new Container();
+        $container->share(new \ArrayObject());
+        $container->share(new \SplStack());
+
+        $table = (new ContainerInspector($container))->inspectRealized(filter: 'array');
+        $ids = array_map('strtolower', array_column($table->rows, 'id'));
+
+        $this->assertContains(strtolower(\ArrayObject::class), $ids);
+        $this->assertNotContains(strtolower(\SplStack::class), $ids);
+    }
 }


### PR DESCRIPTION
Closes #83.

## What

Adds a `--realized` flag to `bin/altair container:inspect`. The base command walks the Container's binding *definitions* (what *would* be built) without instantiating anything. This adds the complementary **realised view** — the singletons the Container has actually constructed so far — for long-running-process introspection: worker memory growth, surprised-by-singleton, and prepare-hook ordering bugs.

```bash
bin/altair container:inspect --realized
bin/altair container:inspect --realized --format=json
bin/altair container:inspect --realized --filter=repository
```

## How

`ContainerInspector::inspectRealized()` filters the shares collection to entries holding a non-null object. `SharesCollection` stores a `null` placeholder for a registered-but-unbuilt singleton (`shareClass()`) and the constructed instance once `make()` / `share($instance)` has run — so a non-null value is the "has been instantiated" signal.

Stays inside the inspector's existing **safety contract**: it only reads instances that already exist and calls `::class` on them. It never `make()`s, and deliberately never `serialize()`s (which would fire `__sleep` / `__serialize` side effects). Robust if invoked mid-process — it reads a snapshot of the shares map.

Empty state: human mode prints an explicit `No services realised yet.`; JSON mode emits an empty `rows` array (agent-parseable).

## Acceptance criteria

- [x] `container:inspect --realized` lists only instantiated services
- [x] Clear message in human mode + empty array in JSON when nothing is realised
- [x] Robust if invoked mid-process (reads existing instances only, guards null placeholders)
- [x] Test: provision a service, assert `--realized` includes it; assert an unprovisioned one is absent

## Design note — deferred enrichment fields

The issue's *optional* `instantiated_at` / `memory_bytes` per-entry fields are **intentionally not implemented**, and the row carries `id / kind / class` (the concrete runtime class) instead:

- **`instantiated_at`** is unknowable post-hoc — the Container doesn't timestamp `make()`, and adding that would instrument a hot path for a debug-only feature (a per-host opt-in cost better suited to #81 profiling).
- **`memory_bytes`** has no safe, side-effect-free per-object implementation in PHP core; `serialize()` would violate the inspector's no-side-effects contract, and `memory_get_usage()` has no sensible post-hoc per-instance diff (the issue itself notes it "may be `null`").

If construction-time instrumentation lands (e.g. via #81), both become trivial to populate without changing this command's shape.

## Tests

- `ContainerInspectorTest`: built-vs-unbuilt shares, empty-before-build, filter.
- `CommandsSmokeTest`: JSON list + human empty-message paths.

Introspection suite green (46 tests). CS-Fixer clean, PHPStan clean. The 6 suite-wide errors on this branch are pre-existing/environmental (missing `ext-mongodb`/`ext-memcached`, PHP 8.5 escalating Container `fixtures.php` deprecations) — verified identical on `master`.