### PR TITLE
re #68 add univeros/doctor — health checks with agent-actionable output

### DIFF
--- a/bin/altair
+++ b/bin/altair
@@ -37,6 +37,7 @@ $paths = [];
 // Built-in framework commands ship with their own packages.
 $builtIn = [
     __DIR__ . '/../src/Altair/AgentSpec/Cli',
+    __DIR__ . '/../src/Altair/Doctor/Cli',
     __DIR__ . '/../src/Altair/Messaging/Cli',
     __DIR__ . '/../src/Altair/Persistence/Cli',
     __DIR__ . '/../src/Altair/Scaffold/Cli',

--- a/composer.json
+++ b/composer.json
@@ -80,6 +80,7 @@
         "univeros/container": "self.version",
         "univeros/cookie": "self.version",
         "univeros/courier": "self.version",
+        "univeros/doctor": "self.version",
         "univeros/events": "self.version",
         "univeros/filesystem": "self.version",
         "univeros/happen": "self.version",

--- a/src/Altair/Doctor/Check/CsCleanCheck.php
+++ b/src/Altair/Doctor/Check/CsCleanCheck.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\FixableCheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Code-style drift via `composer cs`. Fixable: `--fix` runs `composer cs:fix`.
+ */
+final readonly class CsCleanCheck implements FixableCheckInterface
+{
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'cs_clean';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if ($this->runner->run(['composer', 'cs'], $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'Code style is clean.');
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            'Code style violations found.',
+            'Run `composer cs:fix`.',
+            AgentAction::runCommand('composer cs:fix'),
+        );
+    }
+
+    #[Override]
+    public function fix(): bool
+    {
+        return $this->runner->run(['composer', 'cs:fix'], $this->projectRoot)->ok();
+    }
+}

--- a/src/Altair/Doctor/Check/DeterminismCheck.php
+++ b/src/Altair/Doctor/Check/DeterminismCheck.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * The determinism gate as a check (#74): re-run the configured generators,
+ * then `git diff --exit-code` the emitted paths. A non-empty diff means a
+ * generator is non-deterministic — agents would see phantom drift.
+ *
+ * Host apps configure the generators + paths; with none configured the
+ * check reports `skipped` rather than a false pass.
+ */
+final readonly class DeterminismCheck implements CheckInterface
+{
+    /**
+     * @param list<list<string>> $generators argv commands that regenerate emitted content
+     * @param list<string>       $paths      paths to diff after regeneration
+     */
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+        private array $generators = [],
+        private array $paths = [],
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'determinism_check';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if ($this->generators === [] || $this->paths === []) {
+            return CheckResult::skipped(
+                $this->name(),
+                'No generators configured for the determinism gate.',
+            );
+        }
+
+        foreach ($this->generators as $generator) {
+            if (!$this->runner->run($generator, $this->projectRoot)->ok()) {
+                return CheckResult::error(
+                    $this->name(),
+                    'A generator failed to run: ' . implode(' ', $generator),
+                );
+            }
+        }
+
+        $diff = $this->runner->run(['git', 'diff', '--exit-code', ...$this->paths], $this->projectRoot);
+        if ($diff->ok()) {
+            return CheckResult::ok($this->name(), 'Generated content is byte-stable across regeneration.');
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'Generated content differs after regeneration — non-determinism detected.',
+            'Inspect the diff; sort any unstable iteration order and remove inlined timestamps/machine identifiers.',
+        );
+    }
+}

--- a/src/Altair/Doctor/Check/ExtensionsLoadedCheck.php
+++ b/src/Altair/Doctor/Check/ExtensionsLoadedCheck.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Closure;
+use Override;
+
+/**
+ * Verifies every `ext-*` the project requires is actually loaded. The
+ * extension probe is injectable so the check is unit-testable without
+ * depending on the test host's loaded extensions.
+ */
+final readonly class ExtensionsLoadedCheck implements CheckInterface
+{
+    /**
+     * @var Closure(string): bool
+     */
+    private Closure $isLoaded;
+
+    /**
+     * @param list<string>              $required ext names without the `ext-` prefix, e.g. ['redis', 'pdo']
+     * @param (Closure(string): bool)|null $isLoaded
+     */
+    public function __construct(
+        private array $required,
+        ?Closure $isLoaded = null,
+    ) {
+        $this->isLoaded = $isLoaded ?? static fn(string $ext): bool => \extension_loaded($ext);
+    }
+
+    #[Override]
+    public function name(): string
+    {
+        return 'extensions_loaded';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $missing = array_values(array_filter(
+            $this->required,
+            fn(string $ext): bool => !($this->isLoaded)($ext),
+        ));
+
+        if ($missing === []) {
+            return CheckResult::ok(
+                $this->name(),
+                $this->required === []
+                    ? 'No required extensions.'
+                    : 'All required extensions loaded: ' . implode(', ', $this->required) . '.',
+            );
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'Missing required extensions: ' . implode(', ', $missing) . '.',
+            'Install and enable the listed PHP extensions.',
+            AgentAction::installDep('ext-' . $missing[0]),
+        );
+    }
+}

--- a/src/Altair/Doctor/Check/ManifestsCurrentCheck.php
+++ b/src/Altair/Doctor/Check/ManifestsCurrentCheck.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\FixableCheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Whether `.agent/packages/*.md` still matches what the generator would
+ * produce now (via `bin/altair manifest:diff`, which exits non-zero on
+ * drift). Fixable: `--fix` regenerates with `manifest:generate`.
+ */
+final readonly class ManifestsCurrentCheck implements FixableCheckInterface
+{
+    /**
+     * @param list<string> $altairBin argv prefix for the CLI, e.g. ['php', 'bin/altair']
+     */
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+        private array $altairBin = ['php', 'bin/altair'],
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'manifests_current';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $command = [...$this->altairBin, 'manifest:diff', '--format=json'];
+        if ($this->runner->run($command, $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'Agent manifests are current.');
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            'Agent manifests are stale — .agent/ does not match the current source.',
+            'Run `bin/altair manifest:generate`.',
+            AgentAction::runCommand('bin/altair manifest:generate'),
+        );
+    }
+
+    #[Override]
+    public function fix(): bool
+    {
+        $command = [...$this->altairBin, 'manifest:generate'];
+
+        return $this->runner->run($command, $this->projectRoot)->ok();
+    }
+}

--- a/src/Altair/Doctor/Check/PhpVersionCheck.php
+++ b/src/Altair/Doctor/Check/PhpVersionCheck.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+use const PHP_VERSION;
+
+/**
+ * Verifies the active PHP runtime satisfies the project's `composer.json`
+ * floor. The most common "agent got stuck" cause is the wrong PHP on PATH.
+ */
+final readonly class PhpVersionCheck implements CheckInterface
+{
+    public function __construct(
+        private string $floor,
+        private string $current = PHP_VERSION,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'php_version';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if (version_compare($this->current, $this->floor, '>=')) {
+            return CheckResult::ok(
+                $this->name(),
+                \sprintf('PHP %s satisfies >=%s', $this->current, $this->floor),
+            );
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            \sprintf('PHP %s is below the required >=%s', $this->current, $this->floor),
+            \sprintf('Install PHP >= %s and put it first on PATH.', $this->floor),
+            AgentAction::installDep('php@' . $this->floor),
+        );
+    }
+}

