### PR TITLE
re #93 fix PHP 8.4 implicit-nullable param deprecations (Rector)

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -10,8 +10,11 @@ declare(strict_types=1);
  */
 
 use Rector\Config\RectorConfig;
+use Rector\Php81\Rector\ClassMethod\NewInInitializerRector;
+use Rector\Php84\Rector\Param\ExplicitNullableParamTypeRector;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
     ->withPaths([
@@ -20,6 +23,12 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         __DIR__ . '/tests/bootstrap.php',
+        // Scope boundary for #93: making params explicitly `?Type` lets Rector
+        // collapse `?? new X()` bodies into promoted `= new X()` defaults. That
+        // narrows the constructor contract (an explicit `null` arg becomes a
+        // TypeError) — a behaviour change that belongs in its own PR, not the
+        // nullable-deprecation fix. Remove this skip to adopt it deliberately.
+        NewInInitializerRector::class,
         // Container test fixtures declare classes used as container-reflection inputs.
         // "Empty" constructors / unused private methods are not actually unused —
         // they're inspected at runtime via Reflection.
@@ -72,6 +81,15 @@ return RectorConfig::configure()
         SetList::TYPE_DECLARATION,
         SetList::PRIVATIZATION,
         SetList::INSTANCEOF,
+    ])
+    // PHP 8.4 deprecates implicit-nullable params (`Type $x = null`). The
+    // explicit `?Type` form is valid back to 7.1, so this single rule is a
+    // forward-compat fix that does not raise the PHP 8.3 floor. The rule is
+    // version-bonded to 8.4, so the target is lifted to 8.4 purely to arm it.
+    // See issue #93.
+    ->withPhpVersion(PhpVersion::PHP_84)
+    ->withRules([
+        ExplicitNullableParamTypeRector::class,
     ])
     ->withImportNames(
         importNames: true,

--- a/src/Altair/Cache/CacheItemPool.php
+++ b/src/Altair/Cache/CacheItemPool.php
@@ -42,14 +42,12 @@ class CacheItemPool implements CacheItemPoolInterface, LoggerAwareInterface
 
     /**
      * CacheItemPool constructor.
-     *
-     * @param CacheItemKeyValidatorInterface|null $cacheItemKeyValidator
      */
     public function __construct(
         protected CacheItemStorageInterface $store,
         string $namespace = '',
         int $defaultLifespan = 0,
-        CacheItemKeyValidatorInterface $cacheItemKeyValidator = null
+        ?CacheItemKeyValidatorInterface $cacheItemKeyValidator = null
     ) {
         if ($this->store instanceof PredisCacheItemStorage) {
             $this->store->useNamespace($namespace);
@@ -335,10 +333,8 @@ class CacheItemPool implements CacheItemPoolInterface, LoggerAwareInterface
     /**
      * Creates the cache item factory closure by using the Closure Bind Override. It uses the bind static method of
      * Closure to access the protected properties of the object.
-     *
-     * @param int|null $defaultLifespan
      */
-    protected function createCacheItemFactoryClosure(int $defaultLifespan = null): Closure
+    protected function createCacheItemFactoryClosure(?int $defaultLifespan = null): Closure
     {
         return Closure::bind(
             static function (string $key, $value, bool $isHit) use ($defaultLifespan): CacheItem {

--- a/src/Altair/Cache/Storage/FilesystemCacheItemStorage.php
+++ b/src/Altair/Cache/Storage/FilesystemCacheItemStorage.php
@@ -28,10 +28,8 @@ class FilesystemCacheItemStorage implements CacheItemStorageInterface
 
     /**
      * FilesystemCacheItemPoolStorage constructor.
-     *
-     * @param string|null $directory
      */
-    public function __construct(Filesystem $filesystem, string $directory = null)
+    public function __construct(Filesystem $filesystem, ?string $directory = null)
     {
         $this->setCacheDirectory($filesystem, $directory);
         $this->filesystem = $filesystem;
@@ -141,10 +139,9 @@ class FilesystemCacheItemStorage implements CacheItemStorageInterface
      * Modified version to return a boolean when writing contents to the file
      *
      * @param $value
-     * @param int|null $expiresAt
      *
      */
-    protected function put(string $id, $value, int $expiresAt = null): bool
+    protected function put(string $id, $value, ?int $expiresAt = null): bool
     {
         $file = $this->getFilePath($id, true);
 

--- a/src/Altair/Common/Registry/ArrayRegistry.php
+++ b/src/Altair/Common/Registry/ArrayRegistry.php
@@ -21,10 +21,8 @@ class ArrayRegistry implements RegistryInterface
 
     /**
      * ArrayRegistry constructor.
-     *
-     * @param array|null $data
      */
-    public function __construct(array $data = null)
+    public function __construct(?array $data = null)
     {
         $this->data = $data ?? [];
     }

--- a/src/Altair/Common/Support/Inflector.php
+++ b/src/Altair/Common/Support/Inflector.php
@@ -32,7 +32,7 @@ class Inflector
      * @param string $replacement the replacement to use for spaces
      * @param bool $lowercase whether to return the string in lowercase or not. Defaults to true.
      */
-    public function slug(string $value, string $replacement = null, $lowercase = true): string
+    public function slug(string $value, ?string $replacement = null, $lowercase = true): string
     {
         $replacement ??= '-';
         $value = $this->transliterator->transliterate($value);

--- a/src/Altair/Common/Support/Str.php
+++ b/src/Altair/Common/Support/Str.php
@@ -33,7 +33,7 @@ class Str
      * @param int $start the starting position.
      * @param int|null $length the desired portion length. If none specified, there will be no limit on length.
      */
-    public function byteSubString(string $value, int $start, int $length = null, string $encoding = '8bit'): string
+    public function byteSubString(string $value, int $start, ?int $length = null, string $encoding = '8bit'): string
     {
         return mb_substr($value, $start, $length ?? mb_strlen($value, $encoding), $encoding);
     }

--- a/src/Altair/Container/Builder/ArgumentsBuilder.php
+++ b/src/Altair/Container/Builder/ArgumentsBuilder.php
@@ -28,14 +28,13 @@ class ArgumentsBuilder implements BuilderInterface
     public function __construct(protected Container $container) {}
 
     /**
-     * @param array|null $reflectionParameters
      * @throws InjectionException
      * @throws ReflectionException
      */
     public function build(
         ReflectionFunctionAbstract $reflectionFunction,
         Definition $definition,
-        array $reflectionParameters = null
+        ?array $reflectionParameters = null
     ): array {
         $arguments = [];
 

--- a/src/Altair/Container/Cache/FileCache.php
+++ b/src/Altair/Container/Cache/FileCache.php
@@ -26,10 +26,8 @@ class FileCache implements ReflectionCacheInterface
 
     /**
      * FileCache constructor.
-     *
-     * @param string|null $path
      */
-    public function __construct(string $path = null)
+    public function __construct(?string $path = null)
     {
         $this->path = $path ?? sys_get_temp_dir();
     }

--- a/src/Altair/Container/Container.php
+++ b/src/Altair/Container/Container.php
@@ -60,27 +60,17 @@ class Container implements ContainerInterface
 
     /**
      * Container constructor.
-     *
-     * @param ReflectionInterface|null $reflector
-     * @param AliasesCollection|null $aliasesCollection
-     * @param ClassDefinitionsCollection|null $classDefinitionsCollection
-     * @param ParameterDefinitionsCollection|null $parameterDefinitionsCollection
-     * @param SharesCollection|null $sharesCollection
-     * @param PreparesCollection|null $preparesCollection
-     * @param DelegatesCollection|null $delegatesCollection
-     * @param ExecutableBuilder|null $executableBuilder
-     * @param ArgumentsBuilder|null $argumentsBuilder
      */
     public function __construct(
-        ReflectionInterface $reflector = null,
-        AliasesCollection $aliasesCollection = null,
-        ClassDefinitionsCollection $classDefinitionsCollection = null,
-        ParameterDefinitionsCollection $parameterDefinitionsCollection = null,
-        SharesCollection $sharesCollection = null,
-        PreparesCollection $preparesCollection = null,
-        DelegatesCollection $delegatesCollection = null,
-        ExecutableBuilder $executableBuilder = null,
-        ArgumentsBuilder $argumentsBuilder = null
+        ?ReflectionInterface $reflector = null,
+        ?AliasesCollection $aliasesCollection = null,
+        ?ClassDefinitionsCollection $classDefinitionsCollection = null,
+        ?ParameterDefinitionsCollection $parameterDefinitionsCollection = null,
+        ?SharesCollection $sharesCollection = null,
+        ?PreparesCollection $preparesCollection = null,
+        ?DelegatesCollection $delegatesCollection = null,
+        ?ExecutableBuilder $executableBuilder = null,
+        ?ArgumentsBuilder $argumentsBuilder = null
     ) {
         $this->reflector = $reflector ?? new CachedReflection();
         $this->aliases = $aliasesCollection ?? new AliasesCollection();
@@ -252,12 +242,11 @@ class Container implements ContainerInterface
 
     /**
      * Instantiate/provision a class instance
-     * @param Definition|null $definition
      * @throws InjectionException
      * @throws ReflectionException
      * @return mixed|object|null
      */
-    public function make(string $name, Definition $definition = null)
+    public function make(string $name, ?Definition $definition = null)
     {
         [$className, $normalizedClass] = $this->aliases->resolve($name);
 
@@ -305,11 +294,10 @@ class Container implements ContainerInterface
      * Invoke the specified callable or class::method string, provisioning dependencies along the way
      *
      * @param $callableOrMethodString
-     * @param Definition|null $definition
      * @throws InjectionException
      * @throws ReflectionException
      */
-    public function execute($callableOrMethodString, Definition $definition = null): mixed
+    public function execute($callableOrMethodString, ?Definition $definition = null): mixed
     {
         $executable = $this->executableBuilder->build($callableOrMethodString);
         $definition ??= new Definition([]);

--- a/src/Altair/Container/Reflection/CachedReflection.php
+++ b/src/Altair/Container/Reflection/CachedReflection.php
@@ -30,11 +30,8 @@ class CachedReflection implements ReflectionInterface
 
     /**
      * CachedReflection constructor.
-     *
-     * @param ReflectionInterface|null $reflector
-     * @param ReflectionCacheInterface|null $cache
      */
-    public function __construct(ReflectionInterface $reflector = null, ReflectionCacheInterface $cache = null)
+    public function __construct(?ReflectionInterface $reflector = null, ?ReflectionCacheInterface $cache = null)
     {
         $this->reflector = $reflector ?? new StandardReflection();
         $this->cache = $cache ?? new ArrayCache();

--- a/src/Altair/Cookie/Collection/CookieCollection.php
+++ b/src/Altair/Cookie/Collection/CookieCollection.php
@@ -83,7 +83,7 @@ class CookieCollection extends Map
      * {@inheritDoc}
      */
     #[Override]
-    public function sort(callable $comparator = null): MapInterface
+    public function sort(?callable $comparator = null): MapInterface
     {
         $pairs = array_merge([], $this->internal);
 

--- a/src/Altair/Cookie/Collection/SetCookieCollection.php
+++ b/src/Altair/Cookie/Collection/SetCookieCollection.php
@@ -83,7 +83,7 @@ class SetCookieCollection extends Map
      * {@inheritDoc}
      */
     #[Override]
-    public function sort(callable $comparator = null): MapInterface
+    public function sort(?callable $comparator = null): MapInterface
     {
         $pairs = array_merge([], $this->internal);
 

--- a/src/Altair/Cookie/CookieManager.php
+++ b/src/Altair/Cookie/CookieManager.php
@@ -18,11 +18,7 @@ use Psr\Http\Message\ResponseInterface;
 
 class CookieManager
 {
-    /**
-     * @param string|null $value
-     *
-     */
-    public function getFromRequest(RequestInterface $request, string $name, string $value = null): Cookie
+    public function getFromRequest(RequestInterface $request, string $name, ?string $value = null): Cookie
     {
         $cookies = CookieFactory::createCollectionFromRequest($request);
 
@@ -58,11 +54,7 @@ class CookieManager
         return $cookies->injectIntoRequestHeader($request);
     }
 
-    /**
-     * @param string|null $value
-     *
-     */
-    public function getFromResponse(ResponseInterface $response, string $name, string $value = null): SetCookie
+    public function getFromResponse(ResponseInterface $response, string $name, ?string $value = null): SetCookie
     {
         $cookies = SetCookieFactory::createCollectionFromResponse($response);
 

--- a/src/Altair/Cookie/Factory/CookieFactory.php
+++ b/src/Altair/Cookie/Factory/CookieFactory.php
@@ -19,11 +19,7 @@ use Psr\Http\Message\RequestInterface;
 
 class CookieFactory
 {
-    /**
-     * @param string|null $value
-     *
-     */
-    public static function create(string $name, string $value = null): Cookie
+    public static function create(string $name, ?string $value = null): Cookie
     {
         return new Cookie($name, $value);
     }

--- a/src/Altair/Cookie/Factory/SetCookieFactory.php
+++ b/src/Altair/Cookie/Factory/SetCookieFactory.php
@@ -20,20 +20,15 @@ use Psr\Http\Message\ResponseInterface;
 
 class SetCookieFactory
 {
-    /**
-     * @param string|null $value
-     *
-     */
-    public static function create(string $name, string $value = null): SetCookie
+    public static function create(string $name, ?string $value = null): SetCookie
     {
         return new SetCookie($name, $value);
     }
 
     /**
-     * @param string|null $value
      *@throws Exception
      */
-    public static function createRemembered(string $name, string $value = null): SetCookie
+    public static function createRemembered(string $name, ?string $value = null): SetCookie
     {
         return (new SetCookie($name, $value))->remember();
     }

--- a/src/Altair/Courier/Service/InMemoryCommandLocatorService.php
+++ b/src/Altair/Courier/Service/InMemoryCommandLocatorService.php
@@ -23,10 +23,8 @@ class InMemoryCommandLocatorService implements InMemoryCommandLocatorServiceInte
 
     /**
      * InMemoryCommandLocatorService constructor.
-     *
-     * @param MessageCommandMap|null $map
      */
-    public function __construct(MessageCommandMap $map = null)
+    public function __construct(?MessageCommandMap $map = null)
     {
         $this->map = $map ?? new MessageCommandMap();
     }

--- a/src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
+++ b/src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
@@ -28,10 +28,8 @@ class CommandRunnerMiddlewareStrategy implements CommandRunnerStrategyInterface
 
     /**
      * CommandRunnerMiddlewareStrategy constructor.
-     *
-     * @param array|null $middlewares
      */
-    public function __construct(array $middlewares = null, protected ?MiddlewareResolverInterface $resolver = null)
+    public function __construct(?array $middlewares = null, protected ?MiddlewareResolverInterface $resolver = null)
     {
         $this->middlewares = $middlewares ?? [];
     }

--- a/src/Altair/Happen/Contracts/EventDispatcherInterface.php
+++ b/src/Altair/Happen/Contracts/EventDispatcherInterface.php
@@ -52,7 +52,7 @@ interface EventDispatcherInterface
      *
      *
      */
-    public function dispatch(string $name, EventInterface $event = null): EventInterface;
+    public function dispatch(string $name, ?EventInterface $event = null): EventInterface;
 
     /**
      * Dispatches a stack of events. The result is an array of EventInterface objects.

--- a/src/Altair/Happen/Event.php
+++ b/src/Altair/Happen/Event.php
@@ -32,10 +32,8 @@ class Event implements EventInterface
 
     /**
      * Event constructor.
-     *
-     * @param array|null $arguments
      */
-    public function __construct(protected string $name, array $arguments = null)
+    public function __construct(protected string $name, ?array $arguments = null)
     {
         $this->arguments = $arguments ?? [];
         $this->occurredOn = Carbon::today('UTC')->getTimestamp();

--- a/src/Altair/Happen/EventDispatcher.php
+++ b/src/Altair/Happen/EventDispatcher.php
@@ -83,7 +83,7 @@ class EventDispatcher implements EventDispatcherInterface
      * @inheritDoc
      */
     #[Override]
-    public function dispatch(string $name, EventInterface $event = null): EventInterface
+    public function dispatch(string $name, ?EventInterface $event = null): EventInterface
     {
         $event ??= new Event($name);
 

--- a/src/Altair/Http/Base/Payload.php
+++ b/src/Altair/Http/Base/Payload.php
@@ -43,11 +43,8 @@ class Payload implements PayloadInterface
 
     /**
      * Payload constructor.
-     *
-     * @param InputCollection|null $inputCollection
-     * @param SettingsCollection|null $settingsCollection
      */
-    public function __construct(InputCollection $inputCollection = null, SettingsCollection $settingsCollection = null)
+    public function __construct(?InputCollection $inputCollection = null, ?SettingsCollection $settingsCollection = null)
     {
         $this->inputCollection = $inputCollection ?? new InputCollection();
         $this->settingsCollection = $settingsCollection ?? new SettingsCollection();

--- a/src/Altair/Http/Contracts/TokenInterface.php
+++ b/src/Altair/Http/Contracts/TokenInterface.php
@@ -20,9 +20,8 @@ interface TokenInterface
     /**
      * Returns a value from its metadata if any.
      *
-     * @param string|null $key
      *
      * @return mixed
      */
-    public function getMetadata(string $key = null);
+    public function getMetadata(?string $key = null);
 }

--- a/src/Altair/Http/Exception/AuthorizationException.php
+++ b/src/Altair/Http/Exception/AuthorizationException.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class AuthorizationException extends HttpException
 {
-    public function __construct($message = "", Throwable $previous = null)
+    public function __construct($message = "", ?Throwable $previous = null)
     {
         parent::__construct($message, HttpStatusCodeInterface::HTTP_UNAUTHORIZED, $previous);
     }

--- a/src/Altair/Http/Exception/AuthorizationTokenException.php
+++ b/src/Altair/Http/Exception/AuthorizationTokenException.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class AuthorizationTokenException extends HttpException
 {
-    public function __construct($message = "", Throwable $previous = null)
+    public function __construct($message = "", ?Throwable $previous = null)
     {
         parent::__construct($message, HttpStatusCodeInterface::HTTP_FORBIDDEN, $previous);
     }

--- a/src/Altair/Http/Exception/HttpNotFoundException.php
+++ b/src/Altair/Http/Exception/HttpNotFoundException.php
@@ -21,7 +21,7 @@ class HttpNotFoundException extends HttpBadRequestException
      * @param string $message error message
      * @param Exception $previous The previous exception used for the exception chaining.
      */
-    public function __construct($message = null, Exception $previous = null)
+    public function __construct($message = null, ?Exception $previous = null)
     {
         parent::__construct($message, HttpStatusCodeInterface::HTTP_NOT_FOUND, $previous);
     }

--- a/src/Altair/Http/Rule/RequestMethodRule.php
+++ b/src/Altair/Http/Rule/RequestMethodRule.php
@@ -23,10 +23,8 @@ class RequestMethodRule implements HttpAuthRuleInterface
 
     /**
      * RequestMethodRule constructor.
-     *
-     * @param array|null $options
      */
-    public function __construct(array $options = null)
+    public function __construct(?array $options = null)
     {
         $this->options = array_merge($this->options, $options ?? []);
     }

--- a/src/Altair/Http/Support/Token.php
+++ b/src/Altair/Http/Support/Token.php
@@ -37,7 +37,7 @@ class Token implements TokenInterface
      * @inheritDoc
      */
     #[Override]
-    public function getMetadata(string $key = null)
+    public function getMetadata(?string $key = null)
     {
         return null !== $key
             ? $this->metadata[$key] ?? null

--- a/src/Altair/Http/Support/TokenConfiguration.php
+++ b/src/Altair/Http/Support/TokenConfiguration.php
@@ -21,14 +21,12 @@ final readonly class TokenConfiguration implements TokenConfigurationInterface
 
     /**
      * TokenGeneratorConfiguration constructor.
-     *
-     * @param int|null $timestamp
      */
     public function __construct(
         private string $publicKey,
         private int $ttl,
         private Signer $signer,
-        int $timestamp = null,
+        ?int $timestamp = null,
         private ?string $privateKey = null
     ) {
         $this->timestamp = $timestamp ?: time();

--- a/src/Altair/Http/Traits/HttpAuthenticationAwareTrait.php
+++ b/src/Altair/Http/Traits/HttpAuthenticationAwareTrait.php
@@ -60,7 +60,7 @@ trait HttpAuthenticationAwareTrait
      *
      * @param HttpAuthRuleInterface[] $rules
      */
-    public function __construct(IdentityValidatorInterface $identityValidator, array $rules = null, array $options = null)
+    public function __construct(IdentityValidatorInterface $identityValidator, ?array $rules = null, ?array $options = null)
     {
         $this->identityValidator = $identityValidator;
         $this->rules = $rules ?? [];

--- a/src/Altair/Http/Validator/ArrayIdentityValidator.php
+++ b/src/Altair/Http/Validator/ArrayIdentityValidator.php
@@ -20,10 +20,8 @@ class ArrayIdentityValidator implements IdentityValidatorInterface
 
     /**
      * ArrayIdentityValidator constructor.
-     *
-     * @param array|null $users
      */
-    public function __construct(array $users = null)
+    public function __construct(?array $users = null)
     {
         $this->users = $users ?? [];
     }

--- a/src/Altair/Http/Validator/DigestSignatureValidator.php
+++ b/src/Altair/Http/Validator/DigestSignatureValidator.php
@@ -21,10 +21,8 @@ class DigestSignatureValidator implements IdentityValidatorInterface
 
     /**
      * RepositoryIdentityValidator constructor.
-     *
-     * @param array|null $options
      */
-    public function __construct(protected QueryRepositoryInterface $repository, array $options = null)
+    public function __construct(protected QueryRepositoryInterface $repository, ?array $options = null)
     {
         // Options contain the names of the fields to search on the db by the entity.
         // By default: 'username' and 'hash' are the default fieldname values. You can easily change them as:

--- a/src/Altair/Http/Validator/RepositoryIdentityValidator.php
+++ b/src/Altair/Http/Validator/RepositoryIdentityValidator.php
@@ -22,10 +22,8 @@ class RepositoryIdentityValidator implements IdentityValidatorInterface
 
     /**
      * RepositoryIdentityValidator constructor.
-     *
-     * @param array|null $options
      */
-    public function __construct(protected QueryRepositoryInterface $repository, array $options = null)
+    public function __construct(protected QueryRepositoryInterface $repository, ?array $options = null)
     {
         // Options contain the names of the fields to search on the db by the entity.
         // By default: 'username' and 'hash' are the default fieldname values. You can easily change them as:

--- a/src/Altair/Middleware/Payload.php
+++ b/src/Altair/Middleware/Payload.php
@@ -21,10 +21,8 @@ class Payload implements PayloadInterface, JsonSerializable
 
     /**
      * Payload constructor.
-     *
-     * @param array|null $attributes
      */
-    public function __construct(array $attributes = null)
+    public function __construct(?array $attributes = null)
     {
         $this->attributes = $attributes ?? [];
     }

--- a/src/Altair/Middleware/Runner.php
+++ b/src/Altair/Middleware/Runner.php
@@ -38,7 +38,7 @@ class Runner implements MiddlewareRunnerInterface
      * @param callable|MiddlewareResolverInterface $resolver Converts queue entries to callables.
      *
      */
-    public function __construct(protected Queue $queue, callable $resolver = null)
+    public function __construct(protected Queue $queue, ?callable $resolver = null)
     {
         $this->resolver = $resolver;
     }

--- a/src/Altair/Sanitation/Filter/DateTimeFilter.php
+++ b/src/Altair/Sanitation/Filter/DateTimeFilter.php
@@ -21,7 +21,7 @@ class DateTimeFilter extends AbstractFilter
     /**
      * DateTimeFilter constructor.
      */
-    public function __construct(string $format = null)
+    public function __construct(?string $format = null)
     {
         $this->format = $format ?? 'Y-m-d H:i:s';
     }

--- a/src/Altair/Sanitation/Filter/MinStrLengthFilter.php
+++ b/src/Altair/Sanitation/Filter/MinStrLengthFilter.php
@@ -20,7 +20,7 @@ class MinStrLengthFilter extends AbstractFilter
     /**
      * MaxStrLengthFilter constructor.
      */
-    public function __construct(protected int $min, string $pad = null, protected int $direction = STR_PAD_RIGHT)
+    public function __construct(protected int $min, ?string $pad = null, protected int $direction = STR_PAD_RIGHT)
     {
         $this->pad = $pad ?? ' ';
     }

--- a/src/Altair/Sanitation/Filter/TrimFilter.php
+++ b/src/Altair/Sanitation/Filter/TrimFilter.php
@@ -19,10 +19,8 @@ class TrimFilter extends AbstractFilter
 
     /**
      * TrimFilter constructor.
-     *
-     * @param string|null $chars
      */
-    public function __construct(string $chars = null)
+    public function __construct(?string $chars = null)
     {
         $this->chars = $chars ?? " \t\n\r\0\x0B";
     }

--- a/src/Altair/Sanitation/FiltersRunner.php
+++ b/src/Altair/Sanitation/FiltersRunner.php
@@ -36,7 +36,7 @@ class FiltersRunner implements FiltersRunnerInterface
      * @param callable|ResolverInterface $resolver Converts queue entries to callables.
      * @param Queue $queue The middleware queue.
      */
-    public function __construct(ResolverInterface $resolver = null, protected ?Queue $queue = null)
+    public function __construct(?ResolverInterface $resolver = null, protected ?Queue $queue = null)
     {
         $this->resolver = $resolver;
     }

--- a/src/Altair/Session/Contracts/SessionManagerInterface.php
+++ b/src/Altair/Session/Contracts/SessionManagerInterface.php
@@ -27,10 +27,8 @@ interface SessionManagerInterface
 
     /**
      * Sets the callable used to clear the session cookie when destroying the session.
-     *
-     * @param callable|null $callable
      */
-    public function setDeleteCookieCallable(callable $callable = null);
+    public function setDeleteCookieCallable(?callable $callable = null);
 
     /**
      * Creates a session block.

--- a/src/Altair/Session/SessionManager.php
+++ b/src/Altair/Session/SessionManager.php
@@ -55,13 +55,11 @@ class SessionManager implements SessionManagerInterface
 
     /**
      * SessionManager constructor.
-     *
-     * @param callable|null $deleteCookieCallable
      */
     public function __construct(
         ServerRequestInterface $request,
         protected ?SessionHandlerInterface $sessionHandler = null,
-        callable $deleteCookieCallable = null
+        ?callable $deleteCookieCallable = null
     ) {
         $this->cookies = $request->getCookieParams();
         $this->cookieParams = session_get_cookie_params();
@@ -92,7 +90,7 @@ class SessionManager implements SessionManagerInterface
      * @inheritDoc
      */
     #[Override]
-    public function setDeleteCookieCallable(callable $callable = null): void
+    public function setDeleteCookieCallable(?callable $callable = null): void
     {
         $this->deleteCookieCallable = $callable ?? function ($name, $params): void {
             $path = $params['path'] ?? null;

--- a/src/Altair/Session/Traits/PdoSessionAdapterAwareTrait.php
+++ b/src/Altair/Session/Traits/PdoSessionAdapterAwareTrait.php
@@ -77,15 +77,13 @@ trait PdoSessionAdapterAwareTrait
 
     /**
      * PdoSessionHandler constructor.
-     *
-     * @param int|null $lockMode
      */
     public function __construct(
         string $dsn,
         string $username,
         string $password,
         string $table,
-        int $lockMode = null,
+        ?int $lockMode = null,
         array $options = []
     ) {
         $this->dsn = $dsn;

--- a/src/Altair/Structure/Contracts/MapInterface.php
+++ b/src/Altair/Structure/Contracts/MapInterface.php
@@ -96,7 +96,7 @@ interface MapInterface extends CollectionInterface
      *
      * If a length is not provided, the resulting map will contains all pairs between the offset and the end of the map.
      */
-    public function slice(int $offset, int $length = null): MapInterface;
+    public function slice(int $offset, ?int $length = null): MapInterface;
 
     /**
      * Returns a sorted copy of the map, based on an optional callable
@@ -104,7 +104,7 @@ interface MapInterface extends CollectionInterface
      *
      * @param callable|null $comparator Accepts two values to be compared.
      */
-    public function sort(callable $comparator = null): MapInterface;
+    public function sort(?callable $comparator = null): MapInterface;
 
     /**
      * Returns a sorted copy of the map, based on an optional callable
@@ -112,7 +112,7 @@ interface MapInterface extends CollectionInterface
      *
      * @param callable|null $comparator Accepts two keys to be compared.
      */
-    public function ksort(callable $comparator = null): MapInterface;
+    public function ksort(?callable $comparator = null): MapInterface;
 
     /**
      * Merges two maps.

--- a/src/Altair/Structure/Contracts/SequenceInterface.php
+++ b/src/Altair/Structure/Contracts/SequenceInterface.php
@@ -46,7 +46,7 @@ interface SequenceInterface extends CollectionInterface
      * @param callable|null $callback Accepts a value, returns a boolean result: true : include the value, false: skip
      * the value.
      */
-    public function filter(callable $callback = null): SequenceInterface;
+    public function filter(?callable $callback = null): SequenceInterface;
 
     /**
      * Returns the index of a given value, or false if it could not be found.
@@ -95,7 +95,7 @@ interface SequenceInterface extends CollectionInterface
      *
      *
      */
-    public function join(string $glue = null): string;
+    public function join(?string $glue = null): string;
 
     /**
      * Returns the last value in the sequence.
@@ -206,7 +206,7 @@ interface SequenceInterface extends CollectionInterface
      * If a length is not provided, the resulting sequence will contain all values between the index and the end of the
      * sequence.
      */
-    public function slice(int $index, int $length = null): SequenceInterface;
+    public function slice(int $index, ?int $length = null): SequenceInterface;
 
     /**
      * Returns a sorted copy of the sequence, based on an optional callable
@@ -214,7 +214,7 @@ interface SequenceInterface extends CollectionInterface
      *
      * @param callable|null $comparator Accepts two values to be compared. Should return the result of a <=> b.
      */
-    public function sort(callable $comparator = null): SequenceInterface;
+    public function sort(?callable $comparator = null): SequenceInterface;
 
     /**
      * Returns the sum of all values in the sequence.

--- a/src/Altair/Structure/Contracts/SetInterface.php
+++ b/src/Altair/Structure/Contracts/SetInterface.php
@@ -71,7 +71,7 @@ interface SetInterface extends CollectionInterface
      * @param callable|null $callback Accepts a value, returns a boolean: true : include the value, false: skip the
      * value.
      */
-    public function filter(callable $callback = null): SetInterface;
+    public function filter(?callable $callback = null): SetInterface;
 
     /**
      * Returns the first value in the set.
@@ -116,7 +116,7 @@ interface SetInterface extends CollectionInterface
      *
      *
      */
-    public function join(string $glue = null): string;
+    public function join(?string $glue = null): string;
 
     /**
      * Iteratively reduces the set to a single value using a callback.
@@ -148,14 +148,14 @@ interface SetInterface extends CollectionInterface
      * If a length is given and is negative, the set will stop that many values from the end. If a length is not
      * provided, the resulting set will contains all values between the offset and the end of the set.
      */
-    public function slice(int $offset, int $length = null): SetInterface;
+    public function slice(int $offset, ?int $length = null): SetInterface;
 
     /**
      * Sorts the set in-place, based on an optional callable comparator.
      *
      * @param callable|null $comparator Accepts two values to be compared. Should return the result of a <=> b.
      */
-    public function sort(callable $comparator = null): SetInterface;
+    public function sort(?callable $comparator = null): SetInterface;
 
     /**
      * Returns the result of adding all given values to the set.

--- a/src/Altair/Structure/Map.php
+++ b/src/Altair/Structure/Map.php
@@ -112,7 +112,7 @@ class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function filter(callable $callback = null): MapInterface
+    public function filter(?callable $callback = null): MapInterface
     {
         $filtered = new static();
 
@@ -186,7 +186,7 @@ class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function slice(int $offset, int $length = null): MapInterface
+    public function slice(int $offset, ?int $length = null): MapInterface
     {
         $slice = \func_num_args() === 1 ? \array_slice($this->internal, $offset) : \array_slice($this->internal, $offset, $length);
 
@@ -197,7 +197,7 @@ class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function sort(callable $comparator = null): MapInterface
+    public function sort(?callable $comparator = null): MapInterface
     {
         $pairs = array_merge([], $this->internal);
 
@@ -220,7 +220,7 @@ class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function ksort(callable $comparator = null): MapInterface
+    public function ksort(?callable $comparator = null): MapInterface
     {
         $pairs = array_merge([], $this->internal);
 

--- a/src/Altair/Structure/Set.php
+++ b/src/Altair/Structure/Set.php
@@ -125,7 +125,7 @@ class Set implements IteratorAggregate, ArrayAccess, SetInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function filter(callable $callback = null): SetInterface
+    public function filter(?callable $callback = null): SetInterface
     {
         return new static(array_filter($this->toArray(), $callback ?: 'boolval'));
     }
@@ -220,7 +220,7 @@ class Set implements IteratorAggregate, ArrayAccess, SetInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function slice(int $offset, int $length = null): SetInterface
+    public function slice(int $offset, ?int $length = null): SetInterface
     {
         return new static($this->internal->slice($offset, $length)->keys());
     }
@@ -229,7 +229,7 @@ class Set implements IteratorAggregate, ArrayAccess, SetInterface, CapacityInter
      * {@inheritDoc}
      */
     #[Override]
-    public function sort(callable $comparator = null): SetInterface
+    public function sort(?callable $comparator = null): SetInterface
     {
         return new static($this->getMap()->ksort($comparator)->keys());
     }

--- a/src/Altair/Structure/Traits/SequenceTrait.php
+++ b/src/Altair/Structure/Traits/SequenceTrait.php
@@ -74,7 +74,7 @@ trait SequenceTrait
     /**
      * {@inheritDoc}
      */
-    public function filter(callable $callback = null): SequenceInterface
+    public function filter(?callable $callback = null): SequenceInterface
     {
         return new static(array_filter($this->internal, $callback ?: 'boolval'));
     }
@@ -259,7 +259,7 @@ trait SequenceTrait
     /**
      * {@inheritDoc}
      */
-    public function slice(int $offset, int $length = null): SequenceInterface
+    public function slice(int $offset, ?int $length = null): SequenceInterface
     {
         if (\func_num_args() === 1) {
             $length = \count($this);
@@ -271,7 +271,7 @@ trait SequenceTrait
     /**
      * {@inheritDoc}
      */
-    public function sort(callable $comparator = null): SequenceInterface
+    public function sort(?callable $comparator = null): SequenceInterface
     {
         $internal = $this->internal;
 

--- a/src/Altair/Validation/Rule/IpRule.php
+++ b/src/Altair/Validation/Rule/IpRule.php
@@ -20,10 +20,8 @@ class IpRule extends AbstractRule
 
     /**
      * IpRule constructor.
-     *
-     * @param string|null $range
      */
-    public function __construct(protected ?int $options = null, string $range = null)
+    public function __construct(protected ?int $options = null, ?string $range = null)
     {
         $this->range = $range !== null ? $this->parseRange($range) : null;
     }

--- a/src/Altair/Validation/Rule/IsbnRule.php
+++ b/src/Altair/Validation/Rule/IsbnRule.php
@@ -20,10 +20,8 @@ class IsbnRule extends AbstractRule
 
     /**
      * IsbnRule constructor.
-     *
-     * @param int|null $type
      */
-    public function __construct(int $type = null)
+    public function __construct(?int $type = null)
     {
         if (null !== $type && !\in_array($type, [10, 13], false)) {
             throw new InvalidArgumentException(\sprintf('ISBN type must be 10 or 13, "%d" given.', $type));

--- a/src/Altair/Validation/Rule/ZipCodeRule.php
+++ b/src/Altair/Validation/Rule/ZipCodeRule.php
@@ -228,10 +228,8 @@ class ZipCodeRule extends AbstractRule
 
     /**
      * ZipCodeRule constructor.
-     *
-     * @param string|null $country
      */
-    public function __construct(string $country = null)
+    public function __construct(?string $country = null)
     {
         $this->country = strtoupper(trim($country ?? 'US'));
         if (!\array_key_exists($this->country, self::$patterns)) {

--- a/src/Altair/Validation/RulesRunner.php
+++ b/src/Altair/Validation/RulesRunner.php
@@ -36,7 +36,7 @@ class RulesRunner implements RulesRunnerInterface
      * @param callable|ResolverInterface $resolver Converts queue entries to callables.
      * @param Queue $queue The middleware queue.
      */
-    public function __construct(ResolverInterface $resolver = null, protected ?Queue $queue = null)
+    public function __construct(?ResolverInterface $resolver = null, protected ?Queue $queue = null)
     {
         $this->resolver = $resolver;
     }

--- a/tests/Container/fixtures.php
+++ b/tests/Container/fixtures.php
@@ -512,7 +512,7 @@ class NonConcreteDependencyWithDefaultValue
 {
     public $interface;
 
-    public function __construct(DelegatableInterface $i = null)
+    public function __construct(?DelegatableInterface $i = null)
     {
         $this->interface = $i;
     }
@@ -522,7 +522,7 @@ class ConcreteDependencyWithDefaultValue
 {
     public $dependency;
 
-    public function __construct(\StdClass $instance = null)
+    public function __construct(?\StdClass $instance = null)
     {
         $this->dependency = $instance;
     }

--- a/tests/Introspection/Inspector/ListenerInspectorTest.php
+++ b/tests/Introspection/Inspector/ListenerInspectorTest.php
@@ -73,7 +73,7 @@ class ListenerInspectorTest extends TestCase
             }
 
             #[Override]
-            public function dispatch(string $name, EventInterface $event = null): EventInterface
+            public function dispatch(string $name, ?EventInterface $event = null): EventInterface
             {
                 throw new \RuntimeException('not implemented');
             }

--- a/tests/Validation/Rule/IpRuleTest.php
+++ b/tests/Validation/Rule/IpRuleTest.php
@@ -74,7 +74,7 @@ class IpRuleTest extends TestCase
      * @param null|mixed $range
      */
     #[DataProvider('trueProvider')]
-    public function testPayloadTrue(string $value, $options = null, string $range = null): void
+    public function testPayloadTrue(string $value, $options = null, ?string $range = null): void
     {
         $this->assertTrue($this->assertPayload($value, $options, $range));
     }
@@ -85,7 +85,7 @@ class IpRuleTest extends TestCase
      * @param null|mixed $range
      */
     #[DataProvider('falseProvider')]
-    public function testPayloadFalse(string $value, int $options = null, $range = null): void
+    public function testPayloadFalse(string $value, ?int $options = null, $range = null): void
     {
         $this->assertFalse($this->assertPayload($value, $options, $range));
     }
@@ -96,7 +96,7 @@ class IpRuleTest extends TestCase
      * @param null|mixed $range
      */
     #[DataProvider('trueProvider')]
-    public function testValueTrue(string $value, $options = null, string $range = null): void
+    public function testValueTrue(string $value, $options = null, ?string $range = null): void
     {
         $this->assertTrue($this->assertValue($value, $options, $range));
     }
@@ -107,7 +107,7 @@ class IpRuleTest extends TestCase
      * @param null|mixed $range
      */
     #[DataProvider('falseProvider')]
-    public function testValueFalse(string $value, int $options = null, $range = null): void
+    public function testValueFalse(string $value, ?int $options = null, $range = null): void
     {
         $this->assertFalse($this->assertValue($value, $options, $range));
     }
@@ -116,7 +116,7 @@ class IpRuleTest extends TestCase
      * @param $value
      */
     #[DataProvider('invalidIpsForNetworkRangeProvider')]
-    public function testInvalidIpsForRange(string $value, $options = null, string $range = null): void
+    public function testInvalidIpsForRange(string $value, $options = null, ?string $range = null): void
     {
         $this->assertFalse($this->assertValue($value, $options, $range));
     }

--- a/tests/Validation/Rule/IsbnRuleTest.php
+++ b/tests/Validation/Rule/IsbnRuleTest.php
@@ -72,7 +72,7 @@ class IsbnRuleTest extends TestCase
      * @param null|mixed $type
      */
     #[DataProvider('trueProvider')]
-    public function testPayloadTrue(string $value, int $type = null): void
+    public function testPayloadTrue(string $value, ?int $type = null): void
     {
         $this->assertTrue($this->assertPayload($value, $type));
     }
@@ -82,7 +82,7 @@ class IsbnRuleTest extends TestCase
      * @param null|mixed $type
      */
     #[DataProvider('falseProvider')]
-    public function testPayloadFalse(string|int $value, int $type = null): void
+    public function testPayloadFalse(string|int $value, ?int $type = null): void
     {
         $this->assertFalse($this->assertPayload($value, $type));
     }
@@ -92,7 +92,7 @@ class IsbnRuleTest extends TestCase
      * @param null|mixed $type
      */
     #[DataProvider('trueProvider')]
-    public function testValueTrue(string $value, int $type = null): void
+    public function testValueTrue(string $value, ?int $type = null): void
     {
         $this->assertTrue($this->assertValue($value, $type));
     }
@@ -102,7 +102,7 @@ class IsbnRuleTest extends TestCase
      * @param null|mixed $type
      */
     #[DataProvider('falseProvider')]
-    public function testValueFalse(string|int $value, int $type = null): void
+    public function testValueFalse(string|int $value, ?int $type = null): void
     {
         $this->assertFalse($this->assertValue($value, $type));
     }


### PR DESCRIPTION
Closes #93.

## What

PHP 8.4 deprecated implicit-nullable parameters — `Type $x = null` must be `?Type $x = null`. This converts all such occurrences across `src/` + `tests/` to the explicit form.

Under PHP 8.5 some escalate from deprecation to **fatal** — the root cause of the `Altair\Tests\Session\PdoSessionHandlerTest::testSessionGc` error (deprecation in `tests/Container/fixtures.php` thrown as an exception). That test now passes.

## How

Arms Rector's version-bonded `ExplicitNullableParamTypeRector` by lifting the **target** to PHP 8.4, then applies it:

```php
->withPhpVersion(PhpVersion::PHP_84)
->withRules([ExplicitNullableParamTypeRector::class])
```

- `?Type` is valid back to PHP 7.1, so this is a pure forward-compat fix — **`composer.json` stays `">=8.3"`**, no 8.4-only syntax emitted.
- The 4 blanket-skipped fixture files keep their Rector skip; the 2 implicit-nullable params in `tests/Container/fixtures.php` are fixed by hand.

## Two follow-on Rector rules that the explicit-nullable change unmasks

Making params explicitly nullable lets two already-configured rules fire (the implicit form had hidden them):

- **`RemoveUselessParamTagRector` — applied.** Drops the now-redundant `@param Type|null` docblocks (aligns with the repo's "native types beat PHPDoc" rule).
- **`NewInInitializerRector` — skipped (documented in `rector.php`).** It would collapse `?? new X()` constructor bodies into promoted `= new X()` defaults — which **narrows the constructor contract** (an explicit `null` arg becomes a TypeError). That's a behaviour change that deserves its own PR, not a deprecation fix. Remove the skip to adopt it deliberately.

## CI note

CI's `static-analysis` job runs `rector process --dry-run` (it is **not** part of `composer qa`, which is why the first push went red). Verified locally against the **same Rector 1.2.10** CI uses:

- `rector process --dry-run`: clean
- **PHPStan: no errors**, **CS: clean**
- **0** implicit-nullable deprecations remain
- `PdoSessionHandlerTest::testSessionGc`: passes

The 5 remaining suite errors are pre-existing/environmental (`ext-mongodb` not loaded), identical to `master`.

## Acceptance criteria

- [x] No implicit-nullable params remain in `src/` or `tests/`
- [x] Zero implicit-nullable deprecations under PHP 8.4/8.5
- [x] `testSessionGc` no longer errors from escalated deprecations
- [x] PHP floor stays 8.3 (no `composer.json` platform bump)