### PR TITLE
re #68 doctor: add the remaining checks (completes v1)

### DIFF
--- a/src/Altair/Doctor/Check/ComposerDepsCheck.php
+++ b/src/Altair/Doctor/Check/ComposerDepsCheck.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\FixableCheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Whether `vendor/` is current with `composer.lock` — `composer install
+ * --dry-run` exits non-zero when there's pending work. Fixable: `--fix`
+ * runs `composer install`.
+ */
+final readonly class ComposerDepsCheck implements FixableCheckInterface
+{
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'composer_deps';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $command = ['composer', 'install', '--dry-run', '--no-interaction', '--no-scripts'];
+        if ($this->runner->run($command, $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'Composer dependencies are current with composer.lock.');
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            'Composer dependencies are out of date or composer.lock has drifted.',
+            'Run `composer install`.',
+            AgentAction::runCommand('composer install'),
+        );
+    }
+
+    #[Override]
+    public function fix(): bool
+    {
+        return $this->runner->run(['composer', 'install', '--no-interaction'], $this->projectRoot)->ok();
+    }
+}

--- a/src/Altair/Doctor/Check/ContainerBootsCheck.php
+++ b/src/Altair/Doctor/Check/ContainerBootsCheck.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\CheckResult;
+use Closure;
+use Override;
+use Throwable;
+
+/**
+ * Verifies the host application's Container can be constructed from scratch
+ * without errors — the most common "agent got stuck" failure mode is a
+ * missing Configuration binding that only surfaces at boot.
+ *
+ * The boot callable is host-supplied (e.g. the same bootstrap `bin/altair`
+ * uses). With no callable wired, the check reports `skipped` rather than
+ * pass — there's nothing to verify in a library-only context.
+ */
+final readonly class ContainerBootsCheck implements CheckInterface
+{
+    /**
+     * @param (Closure(): mixed)|null $booter
+     */
+    public function __construct(
+        private ?Closure $booter = null,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'container_boots';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if (!$this->booter instanceof Closure) {
+            return CheckResult::skipped(
+                $this->name(),
+                'No application boot callable configured.',
+            );
+        }
+
+        try {
+            ($this->booter)();
+
+            return CheckResult::ok($this->name(), 'Application Container constructed without errors.');
+        } catch (Throwable $throwable) {
+            return CheckResult::error(
+                $this->name(),
+                'Boot threw: ' . $throwable->getMessage(),
+                'Review the Configurations applied to the Container; the failing one is the first to throw.',
+            );
+        }
+    }
+}

--- a/src/Altair/Doctor/Check/ContainerResolvesCheck.php
+++ b/src/Altair/Doctor/Check/ContainerResolvesCheck.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+use Psr\Container\ContainerInterface;
+use Throwable;
+
+/**
+ * Verifies a configured list of critical bindings (PSR-11 ids — e.g.
+ * `MiddlewareInterface`, `EntityManagerInterface`) actually resolve. This is
+ * the granular companion to {@see ContainerBootsCheck}: boot succeeding
+ * doesn't guarantee every contract a host expects is wired.
+ *
+ * With an empty list the check is `skipped` — hosts opt in by declaring
+ * their critical contracts via `DoctorConfiguration`.
+ */
+final readonly class ContainerResolvesCheck implements CheckInterface
+{
+    /**
+     * @param list<class-string> $criticalBindings
+     */
+    public function __construct(
+        private ContainerInterface $container,
+        private array $criticalBindings,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'container_resolves';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return ['container_boots'];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if ($this->criticalBindings === []) {
+            return CheckResult::skipped(
+                $this->name(),
+                'No critical bindings configured.',
+            );
+        }
+
+        $failed = [];
+        foreach ($this->criticalBindings as $id) {
+            try {
+                $this->container->get($id);
+            } catch (Throwable $throwable) {
+                $failed[] = $id . ' (' . $throwable->getMessage() . ')';
+            }
+        }
+
+        if ($failed === []) {
+            return CheckResult::ok(
+                $this->name(),
+                'All ' . \count($this->criticalBindings) . ' critical bindings resolve.',
+            );
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'Failed to resolve: ' . implode('; ', $failed),
+            'Review the Configurations that bind these contracts; ensure each is applied to the Container.',
+        );
+    }
+}

