### PR TITLE
re #96 burn down PHPStan baseline (1): Filesystem, Middleware, Events, TestReporter, Security

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1006,76 +1006,6 @@ parameters:
 			path: src/Altair/Data/Contracts/UpdateRepositoryInterface.php
 
 		-
-			message: "#^Method Altair\\\\Events\\\\Event\\:\\:create\\(\\) has parameter \\$extra with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Events/Event.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:checksum\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:copy\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:createDirectory\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:move\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:publicUrl\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:temporaryUrl\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:write\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Adapter\\\\FlysystemAdapter\\:\\:writeStream\\(\\) has parameter \\$config with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Adapter/FlysystemAdapter.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Filesystem\\:\\:delete\\(\\) has parameter \\$paths with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Filesystem.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Filesystem\\:\\:glob\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Filesystem.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Filesystem\\:\\:listDirectories\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Filesystem.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Filesystem\\:\\:listFiles\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Filesystem.php
-
-		-
-			message: "#^Method Altair\\\\Filesystem\\\\Filesystem\\:\\:readLines\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Filesystem/Filesystem.php
-
-		-
 			message: "#^Method Altair\\\\Happen\\\\Contracts\\\\EventDispatcherInterface\\:\\:dispatchStack\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Happen/Contracts/EventDispatcherInterface.php
@@ -1656,36 +1586,6 @@ parameters:
 			path: src/Altair/Messaging/Transport/TransportRegistry.php
 
 		-
-			message: "#^Method Altair\\\\Middleware\\\\Contracts\\\\PayloadInterface\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Middleware/Contracts/PayloadInterface.php
-
-		-
-			message: "#^Method Altair\\\\Middleware\\\\Contracts\\\\PayloadInterface\\:\\:withAttributes\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Middleware/Contracts/PayloadInterface.php
-
-		-
-			message: "#^Method Altair\\\\Middleware\\\\Payload\\:\\:__construct\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Middleware/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Middleware\\\\Payload\\:\\:getAttributes\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Middleware/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Middleware\\\\Payload\\:\\:withAttributes\\(\\) has parameter \\$attributes with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Middleware/Payload.php
-
-		-
-			message: "#^Property Altair\\\\Middleware\\\\Payload\\:\\:\\$attributes type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Middleware/Payload.php
-
-		-
 			message: "#^Property Altair\\\\Persistence\\\\Cycle\\\\CycleRepository\\:\\:\\$repository with generic interface Cycle\\\\ORM\\\\RepositoryInterface does not specify its types\\: TEntity$#"
 			count: 1
 			path: src/Altair/Persistence/Cycle/CycleRepository.php
@@ -1831,24 +1731,9 @@ parameters:
 			path: src/Altair/Sanitation/Sanitizer.php
 
 		-
-			message: "#^Method Altair\\\\Security\\\\Encrypter\\:\\:encrypt\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Security/Encrypter.php
-
-		-
-			message: "#^Method Altair\\\\Security\\\\Encrypter\\:\\:getPayload\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Security/Encrypter.php
-
-		-
 			message: "#^Strict comparison using \\=\\=\\= between non\\-falsy\\-string and false will always evaluate to false\\.$#"
 			count: 1
 			path: src/Altair/Security/Support/Pbkdf2Key.php
-
-		-
-			message: "#^Method Altair\\\\Security\\\\Validator\\\\PayloadValidator\\:\\:__construct\\(\\) has parameter \\$payload with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Security/Validator/PayloadValidator.php
 
 		-
 			message: "#^Method Altair\\\\Session\\\\Adapter\\\\MySqlPdoSessionAdapter\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
@@ -3259,26 +3144,6 @@ parameters:
 			message: "#^Property Altair\\\\Structure\\\\Vector\\:\\:\\$internal has no type specified\\.$#"
 			count: 1
 			path: src/Altair/Structure/Vector.php
-
-		-
-			message: "#^Method Altair\\\\TestReporter\\\\Resolver\\\\SourceUnderTestResolver\\:\\:findMethod\\(\\) has parameter \\$reflection with generic class ReflectionClass but does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/TestReporter/Resolver/SourceUnderTestResolver.php
-
-		-
-			message: "#^Method Altair\\\\TestReporter\\\\Resolver\\\\SourceUnderTestResolver\\:\\:fromAttributes\\(\\) has parameter \\$reflection with generic class ReflectionClass but does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/TestReporter/Resolver/SourceUnderTestResolver.php
-
-		-
-			message: "#^Method Altair\\\\TestReporter\\\\Resolver\\\\SourceUnderTestResolver\\:\\:fromCoversAnnotation\\(\\) has parameter \\$reflection with generic class ReflectionClass but does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/TestReporter/Resolver/SourceUnderTestResolver.php
-
-		-
-			message: "#^Method Altair\\\\TestReporter\\\\Resolver\\\\SourceUnderTestResolver\\:\\:fromNamespaceHeuristic\\(\\) has parameter \\$reflection with generic class ReflectionClass but does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/TestReporter/Resolver/SourceUnderTestResolver.php
 
 		-
 			message: "#^Method Altair\\\\Validation\\\\Collection\\\\RuleCollection\\:\\:put\\(\\) has parameter \\$key with no type specified\\.$#"