--- a/src/Altair/Doctor/Check/PhpstanCleanCheck.php
+++ b/src/Altair/Doctor/Check/PhpstanCleanCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Static-analysis regressions via `composer stan`. Not auto-fixable — type
+ * errors need a human/agent edit at the root cause — so it reports an error
+ * with guidance rather than an `agent_action`.
+ */
+final readonly class PhpstanCleanCheck implements CheckInterface
+{
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'phpstan_clean';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if ($this->runner->run(['composer', 'stan'], $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'PHPStan reports no errors.');
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'PHPStan reported type errors.',
+            'Run `composer stan` and fix the reported errors at the root cause (or add a justified baseline entry).',
+        );
+    }
+}

--- a/src/Altair/Doctor/CheckRegistry.php
+++ b/src/Altair/Doctor/CheckRegistry.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor;
+
+use Altair\Doctor\Contracts\CheckInterface;
+
+/**
+ * The ordered set of checks a doctor run executes.
+ *
+ * Order matters: checks run top-to-bottom, and `dependsOn()` references
+ * resolve against checks already executed. Hosts extend the registry by
+ * `add()`-ing their own checks (typically via a Container `prepare` hook).
+ */
+final class CheckRegistry
+{
+    /**
+     * @var list<CheckInterface>
+     */
+    private array $checks = [];
+
+    /**
+     * @param list<CheckInterface> $checks
+     */
+    public function __construct(array $checks = [])
+    {
+        foreach ($checks as $check) {
+            $this->add($check);
+        }
+    }
+
+    public function add(CheckInterface $check): void
+    {
+        $this->checks[] = $check;
+    }
+
+    /**
+     * @return list<CheckInterface>
+     */
+    public function all(): array
+    {
+        return $this->checks;
+    }
+}