--- a/src/Altair/Doctor/Check/DatabaseReachableCheck.php
+++ b/src/Altair/Doctor/Check/DatabaseReachableCheck.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\CheckResult;
+use Closure;
+use Override;
+use Throwable;
+
+/**
+ * If persistence is configured, can the database be reached? The probe is
+ * host-supplied (it knows about the project's specific DB binding) — a
+ * common shape is `static fn() => $em->getConnection()->isConnected()`.
+ *
+ * With no probe configured the check is `skipped` — not every project uses
+ * a database, and "no probe" must not look like a pass.
+ */
+final readonly class DatabaseReachableCheck implements CheckInterface
+{
+    /**
+     * @param (Closure(): bool)|null $probe
+     */
+    public function __construct(
+        private ?Closure $probe = null,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'database_reachable';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if (!$this->probe instanceof Closure) {
+            return CheckResult::skipped(
+                $this->name(),
+                'No database probe configured.',
+            );
+        }
+
+        try {
+            if (($this->probe)()) {
+                return CheckResult::ok($this->name(), 'Database is reachable.');
+            }
+
+            return CheckResult::error(
+                $this->name(),
+                'Database probe returned false.',
+                'Check DB credentials, that the database server is running, and that the configured connection name matches the bound DatabaseProvider.',
+            );
+        } catch (Throwable $throwable) {
+            return CheckResult::error(
+                $this->name(),
+                'Database probe threw: ' . $throwable->getMessage(),
+                'Check DB connection settings and that the persistence layer is wired.',
+            );
+        }
+    }
+}

--- a/src/Altair/Doctor/Check/MigrationsPendingCheck.php
+++ b/src/Altair/Doctor/Check/MigrationsPendingCheck.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\FixableCheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Reports drift between the migrations directory and what's been applied to
+ * the database. `bin/altair db:migrate:status` exits non-zero when there's
+ * pending work. Fixable: `--fix` runs `db:migrate`.
+ */
+final readonly class MigrationsPendingCheck implements FixableCheckInterface
+{
+    /**
+     * @param list<string> $altairBin
+     */
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+        private array $altairBin = ['php', 'bin/altair'],
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'migrations_pending';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return ['database_reachable'];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $command = [...$this->altairBin, 'db:migrate:status'];
+        if ($this->runner->run($command, $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'No pending migrations.');
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            'There are unapplied migrations.',
+            'Run `bin/altair db:migrate`.',
+            AgentAction::runCommand('bin/altair db:migrate'),
+        );
+    }
+
+    #[Override]
+    public function fix(): bool
+    {
+        return $this->runner->run([...$this->altairBin, 'db:migrate'], $this->projectRoot)->ok();
+    }
+}

--- a/src/Altair/Doctor/Check/OpenApiValidCheck.php
+++ b/src/Altair/Doctor/Check/OpenApiValidCheck.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Verifies the spec sources emit a well-formed OpenAPI document by running
+ * `bin/altair spec:emit-openapi` against a discarded output path. A failure
+ * here means the YAML specs are structurally broken — the emitter would
+ * refuse them.
+ *
+ * Distinct from {@see SpecDriftCheck}: drift compares emitted code against
+ * spec, this verifies the spec itself can produce a document.
+ */
+final readonly class OpenApiValidCheck implements CheckInterface
+{
+    /**
+     * @param list<string> $altairBin
+     */
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+        private string $outputPath = '/dev/null',
+        private array $altairBin = ['php', 'bin/altair'],
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'openapi_valid';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $command = [...$this->altairBin, 'spec:emit-openapi', '--out=' . $this->outputPath];
+        if ($this->runner->run($command, $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'OpenAPI document emits without errors.');
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'spec:emit-openapi failed — the spec source has structural issues.',
+            'Review the YAML specs under api/ and fix the validation errors reported by `bin/altair spec:emit-openapi`.',
+        );
+    }
+}