--- a/src/Altair/Events/Event.php
+++ b/src/Altair/Events/Event.php
@@ -82,6 +82,8 @@ final readonly class Event
 
     /**
      * Common-case factory: stamp an event with a fresh ULID and the current UTC instant.
+     *
+     * @param array<string, mixed> $extra
      */
     public static function create(
         Actor $actor,

--- a/src/Altair/Filesystem/Adapter/FlysystemAdapter.php
+++ b/src/Altair/Filesystem/Adapter/FlysystemAdapter.php
@@ -134,12 +134,18 @@ class FlysystemAdapter implements FilesystemAdapterInterface
         return $this->driver->visibility($path);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     #[Override]
     public function write(string $location, string $contents, array $config = []): void
     {
         $this->driver->write($location, $contents, $config);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     #[Override]
     public function writeStream(string $location, $contents, array $config = []): void
     {
@@ -164,34 +170,52 @@ class FlysystemAdapter implements FilesystemAdapterInterface
         $this->driver->deleteDirectory($location);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     #[Override]
     public function createDirectory(string $location, array $config = []): void
     {
         $this->driver->createDirectory($location, $config);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     #[Override]
     public function move(string $source, string $destination, array $config = []): void
     {
         $this->driver->move($source, $destination, $config);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     #[Override]
     public function copy(string $source, string $destination, array $config = []): void
     {
         $this->driver->copy($source, $destination, $config);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     public function publicUrl(string $path, array $config = []): string
     {
         return $this->driver->publicUrl($path, $config);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     public function temporaryUrl(string $path, DateTimeInterface $expiresAt, array $config = []): string
     {
         return $this->driver->temporaryUrl($path, $expiresAt, $config);
     }
 
+    /**
+     * @param array<string, mixed> $config
+     */
     public function checksum(string $path, array $config = []): string
     {
         return $this->driver->checksum($path, $config);

--- a/src/Altair/Filesystem/Filesystem.php
+++ b/src/Altair/Filesystem/Filesystem.php
@@ -69,7 +69,7 @@ class Filesystem
     /**
      * Read the contents of a file as an array of lines.
      *
-     *
+     * @return list<string>
      */
     public function readLines(string $path): array
     {
@@ -181,7 +181,7 @@ class Filesystem
     /**
      * Delete the file at a given path.
      *
-     * @param  string|array $paths
+     * @param  string|list<string> $paths
      */
     public function delete($paths): bool
     {
@@ -492,8 +492,7 @@ class Filesystem
     /**
      * Find path names matching a given pattern.
      *
-     *
-     * @return array|false
+     * @return list<string>|false
      */
     public function glob(string $pattern, int $flags = 0): array|false
     {
@@ -503,7 +502,7 @@ class Filesystem
     /**
      * Get an array of all files in a directory.
      *
-     *
+     * @return array<int, string>
      */
     public function listFiles(string $directory): array
     {
@@ -555,6 +554,8 @@ class Filesystem
      *
      * @param string $directory
      * @param boolean $ignoreDotDirectories whether to ignore the dotted directories or not.
+     *
+     * @return array<string, string>
      */
     public function listDirectories($directory, $ignoreDotDirectories = true): array
     {

--- a/src/Altair/Middleware/Contracts/PayloadInterface.php
+++ b/src/Altair/Middleware/Contracts/PayloadInterface.php
@@ -38,7 +38,7 @@ interface PayloadInterface
      * The request "attributes" may be used to allow injection of any
      * parameters derived from the process and CAN be mutable.
      *
-     * @return array Attributes derived from the request.
+     * @return array<string, mixed> Attributes derived from the request.
      */
     public function getAttributes(): array;
 
@@ -71,7 +71,7 @@ interface PayloadInterface
      *
      * @see getAttributes()
      *
-     *
+     * @param array<string, mixed> $attributes
      */
     public function withAttributes(array $attributes): PayloadInterface;
 

--- a/src/Altair/Middleware/Payload.php
+++ b/src/Altair/Middleware/Payload.php
@@ -17,10 +17,15 @@ use Override;
 
 class Payload implements PayloadInterface, JsonSerializable
 {
+    /**
+     * @var array<string, mixed>
+     */
     protected array $attributes;
 
     /**
      * Payload constructor.
+     *
+     * @param array<string, mixed>|null $attributes
      */
     public function __construct(?array $attributes = null)
     {
@@ -38,6 +43,8 @@ class Payload implements PayloadInterface, JsonSerializable
 
     /**
      * @inheritDoc
+     *
+     * @return array<string, mixed>
      */
     #[Override]
     public function getAttributes(): array
@@ -59,6 +66,8 @@ class Payload implements PayloadInterface, JsonSerializable
 
     /**
      * @inheritDoc
+     *
+     * @param array<string, mixed> $attributes
      */
     #[Override]
     public function withAttributes(array $attributes): PayloadInterface

--- a/src/Altair/Security/Encrypter.php
+++ b/src/Altair/Security/Encrypter.php
@@ -72,7 +72,7 @@ class Encrypter implements EncrypterInterface
      * @throws Exception
      */
     #[Override]
-    public function encrypt($value): string
+    public function encrypt(mixed $value): string
     {
         $iv = random_bytes(EncrypterInterface::BLOCK_SIZE);
         $value = openssl_encrypt(serialize($value), $this->cipher, $this->derivedKey, 0, $iv);
@@ -125,6 +125,7 @@ class Encrypter implements EncrypterInterface
      *
      * @throws DecryptException
      * @throws Exception
+     * @return array<string, mixed>
      */
     protected function getPayload(string $payload): array
     {

--- a/src/Altair/Security/Validator/PayloadValidator.php
+++ b/src/Altair/Security/Validator/PayloadValidator.php
@@ -22,7 +22,7 @@ class PayloadValidator
     public function __construct(
         protected EncrypterInterface $encrypter,
         /**
-         * @var array the payload to validate against
+         * @var array<string, mixed> the payload to validate against
          */
         protected array $payload
     ) {}

--- a/src/Altair/TestReporter/Resolver/SourceUnderTestResolver.php
+++ b/src/Altair/TestReporter/Resolver/SourceUnderTestResolver.php
@@ -67,6 +67,8 @@ final readonly class SourceUnderTestResolver
     }
 
     /**
+     * @param ReflectionClass<object> $reflection
+     *
      * @return list<SourceLocation>
      */
     private function fromAttributes(ReflectionClass $reflection, string $testMethod): array
@@ -107,6 +109,8 @@ final readonly class SourceUnderTestResolver
     }
 
     /**
+     * @param ReflectionClass<object> $reflection
+     *
      * @return list<SourceLocation>
      */
     private function fromCoversAnnotation(ReflectionClass $reflection, string $testMethod): array
@@ -149,6 +153,8 @@ final readonly class SourceUnderTestResolver
     }
 
     /**
+     * @param ReflectionClass<object> $reflection
+     *
      * @return list<SourceLocation>
      */
     private function fromNamespaceHeuristic(ReflectionClass $reflection, string $testMethod): array
@@ -236,6 +242,9 @@ final readonly class SourceUnderTestResolver
         );
     }
 
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
     private function findMethod(ReflectionClass $reflection, string $preferred): ?ReflectionMethod
     {
         if ($reflection->hasMethod($preferred)) {


### PR DESCRIPTION
First chunk of the #96 PHPStan level-6 baseline burn-down. Adds precise value types at the root cause and regenerates `phpstan-baseline.neon`: **719 → 692 (-27)**.

| Package | Fixed | Types added |
|---|---|---|
| Filesystem | 13 | `FlysystemAdapter` `$config` → `array<string, mixed>`; `Filesystem` `readLines`/`glob`/`listFiles`/`listDirectories` returns + `delete()` `$paths` → `list<string>` / `array<int,string>` / `array<string,string>` |
| Middleware | 6 | `Payload` + `PayloadInterface` attributes → `array<string, mixed>` (property, ctor, get/withAttributes) |
| Events | 1 | `Event::create()` `$extra` → `array<string, mixed>` |
| TestReporter | 4 | `SourceUnderTestResolver`'s four `ReflectionClass<object>` params |
| Security | 3 | `Encrypter::encrypt()` `mixed $value`, `getPayload()` → `array<string, mixed>`, `PayloadValidator` `$payload` |

**Approach:** no type was widened to silence PHPStan — each annotation reflects the real data shape, verified against the method body (e.g. `listFiles` is `array<int,string>` because `array_filter` preserves keys; `listDirectories` is `array<string,string>` because it's basename-keyed). The baseline is regenerated, not hand-edited.

**Deliberately left for follow-ups** (not blanket-fixed): the `Pbkdf2Key` strict-comparison and the Persistence/Messaging generic-template findings — those need code-quality / `@template` work, not array annotations.

**Gates:** `composer stan` green (692 baselined, 0 live), CS clean, rector `--dry-run` clean. Full suite unaffected — the 5 errors are pre-existing `ext-mongodb`/`ext-memcached` environmental.

Part of #96 (stays open through the remaining burn-down and the 6→7→8 raises).