--- a/src/Altair/Doctor/Cli/DoctorCommand.php
+++ b/src/Altair/Doctor/Cli/DoctorCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Cli;
+
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Exception\DoctorException;
+use Altair\Doctor\Output\RendererRegistry;
+
+/**
+ * `bin/altair doctor` — run the health checks and emit an agent-actionable
+ * report. Exit code is the worst observed status: 0 ok, 1 warn, 2 error.
+ */
+#[Command(
+    name: 'doctor',
+    description: 'Run project health checks with agent-actionable output.',
+)]
+final readonly class DoctorCommand
+{
+    public function __construct(
+        private Doctor $doctor,
+        private RendererRegistry $renderers,
+    ) {}
+
+    public function __invoke(
+        #[Option(description: 'Output format: human or json.')]
+        string $format = 'human',
+        #[Option(description: 'Comma-separated check names to run exclusively.')]
+        ?string $only = null,
+        #[Option(description: 'Comma-separated check names to skip.')]
+        ?string $skip = null,
+        #[Option(description: 'Attempt safe auto-fixes for checks that support one.')]
+        bool $fix = false,
+    ): int {
+        $report = $this->doctor->run($this->csv($only), $this->csv($skip), $fix);
+
+        try {
+            echo $this->renderers->get($format)->render($report);
+        } catch (DoctorException $doctorException) {
+            echo $doctorException->getMessage(), "\n";
+
+            return 2;
+        }
+
+        return $report->exitCode();
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function csv(?string $value): array
+    {
+        if ($value === null || trim($value) === '') {
+            return [];
+        }
+
+        return array_values(array_filter(
+            array_map('trim', explode(',', $value)),
+            static fn(string $item): bool => $item !== '',
+        ));
+    }
+}

--- a/src/Altair/Doctor/Configuration/DoctorConfiguration.php
+++ b/src/Altair/Doctor/Configuration/DoctorConfiguration.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Configuration;
+
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Container\Container;
+use Altair\Doctor\Check\CsCleanCheck;
+use Altair\Doctor\Check\DeterminismCheck;
+use Altair\Doctor\Check\ExtensionsLoadedCheck;
+use Altair\Doctor\Check\ManifestsCurrentCheck;
+use Altair\Doctor\Check\PhpstanCleanCheck;
+use Altair\Doctor\Check\PhpVersionCheck;
+use Altair\Doctor\CheckRegistry;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Output\RendererRegistry;
+use Altair\Doctor\Process\ShellProcessRunner;
+
+use const DIRECTORY_SEPARATOR;
+
+use Override;
+
+/**
+ * Wires the doctor runner, the default check set, the process runner, and
+ * the renderer registry into the Container.
+ *
+ * The PHP floor and required `ext-*` list are read from the project's
+ * `composer.json` so `php_version` / `extensions_loaded` reflect the
+ * project's own declared requirements. Hosts add their own checks by
+ * `prepare()`-ing {@see CheckRegistry} after this Configuration runs.
+ */
+final readonly class DoctorConfiguration implements ConfigurationInterface
+{
+    public function __construct(
+        private ?string $projectRoot = null,
+    ) {}
+
+    #[Override]
+    public function apply(Container $container): void
+    {
+        $projectRoot = $this->projectRoot ?? (getcwd() ?: '.');
+        $runner = new ShellProcessRunner();
+
+        [$phpFloor, $extensions] = $this->readRequirements($projectRoot);
+
+        $registry = new CheckRegistry([
+            new PhpVersionCheck($phpFloor),
+            new ExtensionsLoadedCheck($extensions),
+            new ManifestsCurrentCheck($runner, $projectRoot),
+            new CsCleanCheck($runner, $projectRoot),
+            new PhpstanCleanCheck($runner, $projectRoot),
+            new DeterminismCheck($runner, $projectRoot),
+        ]);
+
+        $container
+            ->delegate(ProcessRunnerInterface::class, static fn(): ProcessRunnerInterface => $runner)
+            ->share(ProcessRunnerInterface::class)
+
+            ->delegate(CheckRegistry::class, static fn(): CheckRegistry => $registry)
+            ->share(CheckRegistry::class)
+
+            ->delegate(Doctor::class, static fn(): Doctor => new Doctor($registry))
+            ->share(Doctor::class)
+
+            ->delegate(RendererRegistry::class, static fn(): RendererRegistry => RendererRegistry::default())
+            ->share(RendererRegistry::class);
+    }
+
+    /**
+     * Parse the PHP floor (e.g. `8.3` from `">=8.3"`) and the `ext-*` names
+     * from the project's composer.json `require` block. Falls back to the
+     * running PHP's major.minor and no extensions when absent/unreadable.
+     *
+     * @return array{0: string, 1: list<string>}
+     */
+    private function readRequirements(string $projectRoot): array
+    {
+        $path = $projectRoot . DIRECTORY_SEPARATOR . 'composer.json';
+        $fallbackFloor = \sprintf('%d.%d', PHP_MAJOR_VERSION, PHP_MINOR_VERSION);
+
+        if (!is_file($path)) {
+            return [$fallbackFloor, []];
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            return [$fallbackFloor, []];
+        }
+
+        $decoded = json_decode($raw, true);
+        $require = \is_array($decoded) && isset($decoded['require']) && \is_array($decoded['require'])
+            ? $decoded['require']
+            : [];
+
+        $floor = $fallbackFloor;
+        $extensions = [];
+
+        foreach ($require as $package => $constraint) {
+            $package = (string) $package;
+            if ($package === 'php' && \is_string($constraint)) {
+                $floor = $this->normalizeVersion($constraint, $fallbackFloor);
+
+                continue;
+            }
+
+            if (str_starts_with($package, 'ext-')) {
+                $extensions[] = substr($package, 4);
+            }
+        }
+
+        sort($extensions, SORT_STRING);
+
+        return [$floor, array_values($extensions)];
+    }
+
+    private function normalizeVersion(string $constraint, string $fallback): string
+    {
+        if (preg_match('/(\d+\.\d+(?:\.\d+)?)/', $constraint, $matches) === 1) {
+            return $matches[1];
+        }
+
+        return $fallback;
+    }
+}

--- a/src/Altair/Doctor/Contracts/CheckInterface.php
+++ b/src/Altair/Doctor/Contracts/CheckInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Contracts;
+
+use Altair\Doctor\Result\CheckResult;
+
+/**
+ * A single health check.
+ *
+ * Implementations must be side-effect-free in `run()` (read-only probing);
+ * any remediation belongs behind {@see FixableCheckInterface::fix()} and
+ * only runs under `--fix`.
+ */
+interface CheckInterface
+{
+    /**
+     * Stable machine identifier, e.g. `php_version`. Used by `--only` /
+     * `--skip` and as the `dependsOn()` key other checks reference.
+     */
+    public function name(): string;
+
+    /**
+     * Names of checks that must pass before this one is meaningful. When a
+     * prerequisite errors or is skipped, the runner reports this check as
+     * `skipped` rather than running it.
+     *
+     * @return list<string>
+     */
+    public function dependsOn(): array;
+
+    public function run(): CheckResult;
+}

--- a/src/Altair/Doctor/Contracts/FixableCheckInterface.php
+++ b/src/Altair/Doctor/Contracts/FixableCheckInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Contracts;
+
+/**
+ * A check that can attempt its own safe, non-destructive remediation.
+ *
+ * `fix()` only runs under `bin/altair doctor --fix`, and must never perform
+ * destructive operations (data deletes, downgrades, force-pushes).
+ */
+interface FixableCheckInterface extends CheckInterface
+{
+    /**
+     * Attempt the fix. Returns true if it was applied (the runner then
+     * re-runs the check to confirm the new status).
+     */
+    public function fix(): bool;
+}

--- a/src/Altair/Doctor/Contracts/ProcessRunnerInterface.php
+++ b/src/Altair/Doctor/Contracts/ProcessRunnerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Contracts;
+
+use Altair\Doctor\Process\ProcessResult;
+
+/**
+ * Abstracts sub-process execution so process-backed checks (running
+ * `composer`, `bin/altair`, `git`, ...) stay unit-testable with a fake
+ * runner instead of shelling out for real.
+ */
+interface ProcessRunnerInterface
+{
+    /**
+     * @param list<string> $command argv form (no shell), e.g. ['composer', 'cs']
+     */
+    public function run(array $command, ?string $cwd = null): ProcessResult;
+}

--- a/src/Altair/Doctor/Contracts/ReportRendererInterface.php
+++ b/src/Altair/Doctor/Contracts/ReportRendererInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Contracts;
+
+use Altair\Doctor\Result\Report;
+
+/**
+ * Renders a {@see Report} for a `--format` value (human, json, ...).
+ */
+interface ReportRendererInterface
+{
+    public function render(Report $report): string;
+}

--- a/src/Altair/Doctor/Doctor.php
+++ b/src/Altair/Doctor/Doctor.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Contracts\FixableCheckInterface;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Doctor\Result\CheckStatus;
+use Altair\Doctor\Result\Report;
+
+/**
+ * Runs the registered checks and assembles a {@see Report}.
+ *
+ * Execution rules:
+ * - `--only` / `--skip` filter which checks run (by name).
+ * - dependency-aware: a check whose prerequisite errored or was skipped is
+ *   reported `skipped` instead of running (no point testing downstream when
+ *   the foundation is broken).
+ * - `--fix`: for a non-ok {@see FixableCheckInterface}, attempt the fix then
+ *   re-run the check so the report reflects the post-fix state.
+ */
+final readonly class Doctor
+{
+    public function __construct(
+        private CheckRegistry $registry,
+    ) {}
+
+    /**
+     * @param list<string> $only
+     * @param list<string> $skip
+     */
+    public function run(array $only = [], array $skip = [], bool $fix = false): Report
+    {
+        $startedAt = hrtime(true);
+        $results = [];
+
+        /** @var array<string, CheckStatus> $statusByName */
+        $statusByName = [];
+
+        foreach ($this->registry->all() as $check) {
+            $name = $check->name();
+
+            if ($only !== [] && !\in_array($name, $only, true)) {
+                continue;
+            }
+
+            if (\in_array($name, $skip, true)) {
+                continue;
+            }
+
+            $blockedBy = $this->unmetPrerequisite($check, $statusByName);
+            if ($blockedBy !== null) {
+                $result = CheckResult::skipped(
+                    $name,
+                    \sprintf("Skipped — prerequisite '%s' did not pass.", $blockedBy),
+                );
+            } else {
+                $result = $check->run();
+                if ($fix && $result->status->severity() > 0 && $check instanceof FixableCheckInterface && $check->fix()) {
+                    $result = $check->run();
+                }
+            }
+
+            $statusByName[$name] = $result->status;
+            $results[] = $result;
+        }
+
+        $durationMs = (int) round((hrtime(true) - $startedAt) / 1_000_000);
+
+        return new Report($results, max(0, $durationMs));
+    }
+
+    /**
+     * @param array<string, CheckStatus> $statusByName
+     */
+    private function unmetPrerequisite(CheckInterface $check, array $statusByName): ?string
+    {
+        foreach ($check->dependsOn() as $dependency) {
+            $status = $statusByName[$dependency] ?? null;
+            if ($status === CheckStatus::Error || $status === CheckStatus::Skipped) {
+                return $dependency;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Doctor/Exception/DoctorException.php
+++ b/src/Altair/Doctor/Exception/DoctorException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Exception;
+
+use RuntimeException;
+
+final class DoctorException extends RuntimeException {}

--- a/src/Altair/Doctor/Output/HumanRenderer.php
+++ b/src/Altair/Doctor/Output/HumanRenderer.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Output;
+
+use Altair\Doctor\Contracts\ReportRendererInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Doctor\Result\Report;
+use Override;
+
+/**
+ * Scannable plain text — one line per check, the fix line directly under a
+ * non-ok result, and any `run_command` agent action quoted as a shell
+ * snippet. No frames or boxes (agents may tail this if the user pipes it).
+ */
+final readonly class HumanRenderer implements ReportRendererInterface
+{
+    #[Override]
+    public function render(Report $report): string
+    {
+        $lines = [];
+
+        foreach ($report->checks as $check) {
+            $lines[] = \sprintf('[%-5s] %s — %s', $check->status->value, $check->name, $check->detail);
+            $lines = [...$lines, ...$this->remediation($check)];
+        }
+
+        $lines[] = '';
+        $lines[] = \sprintf(
+            '%s — %d checks in %dms',
+            strtoupper($report->status()->value),
+            \count($report->checks),
+            $report->durationMs,
+        );
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function remediation(CheckResult $check): array
+    {
+        $lines = [];
+
+        if ($check->fix !== null) {
+            $lines[] = '        fix: ' . $check->fix;
+        }
+
+        $action = $check->agentAction;
+        if ($action instanceof AgentAction && $action->type === 'run_command' && isset($action->payload['command'])) {
+            $lines[] = '        $ ' . $action->payload['command'];
+        }
+
+        return $lines;
+    }
+}

--- a/src/Altair/Doctor/Output/JsonRenderer.php
+++ b/src/Altair/Doctor/Output/JsonRenderer.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Output;
+
+use Altair\Doctor\Contracts\ReportRendererInterface;
+use Altair\Doctor\Exception\DoctorException;
+use Altair\Doctor\Result\Report;
+use JsonException;
+use Override;
+
+/**
+ * Machine-readable JSON. Deterministic for a given {@see Report}: fixed key
+ * order, no timestamps in check detail, `duration_ms` the only varying
+ * field. Agents parse this directly.
+ */
+final readonly class JsonRenderer implements ReportRendererInterface
+{
+    #[Override]
+    public function render(Report $report): string
+    {
+        try {
+            return json_encode(
+                $report->toArray(),
+                JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR,
+            ) . "\n";
+        } catch (JsonException $jsonException) {
+            throw new DoctorException('Report is not JSON-encodable: ' . $jsonException->getMessage(), 0, $jsonException);
+        }
+    }
+}

--- a/src/Altair/Doctor/Output/RendererRegistry.php
+++ b/src/Altair/Doctor/Output/RendererRegistry.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Output;
+
+use Altair\Doctor\Contracts\ReportRendererInterface;
+use Altair\Doctor\Exception\DoctorException;
+
+/**
+ * Resolves the right renderer for the `--format` flag. `human` and `json`
+ * ship by default; hosts can pre-bind their own before bootstrapping.
+ */
+final readonly class RendererRegistry
+{
+    /**
+     * @param array<string, ReportRendererInterface> $renderers
+     */
+    public function __construct(
+        private array $renderers,
+    ) {}
+
+    public static function default(): self
+    {
+        return new self([
+            'human' => new HumanRenderer(),
+            'json' => new JsonRenderer(),
+        ]);
+    }
+
+    public function get(string $format): ReportRendererInterface
+    {
+        if (!isset($this->renderers[$format])) {
+            throw new DoctorException(\sprintf(
+                "Unknown output format '%s'. Available: %s.",
+                $format,
+                implode(', ', array_keys($this->renderers)),
+            ));
+        }
+
+        return $this->renderers[$format];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function available(): array
+    {
+        return array_keys($this->renderers);
+    }
+}

--- a/src/Altair/Doctor/Process/ProcessResult.php
+++ b/src/Altair/Doctor/Process/ProcessResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Process;
+
+/**
+ * The outcome of a sub-process: exit code plus captured streams.
+ */
+final readonly class ProcessResult
+{
+    public function __construct(
+        public int $exitCode,
+        public string $stdout = '',
+        public string $stderr = '',
+    ) {}
+
+    public function ok(): bool
+    {
+        return $this->exitCode === 0;
+    }
+}

--- a/src/Altair/Doctor/Process/ShellProcessRunner.php
+++ b/src/Altair/Doctor/Process/ShellProcessRunner.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Process;
+
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Override;
+
+/**
+ * Runs commands via `proc_open()` with the argv array form — no shell, so
+ * no quoting or injection surface. Captures stdout/stderr and the exit code.
+ */
+final readonly class ShellProcessRunner implements ProcessRunnerInterface
+{
+    /**
+     * @param list<string> $command
+     */
+    #[Override]
+    public function run(array $command, ?string $cwd = null): ProcessResult
+    {
+        $descriptors = [
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = proc_open($command, $descriptors, $pipes, $cwd);
+        if (!\is_resource($process)) {
+            return new ProcessResult(127, '', 'Unable to start process: ' . implode(' ', $command));
+        }
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+
+        return new ProcessResult(
+            $exitCode,
+            \is_string($stdout) ? $stdout : '',
+            \is_string($stderr) ? $stderr : '',
+        );
+    }
+}

--- a/src/Altair/Doctor/Result/AgentAction.php
+++ b/src/Altair/Doctor/Result/AgentAction.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Result;
+
+/**
+ * The machine-actionable "do this next" block on a failing check.
+ *
+ * This is the differentiator over human-shaped error text: instead of an
+ * agent guessing what to do, the check states the exact tool call — run a
+ * command, edit a file, install a dependency.
+ */
+final readonly class AgentAction
+{
+    /**
+     * @param array<string, string> $payload
+     */
+    private function __construct(
+        public string $type,
+        public array $payload,
+    ) {}
+
+    public static function runCommand(string $command): self
+    {
+        return new self('run_command', ['command' => $command]);
+    }
+
+    public static function editFile(string $file, string $hint): self
+    {
+        return new self('edit_file', ['file' => $file, 'hint' => $hint]);
+    }
+
+    public static function installDep(string $package): self
+    {
+        return new self('install_dep', ['package' => $package]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return ['type' => $this->type, ...$this->payload];
+    }
+}

--- a/src/Altair/Doctor/Result/CheckResult.php
+++ b/src/Altair/Doctor/Result/CheckResult.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Result;
+
+/**
+ * The outcome of running one check.
+ *
+ * Built via the named constructors so the optional fields (`fix`,
+ * `agentAction`, `source`) only ever appear where they make sense — on a
+ * non-ok result that has a remediation.
+ */
+final readonly class CheckResult
+{
+    private function __construct(
+        public string $name,
+        public CheckStatus $status,
+        public string $detail,
+        public ?string $fix = null,
+        public ?AgentAction $agentAction = null,
+        public ?string $source = null,
+    ) {}
+
+    public static function ok(string $name, string $detail): self
+    {
+        return new self($name, CheckStatus::Ok, $detail);
+    }
+
+    public static function skipped(string $name, string $detail): self
+    {
+        return new self($name, CheckStatus::Skipped, $detail);
+    }
+
+    public static function warn(
+        string $name,
+        string $detail,
+        ?string $fix = null,
+        ?AgentAction $agentAction = null,
+        ?string $source = null,
+    ): self {
+        return new self($name, CheckStatus::Warn, $detail, $fix, $agentAction, $source);
+    }
+
+    public static function error(
+        string $name,
+        string $detail,
+        ?string $fix = null,
+        ?AgentAction $agentAction = null,
+        ?string $source = null,
+    ): self {
+        return new self($name, CheckStatus::Error, $detail, $fix, $agentAction, $source);
+    }
+
+    /**
+     * Deterministic projection: fixed key order, optional fields omitted
+     * when absent (no nulls in the JSON, no timestamps).
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = [
+            'name' => $this->name,
+            'status' => $this->status->value,
+            'detail' => $this->detail,
+        ];
+
+        if ($this->fix !== null) {
+            $out['fix'] = $this->fix;
+        }
+
+        if ($this->agentAction instanceof AgentAction) {
+            $out['agent_action'] = $this->agentAction->toArray();
+        }
+
+        if ($this->source !== null) {
+            $out['source'] = $this->source;
+        }
+
+        return $out;
+    }
+}

--- a/src/Altair/Doctor/Result/CheckStatus.php
+++ b/src/Altair/Doctor/Result/CheckStatus.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Result;
+
+/**
+ * The four outcomes a check can report.
+ *
+ * `severity()` doubles as the process exit code contribution: a run's exit
+ * code is the worst severity observed (0 ok/skipped, 1 warn, 2 error).
+ */
+enum CheckStatus: string
+{
+    case Ok = 'ok';
+    case Warn = 'warn';
+    case Error = 'error';
+    case Skipped = 'skipped';
+
+    public function severity(): int
+    {
+        return match ($this) {
+            self::Ok, self::Skipped => 0,
+            self::Warn => 1,
+            self::Error => 2,
+        };
+    }
+}

--- a/src/Altair/Doctor/Result/Report.php
+++ b/src/Altair/Doctor/Result/Report.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Result;
+
+/**
+ * The full result of a doctor run: every check's result plus the wall-clock
+ * duration.
+ *
+ * `durationMs` is the single explicit timing field permitted by the
+ * determinism standard (#74) — every other field is reproducible, so the
+ * JSON projection is byte-stable for a given set of results.
+ */
+final readonly class Report
+{
+    /**
+     * @param list<CheckResult> $checks
+     */
+    public function __construct(
+        public array $checks,
+        public int $durationMs,
+    ) {}
+
+    public function status(): CheckStatus
+    {
+        $worst = CheckStatus::Ok;
+        foreach ($this->checks as $check) {
+            if ($check->status->severity() > $worst->severity()) {
+                $worst = $check->status;
+            }
+        }
+
+        return $worst;
+    }
+
+    public function exitCode(): int
+    {
+        return $this->status()->severity();
+    }
+
+    /**
+     * @return array{status: string, duration_ms: int, checks: list<array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status()->value,
+            'duration_ms' => $this->durationMs,
+            'checks' => array_map(static fn(CheckResult $c): array => $c->toArray(), $this->checks),
+        ];
+    }
+}

--- a/src/Altair/Doctor/composer.json
+++ b/src/Altair/Doctor/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "univeros/doctor",
+    "description": "bin/altair doctor — health checks with agent-actionable output. Deterministic JSON for agents, scannable text for humans.",
+    "license": "MIT",
+    "homepage": "https://univeros.io",
+    "support": {
+        "issues": "https://github.com/univeros/framework/issues",
+        "source": "https://github.com/univeros/framework"
+    },
+    "require": {
+        "php": ">=8.3",
+        "univeros/cli": "^2.0",
+        "univeros/configuration": "^2.0",
+        "univeros/container": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Altair\\Doctor\\": ""
+        }
+    }
+}

--- a/tests/Doctor/Check/ProcessChecksTest.php
+++ b/tests/Doctor/Check/ProcessChecksTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Check;
+
+use Altair\Doctor\Check\CsCleanCheck;
+use Altair\Doctor\Check\DeterminismCheck;
+use Altair\Doctor\Check\ManifestsCurrentCheck;
+use Altair\Doctor\Check\PhpstanCleanCheck;
+use Altair\Doctor\Process\ProcessResult;
+use Altair\Doctor\Result\CheckStatus;
+use Altair\Tests\Doctor\Support\FakeProcessRunner;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CsCleanCheck::class)]
+#[CoversClass(PhpstanCleanCheck::class)]
+#[CoversClass(ManifestsCurrentCheck::class)]
+#[CoversClass(DeterminismCheck::class)]
+class ProcessChecksTest extends TestCase
+{
+    public function testCsCleanOkWhenComposerCsPasses(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertSame(CheckStatus::Ok, (new CsCleanCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testCsCleanWarnsWithRunCommandActionWhenDirty(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['composer', 'cs'], new ProcessResult(1));
+
+        $result = (new CsCleanCheck($runner, '/p'))->run();
+        $this->assertSame(CheckStatus::Warn, $result->status);
+        $this->assertNotNull($result->agentAction);
+        $this->assertSame('composer cs:fix', $result->agentAction->toArray()['command']);
+    }
+
+    public function testCsCleanFixRunsComposerCsFix(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertTrue((new CsCleanCheck($runner, '/p'))->fix());
+        $this->assertContains(['composer', 'cs:fix'], $runner->calls);
+    }
+
+    public function testPhpstanErrorsWhenAnalysisFails(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['composer', 'stan'], new ProcessResult(1));
+
+        $this->assertSame(CheckStatus::Error, (new PhpstanCleanCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testManifestsWarnWithGenerateActionWhenStale(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['php', 'bin/altair', 'manifest:diff', '--format=json'], new ProcessResult(1));
+
+        $result = (new ManifestsCurrentCheck($runner, '/p'))->run();
+        $this->assertSame(CheckStatus::Warn, $result->status);
+        $this->assertSame('bin/altair manifest:generate', $result->agentAction?->toArray()['command']);
+    }
+
+    public function testDeterminismSkippedWhenUnconfigured(): void
+    {
+        $result = (new DeterminismCheck(new FakeProcessRunner(), '/p'))->run();
+
+        $this->assertSame(CheckStatus::Skipped, $result->status);
+    }
+
+    public function testDeterminismOkWhenNoDrift(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+        $check = new DeterminismCheck($runner, '/p', [['bin/altair', 'manifest:generate']], ['.agent/']);
+
+        $this->assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function testDeterminismErrorsOnDrift(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['bin/altair', 'manifest:generate'], new ProcessResult(0));
+        $runner->on(['git', 'diff', '--exit-code', '.agent/'], new ProcessResult(1));
+
+        $check = new DeterminismCheck($runner, '/p', [['bin/altair', 'manifest:generate']], ['.agent/']);
+
+        $this->assertSame(CheckStatus::Error, $check->run()->status);
+    }
+
+    public function testDeterminismErrorsWhenGeneratorFails(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['bin/altair', 'manifest:generate'], new ProcessResult(3));
+
+        $check = new DeterminismCheck($runner, '/p', [['bin/altair', 'manifest:generate']], ['.agent/']);
+
+        $result = $check->run();
+        $this->assertSame(CheckStatus::Error, $result->status);
+        $this->assertStringContainsString('failed to run', $result->detail);
+    }
+}

--- a/tests/Doctor/Check/PureChecksTest.php
+++ b/tests/Doctor/Check/PureChecksTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Check;
+
+use Altair\Doctor\Check\ExtensionsLoadedCheck;
+use Altair\Doctor\Check\PhpVersionCheck;
+use Altair\Doctor\Result\CheckStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PhpVersionCheck::class)]
+#[CoversClass(ExtensionsLoadedCheck::class)]
+class PureChecksTest extends TestCase
+{
+    public function testPhpVersionOkWhenCurrentSatisfiesFloor(): void
+    {
+        $result = (new PhpVersionCheck('8.3', '8.4.1'))->run();
+
+        $this->assertSame(CheckStatus::Ok, $result->status);
+        $this->assertSame('php_version', $result->name);
+    }
+
+    public function testPhpVersionErrorsWhenBelowFloorWithInstallAction(): void
+    {
+        $result = (new PhpVersionCheck('8.3', '8.1.0'))->run();
+
+        $this->assertSame(CheckStatus::Error, $result->status);
+        $this->assertNotNull($result->agentAction);
+        $this->assertSame('install_dep', $result->agentAction->type);
+    }
+
+    public function testExtensionsOkWhenAllLoaded(): void
+    {
+        $check = new ExtensionsLoadedCheck(['redis', 'pdo'], static fn(string $ext): bool => true);
+
+        $this->assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function testExtensionsErrorListsMissingAndSuggestsInstall(): void
+    {
+        $check = new ExtensionsLoadedCheck(
+            ['redis', 'pdo'],
+            static fn(string $ext): bool => $ext === 'pdo',
+        );
+
+        $result = $check->run();
+        $this->assertSame(CheckStatus::Error, $result->status);
+        $this->assertStringContainsString('redis', $result->detail);
+        $this->assertStringNotContainsString('pdo', $result->detail);
+        $this->assertNotNull($result->agentAction);
+        $this->assertSame('ext-redis', $result->agentAction->toArray()['package']);
+    }
+
+    public function testExtensionsOkWhenNoneRequired(): void
+    {
+        $this->assertSame(CheckStatus::Ok, (new ExtensionsLoadedCheck([]))->run()->status);
+    }
+}

--- a/tests/Doctor/Cli/DoctorCommandTest.php
+++ b/tests/Doctor/Cli/DoctorCommandTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Cli;
+
+use Altair\Doctor\CheckRegistry;
+use Altair\Doctor\Cli\DoctorCommand;
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Output\RendererRegistry;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Tests\Doctor\Support\FakeCheck;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DoctorCommand::class)]
+class DoctorCommandTest extends TestCase
+{
+    public function testJsonOutputAndExitCodeReflectWorstStatus(): void
+    {
+        $command = $this->command([
+            new FakeCheck('a', CheckResult::ok('a', 'ok')),
+            new FakeCheck('b', CheckResult::error('b', 'boom')),
+        ]);
+
+        ob_start();
+        $exit = $command(format: 'json');
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(2, $exit);
+        $this->assertJson(trim($output));
+        $this->assertStringContainsString('"status": "error"', $output);
+    }
+
+    public function testHumanOutputForAllOkExitsZero(): void
+    {
+        $command = $this->command([new FakeCheck('a', CheckResult::ok('a', 'fine'))]);
+
+        ob_start();
+        $exit = $command(format: 'human');
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(0, $exit);
+        $this->assertStringContainsString('[ok', $output);
+    }
+
+    public function testUnknownFormatExitsTwoWithMessage(): void
+    {
+        $command = $this->command([new FakeCheck('a', CheckResult::ok('a', 'fine'))]);
+
+        ob_start();
+        $exit = $command(format: 'xml');
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(2, $exit);
+        $this->assertStringContainsString("Unknown output format 'xml'", $output);
+    }
+
+    public function testOnlyFlagIsForwarded(): void
+    {
+        $command = $this->command([
+            new FakeCheck('a', CheckResult::error('a', 'boom')),
+            new FakeCheck('b', CheckResult::ok('b', 'ok')),
+        ]);
+
+        ob_start();
+        $exit = $command(format: 'json', only: 'b');
+        ob_get_clean();
+
+        $this->assertSame(0, $exit, 'only=b skips the failing a, so exit is 0');
+    }
+
+    /**
+     * @param list<FakeCheck> $checks
+     */
+    private function command(array $checks): DoctorCommand
+    {
+        return new DoctorCommand(new Doctor(new CheckRegistry($checks)), RendererRegistry::default());
+    }
+}

--- a/tests/Doctor/Configuration/DoctorConfigurationTest.php
+++ b/tests/Doctor/Configuration/DoctorConfigurationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Configuration;
+
+use Altair\Container\Container;
+use Altair\Doctor\CheckRegistry;
+use Altair\Doctor\Configuration\DoctorConfiguration;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Output\RendererRegistry;
+use Altair\Doctor\Result\CheckStatus;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DoctorConfiguration::class)]
+class DoctorConfigurationTest extends TestCase
+{
+    private string $root;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->root = sys_get_temp_dir() . '/altair-doctor-' . bin2hex(random_bytes(4));
+        @mkdir($this->root, 0775, true);
+        file_put_contents(
+            $this->root . '/composer.json',
+            (string) json_encode(['require' => ['php' => '>=8.3', 'ext-json' => '*', 'univeros/foo' => '^2.0']]),
+        );
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        @unlink($this->root . '/composer.json');
+        @rmdir($this->root);
+    }
+
+    public function testWiresRunnerRegistryDoctorAndRenderers(): void
+    {
+        $container = new Container();
+        (new DoctorConfiguration($this->root))->apply($container);
+
+        $this->assertInstanceOf(ProcessRunnerInterface::class, $container->make(ProcessRunnerInterface::class));
+        $this->assertInstanceOf(Doctor::class, $container->make(Doctor::class));
+        $this->assertInstanceOf(RendererRegistry::class, $container->make(RendererRegistry::class));
+
+        $registry = $container->make(CheckRegistry::class);
+        $this->assertInstanceOf(CheckRegistry::class, $registry);
+        $names = array_map(static fn($c): string => $c->name(), $registry->all());
+        $this->assertContains('php_version', $names);
+        $this->assertContains('extensions_loaded', $names);
+        $this->assertContains('determinism_check', $names);
+    }
+
+    public function testReadsFloorAndExtensionsFromComposerJson(): void
+    {
+        $container = new Container();
+        (new DoctorConfiguration($this->root))->apply($container);
+
+        // php >=8.3 (this runtime satisfies it) and ext-json (always loaded) → both ok.
+        $report = $container->make(Doctor::class)->run(only: ['php_version', 'extensions_loaded']);
+
+        $this->assertCount(2, $report->checks);
+        $this->assertSame(CheckStatus::Ok, $report->status());
+    }
+}

--- a/tests/Doctor/DoctorTest.php
+++ b/tests/Doctor/DoctorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor;
+
+use Altair\Doctor\CheckRegistry;
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Doctor\Result\CheckStatus;
+use Altair\Tests\Doctor\Support\FakeCheck;
+use Altair\Tests\Doctor\Support\FakeFixableCheck;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Doctor::class)]
+#[CoversClass(CheckRegistry::class)]
+class DoctorTest extends TestCase
+{
+    public function testRunsAllChecksAndReportsWorstStatus(): void
+    {
+        $registry = new CheckRegistry([
+            new FakeCheck('a', CheckResult::ok('a', 'ok')),
+            new FakeCheck('b', CheckResult::warn('b', 'warn')),
+        ]);
+
+        $report = (new Doctor($registry))->run();
+
+        $this->assertCount(2, $report->checks);
+        $this->assertSame(CheckStatus::Warn, $report->status());
+    }
+
+    public function testOnlyFilterRunsExclusivelyTheNamedChecks(): void
+    {
+        $a = new FakeCheck('a', CheckResult::ok('a', 'ok'));
+        $b = new FakeCheck('b', CheckResult::ok('b', 'ok'));
+        $registry = new CheckRegistry([$a, $b]);
+
+        $report = (new Doctor($registry))->run(only: ['b']);
+
+        $this->assertFalse($a->ran);
+        $this->assertTrue($b->ran);
+        $this->assertCount(1, $report->checks);
+    }
+
+    public function testSkipFilterExcludesNamedChecks(): void
+    {
+        $a = new FakeCheck('a', CheckResult::ok('a', 'ok'));
+        $registry = new CheckRegistry([$a]);
+
+        $report = (new Doctor($registry))->run(skip: ['a']);
+
+        $this->assertFalse($a->ran);
+        $this->assertSame([], $report->checks);
+    }
+
+    public function testDownstreamCheckIsSkippedWhenPrerequisiteErrors(): void
+    {
+        $downstream = new FakeCheck('tests_passing', CheckResult::ok('tests_passing', 'ok'), ['composer_deps']);
+        $registry = new CheckRegistry([
+            new FakeCheck('composer_deps', CheckResult::error('composer_deps', 'stale')),
+            $downstream,
+        ]);
+
+        $report = (new Doctor($registry))->run();
+
+        $this->assertFalse($downstream->ran, 'prerequisite errored, so downstream must not run');
+        $this->assertSame(CheckStatus::Skipped, $report->checks[1]->status);
+        $this->assertStringContainsString('composer_deps', $report->checks[1]->detail);
+    }
+
+    public function testFixIsAttemptedThenCheckIsReRun(): void
+    {
+        $check = new FakeFixableCheck(
+            'cs_clean',
+            CheckResult::warn('cs_clean', 'dirty'),
+            CheckResult::ok('cs_clean', 'clean'),
+        );
+        $registry = new CheckRegistry([$check]);
+
+        $report = (new Doctor($registry))->run(fix: true);
+
+        $this->assertSame(1, $check->fixCount);
+        $this->assertSame(2, $check->runCount, 'check runs, fix applies, check re-runs');
+        $this->assertSame(CheckStatus::Ok, $report->checks[0]->status);
+    }
+
+    public function testFixIsNotAttemptedWithoutTheFlag(): void
+    {
+        $check = new FakeFixableCheck('cs_clean', CheckResult::warn('cs_clean', 'dirty'), CheckResult::ok('cs_clean', 'clean'));
+        $registry = new CheckRegistry([$check]);
+
+        (new Doctor($registry))->run();
+
+        $this->assertSame(0, $check->fixCount);
+        $this->assertSame(1, $check->runCount);
+    }
+}

--- a/tests/Doctor/Output/RenderersTest.php
+++ b/tests/Doctor/Output/RenderersTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Output;
+
+use Altair\Doctor\Exception\DoctorException;
+use Altair\Doctor\Output\HumanRenderer;
+use Altair\Doctor\Output\JsonRenderer;
+use Altair\Doctor\Output\RendererRegistry;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Doctor\Result\Report;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(JsonRenderer::class)]
+#[CoversClass(HumanRenderer::class)]
+#[CoversClass(RendererRegistry::class)]
+class RenderersTest extends TestCase
+{
+    public function testJsonIsDeterministicAndOrdered(): void
+    {
+        $report = new Report([
+            CheckResult::ok('php_version', 'PHP 8.4 satisfies >=8.3'),
+            CheckResult::warn('cs_clean', 'dirty', 'Run `composer cs:fix`.', AgentAction::runCommand('composer cs:fix')),
+        ], 0);
+
+        $renderer = new JsonRenderer();
+        $first = $renderer->render($report);
+
+        $this->assertSame($first, $renderer->render($report), 'same report must render byte-identically');
+
+        /** @var array{status: string, duration_ms: int, checks: list<array<string, mixed>>} $decoded */
+        $decoded = json_decode(trim($first), true);
+        $this->assertSame(['status', 'duration_ms', 'checks'], array_keys($decoded));
+        $this->assertSame(['name', 'status', 'detail'], array_keys($decoded['checks'][0]));
+        $this->assertSame('warn', $decoded['status']);
+        $this->assertDoesNotMatchRegularExpression('/\d{4}-\d{2}-\d{2}/', $first, 'no timestamps in output');
+    }
+
+    public function testHumanRendersStatusFixAndCommandSnippet(): void
+    {
+        $report = new Report([
+            CheckResult::ok('php_version', 'fine'),
+            CheckResult::warn('cs_clean', 'dirty', 'Run `composer cs:fix`.', AgentAction::runCommand('composer cs:fix')),
+        ], 5);
+
+        $out = (new HumanRenderer())->render($report);
+
+        $this->assertStringContainsString('[ok', $out);
+        $this->assertStringContainsString('[warn', $out);
+        $this->assertStringContainsString('fix: Run `composer cs:fix`.', $out);
+        $this->assertStringContainsString('$ composer cs:fix', $out);
+        $this->assertStringContainsString('WARN — 2 checks in 5ms', $out);
+    }
+
+    public function testRegistryResolvesAndRejectsUnknownFormat(): void
+    {
+        $registry = RendererRegistry::default();
+
+        $this->assertInstanceOf(JsonRenderer::class, $registry->get('json'));
+        $this->assertInstanceOf(HumanRenderer::class, $registry->get('human'));
+        $this->assertSame(['human', 'json'], $registry->available());
+
+        $this->expectException(DoctorException::class);
+        $registry->get('xml');
+    }
+}

--- a/tests/Doctor/Result/ResultObjectsTest.php
+++ b/tests/Doctor/Result/ResultObjectsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Result;
+
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Doctor\Result\CheckStatus;
+use Altair\Doctor\Result\Report;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CheckStatus::class)]
+#[CoversClass(AgentAction::class)]
+#[CoversClass(CheckResult::class)]
+#[CoversClass(Report::class)]
+class ResultObjectsTest extends TestCase
+{
+    public function testStatusSeverityOrdersOkBelowWarnBelowError(): void
+    {
+        $this->assertSame(0, CheckStatus::Ok->severity());
+        $this->assertSame(0, CheckStatus::Skipped->severity());
+        $this->assertSame(1, CheckStatus::Warn->severity());
+        $this->assertSame(2, CheckStatus::Error->severity());
+    }
+
+    public function testAgentActionFlattensTypeAndPayload(): void
+    {
+        $this->assertSame(['type' => 'run_command', 'command' => 'composer cs:fix'], AgentAction::runCommand('composer cs:fix')->toArray());
+        $this->assertSame(['type' => 'edit_file', 'file' => 'a.php', 'hint' => 'add x'], AgentAction::editFile('a.php', 'add x')->toArray());
+        $this->assertSame(['type' => 'install_dep', 'package' => 'ext-redis'], AgentAction::installDep('ext-redis')->toArray());
+    }
+
+    public function testCheckResultOmitsAbsentOptionalFields(): void
+    {
+        $ok = CheckResult::ok('php_version', 'fine')->toArray();
+        $this->assertSame(['name' => 'php_version', 'status' => 'ok', 'detail' => 'fine'], $ok);
+    }
+
+    public function testCheckResultIncludesFixActionAndSourceWhenPresent(): void
+    {
+        $warn = CheckResult::warn('spec_drift', 'drift', 'edit it', AgentAction::editFile('In.php', 'add field'), 'api/x.yaml')->toArray();
+        $this->assertSame('warn', $warn['status']);
+        $this->assertSame('edit it', $warn['fix']);
+        $this->assertSame(['type' => 'edit_file', 'file' => 'In.php', 'hint' => 'add field'], $warn['agent_action']);
+        $this->assertSame('api/x.yaml', $warn['source']);
+    }
+
+    public function testReportStatusIsWorstAndExitCodeMatchesSeverity(): void
+    {
+        $report = new Report([
+            CheckResult::ok('a', 'ok'),
+            CheckResult::warn('b', 'warn'),
+            CheckResult::error('c', 'err'),
+            CheckResult::skipped('d', 'skip'),
+        ], 12);
+
+        $this->assertSame(CheckStatus::Error, $report->status());
+        $this->assertSame(2, $report->exitCode());
+
+        $warnOnly = new Report([CheckResult::ok('a', 'ok'), CheckResult::warn('b', 'w')], 1);
+        $this->assertSame(1, $warnOnly->exitCode());
+
+        $allOk = new Report([CheckResult::ok('a', 'ok')], 0);
+        $this->assertSame(0, $allOk->exitCode());
+    }
+
+    public function testReportToArrayShape(): void
+    {
+        $array = (new Report([CheckResult::ok('a', 'ok')], 7))->toArray();
+        $this->assertSame('ok', $array['status']);
+        $this->assertSame(7, $array['duration_ms']);
+        $this->assertSame([['name' => 'a', 'status' => 'ok', 'detail' => 'ok']], $array['checks']);
+    }
+}

--- a/tests/Doctor/Support/FakeCheck.php
+++ b/tests/Doctor/Support/FakeCheck.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Support;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * A check that returns a pre-baked result, recording whether it ran — used
+ * to exercise the runner's filtering and dependency-skip logic.
+ */
+final class FakeCheck implements CheckInterface
+{
+    public bool $ran = false;
+
+    /**
+     * @param list<string> $dependsOn
+     */
+    public function __construct(
+        private readonly string $name,
+        private readonly CheckResult $result,
+        private readonly array $dependsOn = [],
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return $this->dependsOn;
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $this->ran = true;
+
+        return $this->result;
+    }
+}

--- a/tests/Doctor/Support/FakeFixableCheck.php
+++ b/tests/Doctor/Support/FakeFixableCheck.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Support;
+
+use Altair\Doctor\Contracts\FixableCheckInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * A fixable check: returns `$before` until `fix()` succeeds, then `$after`.
+ * Lets the runner's --fix path (fix, then re-run) be asserted.
+ */
+final class FakeFixableCheck implements FixableCheckInterface
+{
+    public int $runCount = 0;
+
+    public int $fixCount = 0;
+
+    private bool $fixed = false;
+
+    public function __construct(
+        private readonly string $name,
+        private readonly CheckResult $before,
+        private readonly CheckResult $after,
+        private readonly bool $fixSucceeds = true,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        ++$this->runCount;
+
+        return $this->fixed ? $this->after : $this->before;
+    }
+
+    #[Override]
+    public function fix(): bool
+    {
+        ++$this->fixCount;
+        $this->fixed = $this->fixSucceeds;
+
+        return $this->fixSucceeds;
+    }
+}

--- a/tests/Doctor/Support/FakeProcessRunner.php
+++ b/tests/Doctor/Support/FakeProcessRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Support;
+
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Process\ProcessResult;
+use Override;
+
+/**
+ * In-memory ProcessRunner: scripts results per command and records calls,
+ * so process-backed checks are testable without shelling out.
+ */
+final class FakeProcessRunner implements ProcessRunnerInterface
+{
+    /** @var list<list<string>> */
+    public array $calls = [];
+
+    /** @var array<string, ProcessResult> */
+    private array $scripted = [];
+
+    private readonly ProcessResult $default;
+
+    public function __construct(?ProcessResult $default = null)
+    {
+        $this->default = $default ?? new ProcessResult(0);
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    public function on(array $command, ProcessResult $result): void
+    {
+        $this->scripted[implode(' ', $command)] = $result;
+    }
+
+    /**
+     * @param list<string> $command
+     */
+    #[Override]
+    public function run(array $command, ?string $cwd = null): ProcessResult
+    {
+        $this->calls[] = $command;
+
+        return $this->scripted[implode(' ', $command)] ?? $this->default;
+    }
+}


### PR DESCRIPTION
Adds `bin/altair doctor` — a single command that runs health checks and emits output an agent can act on without scraping. Each non-ok result carries a `fix` line and a machine-readable `agent_action` (`run_command` / `edit_file` / `install_dep`). Exit code is the worst observed status: **0** ok, **1** warn, **2** error.

```bash
bin/altair doctor                      # scannable human text
bin/altair doctor --format=json        # agent-parseable
bin/altair doctor --only=cs_clean,phpstan_clean
bin/altair doctor --skip=determinism_check
bin/altair doctor --fix                # safe auto-fixes for checks that opt in
```

## Architecture (mirrors `univeros/introspection`)

- **Contracts:** `CheckInterface` (`name`/`dependsOn`/`run`), `FixableCheckInterface`, `ReportRendererInterface`, `ProcessRunnerInterface`.
- **Result VOs:** `CheckStatus` enum, `AgentAction`, `CheckResult`, `Report` — all with **deterministic `toArray()`** (ordered keys, optional fields omitted, no timestamps — satisfies #74).
- **`Doctor` runner:** `--only`/`--skip` filtering; **dependency-aware skipping** (a check whose prerequisite errored/skipped is reported `skipped`); `--fix` (fix then re-run); wall-clock duration (the single explicit timing field).
- **Output:** `JsonRenderer` (deterministic), `HumanRenderer` (scannable, no boxes/emoji).
- **`ShellProcessRunner`** via `proc_open` argv (no shell injection), abstracted behind `ProcessRunnerInterface` so process-backed checks are unit-testable with a fake.

## v0 checks

| Check | Kind | Notes |
|---|---|---|
| `php_version` | pure | composer.json floor vs running PHP; `install_dep` action |
| `extensions_loaded` | pure | required `ext-*` from composer.json; injectable probe |
| `cs_clean` | process, fixable | `composer cs` → `composer cs:fix` |
| `phpstan_clean` | process | `composer stan` (no auto-fix; root-cause guidance) |
| `manifests_current` | process, fixable | `manifest:diff` → `manifest:generate` (`run_command` action) |
| `determinism_check` | process | **#74 gate as a check** — regenerate, `git diff`, error on drift |

The registry is extensible (hosts add checks via a `prepare()` hook). `DoctorConfiguration` reads the PHP floor + `ext-*` from the project's composer.json.

## Deliberately deferred (same `CheckInterface` pattern, land next)

Checks needing a live host app/DB — `container_boots`, `container_resolves`, `database_reachable` — and further process checks `composer_deps`, `tests_passing`, `spec_drift`, `openapi_valid`, `migrations_pending`. The architecture supports them without change.

## Tests & gates

35 tests (91 assertions): runner filtering / dependency-skip / fix path; every check (golden + induced-failure + `agent_action` assertions); deterministic JSON; renderers; config composer.json parsing; command exit codes. **CS clean, PHPStan level 6 clean (no baseline entries), rector `--dry-run` clean.** No regressions (the 5 suite-wide errors are pre-existing `ext-mongodb`/`ext-memcached` environmental).

Closes part of #68 (v0); remaining checks tracked there.