--- a/src/Altair/Doctor/Check/SpecDriftCheck.php
+++ b/src/Altair/Doctor/Check/SpecDriftCheck.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * Hand-edits to generated files surface here via `bin/altair spec:lint`,
+ * which compares the emitted artifacts against their YAML specs and exits
+ * non-zero on drift. Fix path: regenerate from the spec (`spec:scaffold`).
+ */
+final readonly class SpecDriftCheck implements CheckInterface
+{
+    /**
+     * @param list<string> $altairBin
+     */
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+        private array $altairBin = ['php', 'bin/altair'],
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'spec_drift';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        $command = [...$this->altairBin, 'spec:lint'];
+        if ($this->runner->run($command, $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'Scaffolded files match their YAML specs.');
+        }
+
+        return CheckResult::warn(
+            $this->name(),
+            'Scaffolded files have drifted from their YAML specs (hand-edits or stale generation).',
+            'Re-run `bin/altair spec:scaffold` to regenerate, or revert the hand-edits to the spec source.',
+            AgentAction::runCommand('bin/altair spec:scaffold'),
+        );
+    }
+}

--- a/src/Altair/Doctor/Check/TestsPassingCheck.php
+++ b/src/Altair/Doctor/Check/TestsPassingCheck.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Doctor\Check;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Contracts\ProcessRunnerInterface;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+/**
+ * PHPUnit exits 0. Slow — declare it skippable in CI/local with
+ * `--skip=tests_passing` when running doctor as a fast feedback loop. Depends
+ * on `composer_deps` (no point running the suite if vendor is stale).
+ */
+final readonly class TestsPassingCheck implements CheckInterface
+{
+    public function __construct(
+        private ProcessRunnerInterface $runner,
+        private string $projectRoot,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'tests_passing';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return ['composer_deps'];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if ($this->runner->run(['vendor/bin/phpunit', '--no-progress'], $this->projectRoot)->ok()) {
+            return CheckResult::ok($this->name(), 'PHPUnit suite passes.');
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'PHPUnit reported failures.',
+            'Run `vendor/bin/phpunit` to see the failing tests and fix the regression at root cause.',
+        );
+    }
+}

--- a/src/Altair/Doctor/Configuration/DoctorConfiguration.php
+++ b/src/Altair/Doctor/Configuration/DoctorConfiguration.php
@@ -13,17 +13,26 @@ namespace Altair\Doctor\Configuration;
 
 use Altair\Configuration\Contracts\ConfigurationInterface;
 use Altair\Container\Container;
+use Altair\Doctor\Check\ComposerDepsCheck;
+use Altair\Doctor\Check\ContainerBootsCheck;
+use Altair\Doctor\Check\ContainerResolvesCheck;
 use Altair\Doctor\Check\CsCleanCheck;
+use Altair\Doctor\Check\DatabaseReachableCheck;
 use Altair\Doctor\Check\DeterminismCheck;
 use Altair\Doctor\Check\ExtensionsLoadedCheck;
 use Altair\Doctor\Check\ManifestsCurrentCheck;
+use Altair\Doctor\Check\MigrationsPendingCheck;
+use Altair\Doctor\Check\OpenApiValidCheck;
 use Altair\Doctor\Check\PhpstanCleanCheck;
 use Altair\Doctor\Check\PhpVersionCheck;
+use Altair\Doctor\Check\SpecDriftCheck;
+use Altair\Doctor\Check\TestsPassingCheck;
 use Altair\Doctor\CheckRegistry;
 use Altair\Doctor\Contracts\ProcessRunnerInterface;
 use Altair\Doctor\Doctor;
 use Altair\Doctor\Output\RendererRegistry;
 use Altair\Doctor\Process\ShellProcessRunner;
+use Closure;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -35,13 +44,24 @@ use Override;
  *
  * The PHP floor and required `ext-*` list are read from the project's
  * `composer.json` so `php_version` / `extensions_loaded` reflect the
- * project's own declared requirements. Hosts add their own checks by
- * `prepare()`-ing {@see CheckRegistry} after this Configuration runs.
+ * project's own declared requirements. Host-app checks (container boot,
+ * critical bindings, database reachability) are opt-in via constructor
+ * arguments — without those hooks they report `skipped` instead of false
+ * positives. Hosts add their own checks by `prepare()`-ing
+ * {@see CheckRegistry} after this Configuration runs.
  */
 final readonly class DoctorConfiguration implements ConfigurationInterface
 {
+    /**
+     * @param (Closure(): mixed)|null $appBooter        boot callable verifying the host Container can be constructed
+     * @param list<class-string>      $criticalBindings PSR-11 ids the host considers must-resolve
+     * @param (Closure(): bool)|null  $databaseProbe    closure returning true when the DB is reachable
+     */
     public function __construct(
         private ?string $projectRoot = null,
+        private ?Closure $appBooter = null,
+        private array $criticalBindings = [],
+        private ?Closure $databaseProbe = null,
     ) {}
 
     #[Override]
@@ -55,9 +75,17 @@ final readonly class DoctorConfiguration implements ConfigurationInterface
         $registry = new CheckRegistry([
             new PhpVersionCheck($phpFloor),
             new ExtensionsLoadedCheck($extensions),
+            new ComposerDepsCheck($runner, $projectRoot),
+            new ContainerBootsCheck($this->appBooter),
+            new ContainerResolvesCheck($container, $this->criticalBindings),
+            new DatabaseReachableCheck($this->databaseProbe),
+            new MigrationsPendingCheck($runner, $projectRoot),
+            new SpecDriftCheck($runner, $projectRoot),
+            new OpenApiValidCheck($runner, $projectRoot),
             new ManifestsCurrentCheck($runner, $projectRoot),
             new CsCleanCheck($runner, $projectRoot),
             new PhpstanCleanCheck($runner, $projectRoot),
+            new TestsPassingCheck($runner, $projectRoot),
             new DeterminismCheck($runner, $projectRoot),
         ]);
 

--- a/tests/Doctor/Check/HostAppChecksTest.php
+++ b/tests/Doctor/Check/HostAppChecksTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Doctor\Check;
+
+use Altair\Container\Container;
+use Altair\Doctor\Check\ContainerBootsCheck;
+use Altair\Doctor\Check\ContainerResolvesCheck;
+use Altair\Doctor\Check\DatabaseReachableCheck;
+use Altair\Doctor\Result\CheckStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+#[CoversClass(ContainerBootsCheck::class)]
+#[CoversClass(ContainerResolvesCheck::class)]
+#[CoversClass(DatabaseReachableCheck::class)]
+class HostAppChecksTest extends TestCase
+{
+    public function testContainerBootsSkippedWithoutBooter(): void
+    {
+        $this->assertSame(CheckStatus::Skipped, (new ContainerBootsCheck())->run()->status);
+    }
+
+    public function testContainerBootsOkWhenBooterReturnsCleanly(): void
+    {
+        $check = new ContainerBootsCheck(static fn(): \stdClass => new \stdClass());
+
+        $this->assertSame(CheckStatus::Ok, $check->run()->status);
+    }
+
+    public function testContainerBootsErrorsWhenBooterThrows(): void
+    {
+        $check = new ContainerBootsCheck(static function (): void {
+            throw new RuntimeException('missing binding for FooInterface');
+        });
+
+        $result = $check->run();
+        $this->assertSame(CheckStatus::Error, $result->status);
+        $this->assertStringContainsString('missing binding for FooInterface', $result->detail);
+    }
+
+    public function testContainerResolvesSkippedWithEmptyList(): void
+    {
+        $this->assertSame(CheckStatus::Skipped, (new ContainerResolvesCheck(new Container(), []))->run()->status);
+    }
+
+    public function testContainerResolvesOkWhenAllBindingsResolve(): void
+    {
+        $container = new Container();
+        $container->share(new \stdClass());
+
+        $this->assertSame(CheckStatus::Ok, (new ContainerResolvesCheck($container, [\stdClass::class]))->run()->status);
+    }
+
+    public function testContainerResolvesErrorListsFailedIds(): void
+    {
+        $container = new Container();
+        $container->share(new \stdClass());
+
+        $result = (new ContainerResolvesCheck($container, [\stdClass::class, 'App\\Missing\\Service']))->run();
+        $this->assertSame(CheckStatus::Error, $result->status);
+        $this->assertStringContainsString('App\\Missing\\Service', $result->detail);
+        $this->assertStringNotContainsString('stdClass (', $result->detail, 'a resolving id must not appear in the failure list');
+    }
+
+    public function testContainerResolvesDependsOnContainerBoots(): void
+    {
+        $this->assertSame(['container_boots'], (new ContainerResolvesCheck(new Container(), []))->dependsOn());
+    }
+
+    public function testDatabaseReachableSkippedWithoutProbe(): void
+    {
+        $this->assertSame(CheckStatus::Skipped, (new DatabaseReachableCheck())->run()->status);
+    }
+
+    public function testDatabaseReachableOkWhenProbeReturnsTrue(): void
+    {
+        $this->assertSame(CheckStatus::Ok, (new DatabaseReachableCheck(static fn(): bool => true))->run()->status);
+    }
+
+    public function testDatabaseReachableErrorsWhenProbeReturnsFalse(): void
+    {
+        $this->assertSame(CheckStatus::Error, (new DatabaseReachableCheck(static fn(): bool => false))->run()->status);
+    }
+
+    public function testDatabaseReachableErrorsWhenProbeThrows(): void
+    {
+        $check = new DatabaseReachableCheck(static function (): bool {
+            throw new RuntimeException('connection refused');
+        });
+
+        $result = $check->run();
+        $this->assertSame(CheckStatus::Error, $result->status);
+        $this->assertStringContainsString('connection refused', $result->detail);
+    }
+}

--- a/tests/Doctor/Check/ProcessChecksTest.php
+++ b/tests/Doctor/Check/ProcessChecksTest.php
@@ -4,10 +4,15 @@ declare(strict_types=1);
 
 namespace Altair\Tests\Doctor\Check;
 
+use Altair\Doctor\Check\ComposerDepsCheck;
 use Altair\Doctor\Check\CsCleanCheck;
 use Altair\Doctor\Check\DeterminismCheck;
 use Altair\Doctor\Check\ManifestsCurrentCheck;
+use Altair\Doctor\Check\MigrationsPendingCheck;
+use Altair\Doctor\Check\OpenApiValidCheck;
 use Altair\Doctor\Check\PhpstanCleanCheck;
+use Altair\Doctor\Check\SpecDriftCheck;
+use Altair\Doctor\Check\TestsPassingCheck;
 use Altair\Doctor\Process\ProcessResult;
 use Altair\Doctor\Result\CheckStatus;
 use Altair\Tests\Doctor\Support\FakeProcessRunner;
@@ -18,6 +23,11 @@ use PHPUnit\Framework\TestCase;
 #[CoversClass(PhpstanCleanCheck::class)]
 #[CoversClass(ManifestsCurrentCheck::class)]
 #[CoversClass(DeterminismCheck::class)]
+#[CoversClass(ComposerDepsCheck::class)]
+#[CoversClass(TestsPassingCheck::class)]
+#[CoversClass(SpecDriftCheck::class)]
+#[CoversClass(OpenApiValidCheck::class)]
+#[CoversClass(MigrationsPendingCheck::class)]
 class ProcessChecksTest extends TestCase
 {
     public function testCsCleanOkWhenComposerCsPasses(): void
@@ -100,5 +110,113 @@ class ProcessChecksTest extends TestCase
         $result = $check->run();
         $this->assertSame(CheckStatus::Error, $result->status);
         $this->assertStringContainsString('failed to run', $result->detail);
+    }
+
+    public function testComposerDepsOkWhenInSync(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertSame(CheckStatus::Ok, (new ComposerDepsCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testComposerDepsWarnsWithInstallActionWhenStale(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['composer', 'install', '--dry-run', '--no-interaction', '--no-scripts'], new ProcessResult(1));
+
+        $result = (new ComposerDepsCheck($runner, '/p'))->run();
+        $this->assertSame(CheckStatus::Warn, $result->status);
+        $this->assertSame('composer install', $result->agentAction?->toArray()['command']);
+    }
+
+    public function testComposerDepsFixRunsInstall(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertTrue((new ComposerDepsCheck($runner, '/p'))->fix());
+        $this->assertContains(['composer', 'install', '--no-interaction'], $runner->calls);
+    }
+
+    public function testTestsPassingOk(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertSame(CheckStatus::Ok, (new TestsPassingCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testTestsPassingErrorsWhenSuiteFails(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['vendor/bin/phpunit', '--no-progress'], new ProcessResult(1));
+
+        $this->assertSame(CheckStatus::Error, (new TestsPassingCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testTestsPassingDependsOnComposerDeps(): void
+    {
+        $this->assertSame(['composer_deps'], (new TestsPassingCheck(new FakeProcessRunner(), '/p'))->dependsOn());
+    }
+
+    public function testSpecDriftOkWhenAligned(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertSame(CheckStatus::Ok, (new SpecDriftCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testSpecDriftWarnsWithScaffoldActionWhenDrifted(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['php', 'bin/altair', 'spec:lint'], new ProcessResult(1));
+
+        $result = (new SpecDriftCheck($runner, '/p'))->run();
+        $this->assertSame(CheckStatus::Warn, $result->status);
+        $this->assertSame('bin/altair spec:scaffold', $result->agentAction?->toArray()['command']);
+    }
+
+    public function testOpenApiValidOk(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['php', 'bin/altair', 'spec:emit-openapi', '--out=/dev/null'], new ProcessResult(0));
+
+        $this->assertSame(CheckStatus::Ok, (new OpenApiValidCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testOpenApiValidErrorsWhenEmitterFails(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['php', 'bin/altair', 'spec:emit-openapi', '--out=/dev/null'], new ProcessResult(2));
+
+        $this->assertSame(CheckStatus::Error, (new OpenApiValidCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testMigrationsPendingOk(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertSame(CheckStatus::Ok, (new MigrationsPendingCheck($runner, '/p'))->run()->status);
+    }
+
+    public function testMigrationsPendingWarnsWithMigrateAction(): void
+    {
+        $runner = new FakeProcessRunner();
+        $runner->on(['php', 'bin/altair', 'db:migrate:status'], new ProcessResult(1));
+
+        $result = (new MigrationsPendingCheck($runner, '/p'))->run();
+        $this->assertSame(CheckStatus::Warn, $result->status);
+        $this->assertSame('bin/altair db:migrate', $result->agentAction?->toArray()['command']);
+    }
+
+    public function testMigrationsPendingFixRunsMigrate(): void
+    {
+        $runner = new FakeProcessRunner(new ProcessResult(0));
+
+        $this->assertTrue((new MigrationsPendingCheck($runner, '/p'))->fix());
+        $this->assertContains(['php', 'bin/altair', 'db:migrate'], $runner->calls);
+    }
+
+    public function testMigrationsPendingDependsOnDatabaseReachable(): void
+    {
+        $this->assertSame(['database_reachable'], (new MigrationsPendingCheck(new FakeProcessRunner(), '/p'))->dependsOn());
     }
 }

--- a/tests/Doctor/Configuration/DoctorConfigurationTest.php
+++ b/tests/Doctor/Configuration/DoctorConfigurationTest.php
@@ -50,9 +50,51 @@ class DoctorConfigurationTest extends TestCase
         $registry = $container->make(CheckRegistry::class);
         $this->assertInstanceOf(CheckRegistry::class, $registry);
         $names = array_map(static fn($c): string => $c->name(), $registry->all());
-        $this->assertContains('php_version', $names);
-        $this->assertContains('extensions_loaded', $names);
-        $this->assertContains('determinism_check', $names);
+
+        // All 13 issue checks plus determinism_check (#74).
+        foreach ([
+            'php_version', 'extensions_loaded', 'composer_deps',
+            'container_boots', 'container_resolves', 'database_reachable',
+            'migrations_pending', 'spec_drift', 'openapi_valid', 'manifests_current',
+            'cs_clean', 'phpstan_clean', 'tests_passing', 'determinism_check',
+        ] as $expected) {
+            $this->assertContains($expected, $names, $expected . ' must be registered');
+        }
+    }
+
+    public function testHostAppHooksMakeTheirChecksRun(): void
+    {
+        $container = new Container();
+        $container->share(new \stdClass());
+
+        (new DoctorConfiguration(
+            projectRoot: $this->root,
+            appBooter: static fn(): bool => true,
+            criticalBindings: [\stdClass::class],
+            databaseProbe: static fn(): bool => true,
+        ))->apply($container);
+
+        $report = $container->make(Doctor::class)->run(
+            only: ['container_boots', 'container_resolves', 'database_reachable'],
+        );
+
+        foreach ($report->checks as $check) {
+            $this->assertSame(CheckStatus::Ok, $check->status, $check->name . ': ' . $check->detail);
+        }
+    }
+
+    public function testHostAppChecksSkipWithoutHooks(): void
+    {
+        $container = new Container();
+        (new DoctorConfiguration($this->root))->apply($container);
+
+        $report = $container->make(Doctor::class)->run(
+            only: ['container_boots', 'container_resolves', 'database_reachable'],
+        );
+
+        foreach ($report->checks as $check) {
+            $this->assertSame(CheckStatus::Skipped, $check->status, $check->name . ' must skip when unconfigured');
+        }
     }
 
     public function testReadsFloorAndExtensionsFromComposerJson(): void


### PR DESCRIPTION
Completes #68 by adding the 8 checks deferred from the v0 PR (#99). No architecture changes — each is an additive `CheckInterface` entry following the established pattern.

## Process-backed checks (unit-tested via the fake runner)

| Check | Command | Notes |
|---|---|---|
| `composer_deps` | `composer install --dry-run` | vendor vs lock; **fixable** (`composer install`) |
| `tests_passing` | `vendor/bin/phpunit` | `dependsOn` `composer_deps` |
| `spec_drift` | `bin/altair spec:lint` | `agent_action`: re-scaffold |
| `openapi_valid` | `bin/altair spec:emit-openapi` (discarded output) | distinct from `spec_drift` — verifies the spec can *emit* a document |
| `migrations_pending` | `bin/altair db:migrate:status` | **fixable** (`db:migrate`); `dependsOn` `database_reachable` |

## Host-app checks (opt-in, skip cleanly when unwired)

These need host context, so they're supplied via `DoctorConfiguration` hooks. With no hook they report **`skipped`** — "not wired" must never look like a pass.

- `container_boots` — runs a host boot callable, catches throwables.
- `container_resolves` — `get()` each configured critical binding (PSR-11), lists failures; `dependsOn` `container_boots`.
- `database_reachable` — runs a host-supplied probe closure.

```php
new DoctorConfiguration(
    appBooter:        static fn() => $kernel->boot(),
    criticalBindings: [MiddlewareInterface::class, EntityManagerInterface::class],
    databaseProbe:    static fn() => $em->getConnection()->isConnected(),
);
```

## Result

`DoctorConfiguration` now wires all **14** checks (the issue's 13 + `determinism_check` from #74). The full v1 check set from the issue is shipped.

## Tests & gates

62 doctor tests (+27): every new check's ok / fail / skip / `agent_action` / fix path, dependency wiring (`tests_passing`→`composer_deps`, `migrations_pending`→`database_reachable`, `container_resolves`→`container_boots`), and config wiring **with and without** host hooks. **CS clean, PHPStan level 6 clean (no baseline), rector `--dry-run` clean.** No regressions (the 5 suite errors are pre-existing `ext-mongodb`/`ext-memcached` environmental).

Closes #68.

### Follow-up (not blocking)
The issue also mentions an optional `#[DoctorCheck]` attribute-discovery path for custom checks; the container `prepare()`-based registration (the other documented mechanism) works today. Attribute discovery can be a small additive follow-up if wanted.