### PR TITLE
re #96 burn down PHPStan baseline (4): Http, Container

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,92 +56,7 @@ parameters:
 			path: src/Altair/Common/Support/Arr.php
 
 		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ArgumentsBuilder\\:\\:build\\(\\) has parameter \\$reflectionParameters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ArgumentsBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ArgumentsBuilder\\:\\:build\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ArgumentsBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ArgumentsBuilder\\:\\:buildArgumentFromClassDefinition\\(\\) has parameter \\$definition with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ArgumentsBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ArgumentsBuilder\\:\\:buildArgumentFromDelegate\\(\\) has parameter \\$callableOrMethodString with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ArgumentsBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructure\\(\\) has parameter \\$callableOrMethodString with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructure\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructureFromArray\\(\\) has parameter \\$executableArray with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructureFromArray\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructureFromClassMethodCallable\\(\\) has parameter \\$class with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructureFromClassMethodCallable\\(\\) has parameter \\$method with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructureFromClassMethodCallable\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:buildExecutableStructureFromString\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Builder\\\\ExecutableBuilder\\:\\:isExecutable\\(\\) has parameter \\$executable with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Builder/ExecutableBuilder.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Cache\\\\ArrayCache\\:\\:put\\(\\) has parameter \\$data with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Cache/ArrayCache.php
-
-		-
-			message: "#^Property Altair\\\\Container\\\\Cache\\\\ArrayCache\\:\\:\\$cache type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Cache/ArrayCache.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Cache\\\\FileCache\\:\\:put\\(\\) has parameter \\$data with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Cache/FileCache.php
-
-		-
 			message: "#^Method Altair\\\\Container\\\\Collection\\\\AliasesCollection\\:\\:define\\(\\) should return Altair\\\\Container\\\\Collection\\\\AliasesCollection but returns Altair\\\\Structure\\\\Contracts\\\\MapInterface\\.$#"
-			count: 1
-			path: src/Altair/Container/Collection/AliasesCollection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\AliasesCollection\\:\\:resolve\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Container/Collection/AliasesCollection.php
 
@@ -151,102 +66,12 @@ parameters:
 			path: src/Altair/Container/Collection/SharesCollection.php
 
 		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\SharesCollection\\:\\:shareInstance\\(\\) has parameter \\$instance with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Collection/SharesCollection.php
-
-		-
 			message: "#^Method Altair\\\\Container\\\\Collection\\\\SharesCollection\\:\\:shareInstance\\(\\) return type has no value type specified in iterable type Altair\\\\Structure\\\\Contracts\\\\MapInterface\\.$#"
 			count: 1
 			path: src/Altair/Container/Collection/SharesCollection.php
 
 		-
-			message: "#^Method Altair\\\\Container\\\\Container\\:\\:execute\\(\\) has parameter \\$callableOrMethodString with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Container.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Container\\:\\:isset\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Container.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Container\\:\\:prepareInstance\\(\\) has parameter \\$normalizedClass with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Container.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Container\\:\\:prepareInstance\\(\\) has parameter \\$object with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Container.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Container\\:\\:provisionInstance\\(\\) has parameter \\$normalizedClass with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Container.php
-
-		-
-			message: "#^Property Altair\\\\Container\\\\Container\\:\\:\\$making type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Container.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Contracts\\\\ReflectionInterface\\:\\:getClass\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/Container/Contracts/ReflectionInterface.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:__construct\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:add\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:addDelegate\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:addRaw\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:get\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:getArguments\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:getIndexed\\(\\) has parameter \\$position with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Definition\\:\\:has\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Definition.php
-
-		-
 			message: "#^Call to an undefined method ReflectionFunctionAbstract\\:\\:invokeArgs\\(\\)\\.$#"
-			count: 1
-			path: src/Altair/Container/Executable.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Executable\\:\\:__invoke\\(\\) has parameter \\$args with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Executable.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Executable\\:\\:invokeClosure\\(\\) has parameter \\$args with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Container/Executable.php
 
@@ -259,41 +84,6 @@ parameters:
 			message: "#^Parameter \\#1 \\$reflection of method Altair\\\\Container\\\\Executable\\:\\:invokeClosure\\(\\) expects ReflectionFunction, ReflectionFunctionAbstract given\\.$#"
 			count: 1
 			path: src/Altair/Container/Executable.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\CachedReflection\\:\\:getClass\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/Container/Reflection/CachedReflection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\CachedReflection\\:\\:getFunction\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Reflection/CachedReflection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\CachedReflection\\:\\:getMethod\\(\\) has parameter \\$classNameOrInstance with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Reflection/CachedReflection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\StandardReflection\\:\\:getClass\\(\\) return type with generic class ReflectionClass does not specify its types\\: T$#"
-			count: 1
-			path: src/Altair/Container/Reflection/StandardReflection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\StandardReflection\\:\\:getFunction\\(\\) has parameter \\$name with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Reflection/StandardReflection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\StandardReflection\\:\\:getFunctionParameters\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Container/Reflection/StandardReflection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Reflection\\\\StandardReflection\\:\\:getMethod\\(\\) has parameter \\$classNameOrInstance with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Container/Reflection/StandardReflection.php
 
 		-
 			message: "#^Access to an undefined property Altair\\\\Structure\\\\Contracts\\\\PairInterface\\:\\:\\$value\\.$#"
@@ -346,62 +136,7 @@ parameters:
 			path: src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
 
 		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Action\\:\\:__construct\\(\\) has parameter \\$input with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Action.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Action\\:\\:__construct\\(\\) has parameter \\$responder with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Action.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\InputParser\\:\\:getParsedBody\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/InputParser.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Payload\\:\\:getMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Payload\\:\\:getOutput\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Payload\\:\\:getSetting\\(\\) has parameter \\$default with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Payload\\:\\:withMessages\\(\\) has parameter \\$messages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Payload\\:\\:withOutput\\(\\) has parameter \\$output with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Base\\\\Payload\\:\\:withSetting\\(\\) has parameter \\$value with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
 			message: "#^PHPDoc tag @var for property Altair\\\\Http\\\\Base\\\\Payload\\:\\:\\$settingsCollection with type Altair\\\\Structure\\\\Map\\|null is not subtype of native type Altair\\\\Http\\\\Collection\\\\SettingsCollection\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Base\\\\Payload\\:\\:\\$messages type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Base/Payload.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Base\\\\Payload\\:\\:\\$output type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Http/Base/Payload.php
 
@@ -416,16 +151,6 @@ parameters:
 			path: src/Altair/Http/Collection/HttpStatusCollection.php
 
 		-
-			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:__construct\\(\\) has parameter \\$values with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:buildCommonValues\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
 			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:getIterator\\(\\) return type with generic class ArrayIterator does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/Altair/Http/Collection/HttpStatusCollection.php
@@ -436,27 +161,7 @@ parameters:
 			path: src/Altair/Http/Collection/HttpStatusCollection.php
 
 		-
-			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:mergeAll\\(\\) has parameter \\$values with no value type specified in iterable type Traversable\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:mergeAll\\(\\) has parameter \\$values with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:mergeAll\\(\\) has parameter \\$values with no value type specified in iterable type array\\|Traversable\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
 			message: "#^Parameter \\#1 \\$string of function substr expects string, int given\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:\\$values type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Http/Collection/HttpStatusCollection.php
 
@@ -486,102 +191,12 @@ parameters:
 			path: src/Altair/Http/Configuration/LcobucciTokenConfiguration.php
 
 		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\CredentialsExtractorInterface\\:\\:extract\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/CredentialsExtractorInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\ErrorLoggerInterface\\:\\:log\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/ErrorLoggerInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\HttpAuthRuleInterface\\:\\:__invoke\\(\\) has no return type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/HttpAuthRuleInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\IdentityValidatorInterface\\:\\:__invoke\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/IdentityValidatorInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\OutputFormatterInterface\\:\\:accepts\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/OutputFormatterInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\PayloadInterface\\:\\:getMessages\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/PayloadInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\PayloadInterface\\:\\:getOutput\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/PayloadInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\PayloadInterface\\:\\:withMessages\\(\\) has parameter \\$messages with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/PayloadInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\PayloadInterface\\:\\:withOutput\\(\\) has parameter \\$output with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/PayloadInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\TokenFactoryInterface\\:\\:fromCredentials\\(\\) has parameter \\$credentials with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/TokenFactoryInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Contracts\\\\TokenGeneratorInterface\\:\\:generate\\(\\) has parameter \\$claims with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Contracts/TokenGeneratorInterface.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Exception\\\\AuthorizationException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Exception/AuthorizationException.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Exception\\\\AuthorizationTokenException\\:\\:__construct\\(\\) has parameter \\$message with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Exception/AuthorizationTokenException.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Formatter\\\\AbstractHtmlFormatter\\:\\:accepts\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Formatter/AbstractHtmlFormatter.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Formatter\\\\JsonFormatter\\:\\:accepts\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Formatter/JsonFormatter.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Formatter\\\\PhpViewFormatter\\:\\:renderLayout\\(\\) has parameter \\$content with no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Formatter/PhpViewFormatter.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Formatter\\\\PhpViewFormatter\\:\\:renderPhpFile\\(\\) has parameter \\$params with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Formatter/PhpViewFormatter.php
-
-		-
 			message: "#^Cannot cast Lcobucci\\\\JWT\\\\UnencryptedToken to string\\.$#"
 			count: 1
 			path: src/Altair/Http/Jwt/LcobucciTokenGenerator.php
 
 		-
 			message: "#^Cannot instantiate interface Lcobucci\\\\JWT\\\\Signer\\\\Key\\.$#"
-			count: 1
-			path: src/Altair/Http/Jwt/LcobucciTokenGenerator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Jwt\\\\LcobucciTokenGenerator\\:\\:generate\\(\\) has parameter \\$claims with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Http/Jwt/LcobucciTokenGenerator.php
 
@@ -621,36 +236,6 @@ parameters:
 			path: src/Altair/Http/Jwt/LcobucciTokenParser.php
 
 		-
-			message: "#^Method Altair\\\\Http\\\\Middleware\\\\BasicAuthenticationMiddleware\\:\\:initAuthentication\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/BasicAuthenticationMiddleware.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Middleware\\\\BasicAuthenticationMiddleware\\:\\:\\$allowed type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/BasicAuthenticationMiddleware.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Middleware\\\\CsrfMiddleware\\:\\:getIps\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/CsrfMiddleware.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Middleware\\\\DigestAuthenticationMiddleware\\:\\:initAuthentication\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/DigestAuthenticationMiddleware.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Middleware\\\\DigestAuthenticationMiddleware\\:\\:\\$allowed type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/DigestAuthenticationMiddleware.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Middleware\\\\FormContentMiddleware\\:\\:parse\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/FormContentMiddleware.php
-
-		-
 			message: "#^Offset 'domain' on array\\{lifetime\\: int\\<0, max\\>, path\\: non\\-falsy\\-string, domain\\: string, secure\\: bool, httponly\\: bool, samesite\\: string\\} on left side of \\?\\? always exists and is not nullable\\.$#"
 			count: 1
 			path: src/Altair/Http/Middleware/SessionHeadersMiddleware.php
@@ -671,84 +256,9 @@ parameters:
 			path: src/Altair/Http/Middleware/SessionHeadersMiddleware.php
 
 		-
-			message: "#^Method Altair\\\\Http\\\\Middleware\\\\TokenAuthenticationMiddleware\\:\\:initAuthentication\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/TokenAuthenticationMiddleware.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Middleware\\\\TokenAuthenticationMiddleware\\:\\:\\$allowed type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Middleware/TokenAuthenticationMiddleware.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\CompoundResponder\\:\\:__construct\\(\\) has parameter \\$responders with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/CompoundResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\CompoundResponder\\:\\:filterResponders\\(\\) has parameter \\$responders with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/CompoundResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\CompoundResponder\\:\\:filterResponders\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/CompoundResponder.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Responder\\\\CompoundResponder\\:\\:\\$responders type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/CompoundResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\FormattedResponder\\:\\:__construct\\(\\) has parameter \\$formatters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/FormattedResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\FormattedResponder\\:\\:filterFormatters\\(\\) has parameter \\$formatters with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/FormattedResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\FormattedResponder\\:\\:filterFormatters\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/FormattedResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Responder\\\\FormattedResponder\\:\\:priorities\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/FormattedResponder.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Responder\\\\FormattedResponder\\:\\:\\$formatters type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Responder/FormattedResponder.php
-
-		-
 			message: "#^Parameter \\#1 \\$reason of method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:getStatusCode\\(\\) expects string, int\\|null given\\.$#"
 			count: 1
 			path: src/Altair/Http/Responder/StatusResponder.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Rule\\\\RequestMethodRule\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Rule/RequestMethodRule.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Rule\\\\RequestMethodRule\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Rule/RequestMethodRule.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Rule\\\\RequestPathRule\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Rule/RequestPathRule.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Support\\\\BodyCredentialsExtractor\\:\\:extract\\(\\) return type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Support/BodyCredentialsExtractor.php
 
 		-
 			message: "#^PHPDoc tag @return with type resource is incompatible with native type GdImage\\|false\\.$#"
@@ -756,79 +266,9 @@ parameters:
 			path: src/Altair/Http/Support/DefaultErrorHandler.php
 
 		-
-			message: "#^Property Altair\\\\Http\\\\Support\\\\DefaultErrorHandler\\:\\:\\$handlers has no type specified\\.$#"
-			count: 1
-			path: src/Altair/Http/Support/DefaultErrorHandler.php
-
-		-
 			message: "#^Call to an undefined method Negotiation\\\\AcceptHeader\\:\\:getValue\\(\\)\\.$#"
 			count: 1
 			path: src/Altair/Http/Support/FormatNegotiator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Support\\\\FormatNegotiator\\:\\:negotiateHeader\\(\\) has parameter \\$priorities with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Support/FormatNegotiator.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Support\\\\FormatNegotiator\\:\\:\\$formats type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Support/FormatNegotiator.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Support\\\\MimeType\\:\\:\\$mimeTypes type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Support/MimeType.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Support\\\\Token\\:\\:__construct\\(\\) has parameter \\$metadata with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Support/Token.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Validator\\\\ArrayIdentityValidator\\:\\:__construct\\(\\) has parameter \\$users with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/ArrayIdentityValidator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Validator\\\\ArrayIdentityValidator\\:\\:__invoke\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/ArrayIdentityValidator.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Validator\\\\ArrayIdentityValidator\\:\\:\\$users type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/ArrayIdentityValidator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Validator\\\\DigestSignatureValidator\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/DigestSignatureValidator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Validator\\\\DigestSignatureValidator\\:\\:__invoke\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/DigestSignatureValidator.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Validator\\\\DigestSignatureValidator\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/DigestSignatureValidator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Validator\\\\RepositoryIdentityValidator\\:\\:__construct\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/RepositoryIdentityValidator.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Validator\\\\RepositoryIdentityValidator\\:\\:__invoke\\(\\) has parameter \\$arguments with no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/RepositoryIdentityValidator.php
-
-		-
-			message: "#^Property Altair\\\\Http\\\\Validator\\\\RepositoryIdentityValidator\\:\\:\\$options type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Http/Validator/RepositoryIdentityValidator.php
 
 		-
 			message: "#^Method Altair\\\\Messaging\\\\Configuration\\\\MessengerConfiguration\\:\\:collectTransportFactories\\(\\) return type with generic interface Symfony\\\\Component\\\\Messenger\\\\Transport\\\\TransportFactoryInterface does not specify its types\\: TTransport$#"

--- a/src/Altair/Container/Builder/ArgumentsBuilder.php
+++ b/src/Altair/Container/Builder/ArgumentsBuilder.php
@@ -28,8 +28,11 @@ class ArgumentsBuilder implements BuilderInterface
     public function __construct(protected Container $container) {}
 
     /**
+     * @param ReflectionParameter[]|null $reflectionParameters
+     *
      * @throws InjectionException
      * @throws ReflectionException
+     * @return list<mixed>
      */
     public function build(
         ReflectionFunctionAbstract $reflectionFunction,
@@ -127,12 +130,10 @@ class ArgumentsBuilder implements BuilderInterface
     }
 
     /**
-     * @param $callableOrMethodString
-     *
      * @throws InjectionException
      * @return mixed
      */
-    protected function buildArgumentFromDelegate(string $name, $callableOrMethodString)
+    protected function buildArgumentFromDelegate(string $name, mixed $callableOrMethodString)
     {
         if ($this->container->getExecutableBuilder()->isExecutable($callableOrMethodString) === false) {
             throw new InjectionException(\sprintf("Unable to create argument '%s' from delegate.", $name));
@@ -144,6 +145,8 @@ class ArgumentsBuilder implements BuilderInterface
     }
 
     /**
+     * @param array{0: string, 1: array<string, mixed>|Definition} $definition
+     *
      * @throws InjectionException
      * @throws ReflectionException
      * @return mixed|object|null

--- a/src/Altair/Container/Builder/ExecutableBuilder.php
+++ b/src/Altair/Container/Builder/ExecutableBuilder.php
@@ -18,6 +18,7 @@ use Altair\Container\Executable;
 use Closure;
 use Override;
 use ReflectionException;
+use ReflectionFunctionAbstract;
 
 class ExecutableBuilder implements ExecutableBuilderInterface
 {
@@ -40,7 +41,7 @@ class ExecutableBuilder implements ExecutableBuilderInterface
      * @inheritDoc
      */
     #[Override]
-    public function isExecutable($executable): bool
+    public function isExecutable(mixed $executable): bool
     {
         return \is_callable($executable)
             || (\is_string($executable) && method_exists($executable, '__invoke'))
@@ -50,11 +51,10 @@ class ExecutableBuilder implements ExecutableBuilderInterface
     }
 
     /**
-     * @param $callableOrMethodString
-     *
      * @throws InjectionException
+     * @return array{0: ReflectionFunctionAbstract, 1: object|null}
      */
-    protected function buildExecutableStructure($callableOrMethodString): array
+    protected function buildExecutableStructure(mixed $callableOrMethodString): array
     {
         try {
             if (\is_string($callableOrMethodString)) {
@@ -83,6 +83,7 @@ class ExecutableBuilder implements ExecutableBuilderInterface
 
     /**
      * @throws InjectionException
+     * @return array{0: ReflectionFunctionAbstract, 1: object|null}
      */
     protected function buildExecutableStructureFromString(string $executableString): array
     {
@@ -104,18 +105,17 @@ class ExecutableBuilder implements ExecutableBuilderInterface
     }
 
     /**
-     * @param $class
-     * @param $method
      * @throws InjectionException
+     * @return array{0: ReflectionFunctionAbstract, 1: object|null}
      */
-    protected function buildExecutableStructureFromClassMethodCallable($class, $method): array
+    protected function buildExecutableStructureFromClassMethodCallable(string $class, string $method): array
     {
-        $relativeStaticMethodStartPos = strpos((string) $method, 'parent::');
+        $relativeStaticMethodStartPos = strpos($method, 'parent::');
 
         if ($relativeStaticMethodStartPos === 0) {
             $childReflection = $this->container->getReflector()->getClass($class);
             $class = $childReflection->getParentClass()->name;
-            $method = substr((string) $method, 8);
+            $method = substr($method, 8);
         }
 
         [$className] = $this->container->getAliases()->resolve($class);
@@ -135,7 +135,10 @@ class ExecutableBuilder implements ExecutableBuilderInterface
     }
 
     /**
+     * @param array{0: object|string, 1: string} $executableArray
+     *
      * @throws InjectionException
+     * @return array{0: ReflectionFunctionAbstract, 1: object|null}
      */
     protected function buildExecutableStructureFromArray(array $executableArray): array
     {

--- a/src/Altair/Container/Cache/ArrayCache.php
+++ b/src/Altair/Container/Cache/ArrayCache.php
@@ -17,7 +17,7 @@ use Override;
 class ArrayCache implements ReflectionCacheInterface
 {
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $cache = [];
 
@@ -35,7 +35,7 @@ class ArrayCache implements ReflectionCacheInterface
      * @inheritDoc
      */
     #[Override]
-    public function put(string $key, $data): ReflectionCacheInterface
+    public function put(string $key, mixed $data): ReflectionCacheInterface
     {
         $this->cache[$key] = $data;
 

--- a/src/Altair/Container/Cache/FileCache.php
+++ b/src/Altair/Container/Cache/FileCache.php
@@ -50,7 +50,7 @@ class FileCache implements ReflectionCacheInterface
      * @inheritDoc
      */
     #[Override]
-    public function put(string $key, $data): ReflectionCacheInterface
+    public function put(string $key, mixed $data): ReflectionCacheInterface
     {
         $value = var_export($data, true);
         // HHVM fails at __set_state, so just use object cast for now

--- a/src/Altair/Container/Collection/AliasesCollection.php
+++ b/src/Altair/Container/Collection/AliasesCollection.php
@@ -56,6 +56,9 @@ class AliasesCollection extends Map
         return $this->put($original, $alias);
     }
 
+    /**
+     * @return array{0: string, 1: string}
+     */
     public function resolve(string $name): array
     {
         $normalizedName = $this->normalizeName($name);

--- a/src/Altair/Container/Collection/SharesCollection.php
+++ b/src/Altair/Container/Collection/SharesCollection.php
@@ -27,11 +27,7 @@ class SharesCollection extends Map
         return $this->put($normalizedName, $this[$normalizedName] ?? null);
     }
 
-    /**
-     * @param $instance
-     *
-     */
-    public function shareInstance($instance, AliasesCollection $aliasesCollection): MapInterface
+    public function shareInstance(object $instance, AliasesCollection $aliasesCollection): MapInterface
     {
         $normalizedName = $this->normalizeName($instance::class);
         if (isset($aliasesCollection[$normalizedName])) {

--- a/src/Altair/Container/Container.php
+++ b/src/Altair/Container/Container.php
@@ -50,7 +50,7 @@ class Container implements ContainerInterface
     protected DelegatesCollection $delegates;
 
     /**
-     * @var array
+     * @var array<string, int>
      */
     protected $making = [];
 
@@ -293,11 +293,10 @@ class Container implements ContainerInterface
     /**
      * Invoke the specified callable or class::method string, provisioning dependencies along the way
      *
-     * @param $callableOrMethodString
      * @throws InjectionException
      * @throws ReflectionException
      */
-    public function execute($callableOrMethodString, ?Definition $definition = null): mixed
+    public function execute(mixed $callableOrMethodString, ?Definition $definition = null): mixed
     {
         $executable = $this->executableBuilder->build($callableOrMethodString);
         $definition ??= new Definition([]);
@@ -346,10 +345,7 @@ class Container implements ContainerInterface
         return $this->prepares;
     }
 
-    /**
-     * @param $name
-     */
-    public function isset($name): bool
+    public function isset(string $name): bool
     {
         $name = $this->normalizeName($name);
 
@@ -369,13 +365,10 @@ class Container implements ContainerInterface
     }
 
     /**
-     * @param $object
-     * @param $normalizedClass
-     *
      * @throws InjectionException
      * @return mixed
      */
-    protected function prepareInstance($object, $normalizedClass)
+    protected function prepareInstance(mixed $object, string $normalizedClass)
     {
         if (isset($this->prepares[$normalizedClass])) {
             $callableOrMethodString = $this->prepares->get($normalizedClass);
@@ -416,13 +409,10 @@ class Container implements ContainerInterface
     }
 
     /**
-     * @param $className
-     * @param $normalizedClass
-     *
      * @throws InjectionException
      * @return mixed|object
      */
-    protected function provisionInstance(string $className, $normalizedClass, Definition $definition)
+    protected function provisionInstance(string $className, string $normalizedClass, Definition $definition)
     {
         try {
             $constructor = $this->reflector->getConstructor($className);

--- a/src/Altair/Container/Contracts/ReflectionInterface.php
+++ b/src/Altair/Container/Contracts/ReflectionInterface.php
@@ -22,7 +22,7 @@ interface ReflectionInterface
     /**
      * Retrieves ReflectionClass instances, caching them for future retrieval
      *
-     *
+     * @return ReflectionClass<object>
      */
     public function getClass(string $class): ReflectionClass;
 

--- a/src/Altair/Container/Definition.php
+++ b/src/Altair/Container/Definition.php
@@ -23,6 +23,8 @@ class Definition
 
     /**
      * Definition constructor.
+     *
+     * @param array<int|string, mixed> $arguments
      */
     public function __construct(protected array $arguments) {}
 
@@ -31,36 +33,27 @@ class Definition
         return new self(array_replace($definition->getArguments(), $this->arguments));
     }
 
+    /**
+     * @return array<int|string, mixed>
+     */
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * @param $value
-     *
-     */
-    public function add(string $key, $value): Definition
+    public function add(string $key, mixed $value): Definition
     {
         $this->arguments[$key] = $value;
 
         return $this;
     }
 
-    /**
-     * @param $value
-     *
-     */
-    public function addRaw(string $key, $value): Definition
+    public function addRaw(string $key, mixed $value): Definition
     {
         return $this->add(self::RAW_PREFIX . $key, $value);
     }
 
-    /**
-     * @param $value
-     *
-     */
-    public function addDelegate(string $key, $value): Definition
+    public function addDelegate(string $key, mixed $value): Definition
     {
         return $this->add(self::DELEGATE_PREFIX . $key, $value);
     }
@@ -70,10 +63,7 @@ class Definition
         return isset($this->arguments[$position]) || \array_key_exists($position, $this->arguments);
     }
 
-    /**
-     * @param $name
-     */
-    public function has($name): bool
+    public function has(string $name): bool
     {
         return isset($this->arguments[$name]) || \array_key_exists($name, $this->arguments);
     }
@@ -103,21 +93,17 @@ class Definition
     }
 
     /**
-     * @param $position
-     *
      * @return mixed
      */
-    public function getIndexed($position)
+    public function getIndexed(int $position)
     {
         return $this->arguments[$position];
     }
 
     /**
-     * @param $name
-     *
      * @return mixed
      */
-    public function get($name)
+    public function get(string $name)
     {
         if (!\array_key_exists($name, $this->arguments) && !isset($this->arguments[$name])) {
             throw new OutOfBoundsException(\sprintf("'%s' not found in definition.", $name));

--- a/src/Altair/Container/Executable.php
+++ b/src/Altair/Container/Executable.php
@@ -49,7 +49,7 @@ class Executable
     /**
      * @return mixed
      */
-    public function __invoke(...$args)
+    public function __invoke(mixed ...$args)
     {
         $reflection = $this->callableReflection;
         if ($reflection instanceof ReflectionMethod) {
@@ -88,7 +88,7 @@ class Executable
 
     /**
      * @param ReflectionFunction|ReflectionFunctionAbstract $reflection
-     *
+     * @param array<int, mixed> $args
      */
     protected function invokeClosure(ReflectionFunction $reflection, array $args): mixed
     {

--- a/src/Altair/Container/Reflection/CachedReflection.php
+++ b/src/Altair/Container/Reflection/CachedReflection.php
@@ -41,6 +41,7 @@ class CachedReflection implements ReflectionInterface
      * @inheritDoc
      *
      * @throws ReflectionException
+     * @return ReflectionClass<object>
      */
     #[Override]
     public function getClass(string $class): ReflectionClass
@@ -142,7 +143,7 @@ class CachedReflection implements ReflectionInterface
      * @throws ReflectionException
      */
     #[Override]
-    public function getFunction($name): ReflectionFunction
+    public function getFunction(mixed $name): ReflectionFunction
     {
         $key = \is_string($name)
             ? ReflectionCacheInterface::FUNCTIONS_KEY_PREFIX . strtolower($name)
@@ -164,7 +165,7 @@ class CachedReflection implements ReflectionInterface
      * @throws ReflectionException
      */
     #[Override]
-    public function getMethod($classNameOrInstance, string $methodName): ReflectionMethod
+    public function getMethod(mixed $classNameOrInstance, string $methodName): ReflectionMethod
     {
         $className = \is_string($classNameOrInstance)
             ? $classNameOrInstance

--- a/src/Altair/Container/Reflection/StandardReflection.php
+++ b/src/Altair/Container/Reflection/StandardReflection.php
@@ -26,6 +26,7 @@ class StandardReflection implements ReflectionInterface
     /**
      * @inheritDoc
      * @throws ReflectionException
+     * @return ReflectionClass<object>
      */
     #[Override]
     public function getClass(string $class): ReflectionClass
@@ -78,13 +79,15 @@ class StandardReflection implements ReflectionInterface
      * @throws ReflectionException
      */
     #[Override]
-    public function getFunction($name): ReflectionFunction
+    public function getFunction(mixed $name): ReflectionFunction
     {
         return new ReflectionFunction($name);
     }
 
     /**
      * @inheritDoc
+     *
+     * @return ReflectionParameter[]|null
      */
     public function getFunctionParameters(ReflectionFunction $reflectionFunction): ?array
     {
@@ -96,7 +99,7 @@ class StandardReflection implements ReflectionInterface
      * @throws ReflectionException
      */
     #[Override]
-    public function getMethod($classNameOrInstance, string $methodName): ReflectionMethod
+    public function getMethod(mixed $classNameOrInstance, string $methodName): ReflectionMethod
     {
         $className = \is_string($classNameOrInstance)
             ? $classNameOrInstance

--- a/src/Altair/Http/Base/Action.php
+++ b/src/Altair/Http/Base/Action.php
@@ -32,6 +32,8 @@ class Action
     /**
      * @inheritDoc
      * @param string $domain
+     * @param string|null $responder class name of \Altair\Http\Contracts\ResponderInterface
+     * @param string|null $input class name of \Altair\Http\Contracts\InputInterface
      */
     public function __construct(
         /**

--- a/src/Altair/Http/Base/InputParser.php
+++ b/src/Altair/Http/Base/InputParser.php
@@ -40,6 +40,9 @@ class InputParser implements InputInterface
         return $this->inputCollection;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     protected function getParsedBody(ServerRequestInterface $request): array
     {
         $body = $request->getParsedBody();

--- a/src/Altair/Http/Base/Payload.php
+++ b/src/Altair/Http/Base/Payload.php
@@ -27,12 +27,12 @@ class Payload implements PayloadInterface
     protected InputCollection $inputCollection;
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $output = [];
 
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     protected $messages = [];
 
@@ -94,6 +94,7 @@ class Payload implements PayloadInterface
 
     /**
      * @inheritDoc
+     * @param array<string, mixed> $output
      */
     #[Override]
     public function withOutput(array $output): PayloadInterface
@@ -106,6 +107,7 @@ class Payload implements PayloadInterface
 
     /**
      * @inheritDoc
+     * @return array<string, mixed>
      */
     #[Override]
     public function getOutput(): array
@@ -115,6 +117,7 @@ class Payload implements PayloadInterface
 
     /**
      * @inheritDoc
+     * @param array<string, mixed> $messages
      */
     #[Override]
     public function withMessages(array $messages): PayloadInterface
@@ -127,6 +130,7 @@ class Payload implements PayloadInterface
 
     /**
      * @inheritDoc
+     * @return array<string, mixed>
      */
     #[Override]
     public function getMessages(): array
@@ -136,6 +140,7 @@ class Payload implements PayloadInterface
 
     /**
      * @inheritDoc
+     * @param mixed $value
      */
     #[Override]
     public function withSetting(string $name, $value): PayloadInterface
@@ -172,6 +177,7 @@ class Payload implements PayloadInterface
 
     /**
      * @inheritDoc
+     * @param mixed $default
      */
     #[Override]
     public function getSetting(string $name, $default = null)

--- a/src/Altair/Http/Collection/HttpStatusCollection.php
+++ b/src/Altair/Http/Collection/HttpStatusCollection.php
@@ -25,12 +25,15 @@ use Traversable;
 class HttpStatusCollection implements Countable, IteratorAggregate
 {
     /**
-     * @var array of status codes and texts
+     * Status codes and their reason phrases.
+     *
+     * @var array<int, string>
      */
     protected $values;
 
     /**
      * @inheritDoc
+     * @param array<int, string>|Traversable<int, string> $values
      */
     public function __construct($values = [])
     {
@@ -164,7 +167,7 @@ class HttpStatusCollection implements Countable, IteratorAggregate
     /**
      * Merges an array of status codes and its reason phrase into the default values.
      *
-     * @param array|Traversable $values
+     * @param array<int, string>|Traversable<int, string> $values
      */
     public function mergeAll($values): void
     {
@@ -182,6 +185,8 @@ class HttpStatusCollection implements Countable, IteratorAggregate
      *
      * @see HttpStatusInterface
      * @see HttpStatusCodeInterface
+     *
+     * @return array<int, string>
      */
     protected function buildCommonValues(): array
     {

--- a/src/Altair/Http/Contracts/CredentialsExtractorInterface.php
+++ b/src/Altair/Http/Contracts/CredentialsExtractorInterface.php
@@ -18,7 +18,7 @@ interface CredentialsExtractorInterface
     /**
      * Returns the credentials within the request (if any).
      *
-     *
+     * @return array<array-key, mixed>|null
      */
     public function extract(ServerRequestInterface $request): ?array;
 }

--- a/src/Altair/Http/Contracts/ErrorLoggerInterface.php
+++ b/src/Altair/Http/Contracts/ErrorLoggerInterface.php
@@ -24,5 +24,5 @@ interface ErrorLoggerInterface
      *
      * @param Exception|Error $error
      */
-    public function log($error);
+    public function log($error): void;
 }

--- a/src/Altair/Http/Contracts/HttpAuthRuleInterface.php
+++ b/src/Altair/Http/Contracts/HttpAuthRuleInterface.php
@@ -15,5 +15,5 @@ use Psr\Http\Message\ServerRequestInterface;
 
 interface HttpAuthRuleInterface
 {
-    public function __invoke(ServerRequestInterface $request);
+    public function __invoke(ServerRequestInterface $request): bool;
 }

--- a/src/Altair/Http/Contracts/IdentityValidatorInterface.php
+++ b/src/Altair/Http/Contracts/IdentityValidatorInterface.php
@@ -14,6 +14,7 @@ namespace Altair\Http\Contracts;
 interface IdentityValidatorInterface
 {
     /**
+     * @param array<string, mixed> $arguments
      * @return bool
      */
     public function __invoke(array $arguments);

--- a/src/Altair/Http/Contracts/OutputFormatterInterface.php
+++ b/src/Altair/Http/Contracts/OutputFormatterInterface.php
@@ -15,6 +15,8 @@ interface OutputFormatterInterface
 {
     /**
      * Get the content types that this formatter can satisfy.
+     *
+     * @return list<string>
      */
     public static function accepts(): array;
 

--- a/src/Altair/Http/Contracts/PayloadInterface.php
+++ b/src/Altair/Http/Contracts/PayloadInterface.php
@@ -49,24 +49,28 @@ interface PayloadInterface extends HttpStatusInterface
     /**
      * Create a copy of the payload with output array.
      *
-     *
+     * @param array<string, mixed> $output
      */
     public function withOutput(array $output): PayloadInterface;
 
     /**
      * Get output array from the payload.
+     *
+     * @return array<string, mixed>
      */
     public function getOutput(): array;
 
     /**
      * Create a copy of the payload with messages array.
      *
-     *
+     * @param array<string, mixed> $messages
      */
     public function withMessages(array $messages): PayloadInterface;
 
     /**
      * Get messages array from the payload.
+     *
+     * @return array<string, mixed>
      */
     public function getMessages(): array;
 

--- a/src/Altair/Http/Contracts/TokenFactoryInterface.php
+++ b/src/Altair/Http/Contracts/TokenFactoryInterface.php
@@ -36,6 +36,8 @@ interface TokenFactoryInterface
      *
      *
      * @see TokenAuthenticationMiddleware::__invoke()
+     *
+     * @param array<string, mixed> $credentials
      */
     public function fromCredentials(array $credentials): TokenInterface;
 }

--- a/src/Altair/Http/Contracts/TokenGeneratorInterface.php
+++ b/src/Altair/Http/Contracts/TokenGeneratorInterface.php
@@ -16,7 +16,7 @@ interface TokenGeneratorInterface
     /**
      * Generates a JWT authentication token string
      *
-     *
+     * @param array<string, mixed> $claims
      */
     public function generate(array $claims = []): string;
 }

--- a/src/Altair/Http/Exception/AuthorizationException.php
+++ b/src/Altair/Http/Exception/AuthorizationException.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class AuthorizationException extends HttpException
 {
-    public function __construct($message = "", ?Throwable $previous = null)
+    public function __construct(string $message = "", ?Throwable $previous = null)
     {
         parent::__construct($message, HttpStatusCodeInterface::HTTP_UNAUTHORIZED, $previous);
     }

--- a/src/Altair/Http/Exception/AuthorizationTokenException.php
+++ b/src/Altair/Http/Exception/AuthorizationTokenException.php
@@ -16,7 +16,7 @@ use Throwable;
 
 class AuthorizationTokenException extends HttpException
 {
-    public function __construct($message = "", ?Throwable $previous = null)
+    public function __construct(string $message = "", ?Throwable $previous = null)
     {
         parent::__construct($message, HttpStatusCodeInterface::HTTP_FORBIDDEN, $previous);
     }

--- a/src/Altair/Http/Formatter/AbstractHtmlFormatter.php
+++ b/src/Altair/Http/Formatter/AbstractHtmlFormatter.php
@@ -16,6 +16,9 @@ use Override;
 
 abstract class AbstractHtmlFormatter implements OutputFormatterInterface
 {
+    /**
+     * @return list<string>
+     */
     #[Override]
     public static function accepts(): array
     {

--- a/src/Altair/Http/Formatter/JsonFormatter.php
+++ b/src/Altair/Http/Formatter/JsonFormatter.php
@@ -29,6 +29,7 @@ class JsonFormatter implements OutputFormatterInterface
 
     /**
      * @inheritDoc
+     * @return list<string>
      */
     #[Override]
     public static function accepts(): array

--- a/src/Altair/Http/Formatter/PhpViewFormatter.php
+++ b/src/Altair/Http/Formatter/PhpViewFormatter.php
@@ -65,7 +65,7 @@ class PhpViewFormatter extends AbstractHtmlFormatter
      * Renders the contents to a layout specified within the payload settings. If not layout is found, it will use the
      * one configured.
      *
-     * @param $content
+     * @param string $content
      *
      *
      * @see PhpViewConfiguration::apply()
@@ -92,6 +92,7 @@ class PhpViewFormatter extends AbstractHtmlFormatter
     /**
      * Renders a view file as a PHP script.
      *
+     * @param array<string, mixed> $params
      *
      * @throws Exception
      * @throws Throwable

--- a/src/Altair/Http/Jwt/LcobucciTokenGenerator.php
+++ b/src/Altair/Http/Jwt/LcobucciTokenGenerator.php
@@ -28,6 +28,7 @@ class LcobucciTokenGenerator implements TokenGeneratorInterface
 
     /**
      * @inheritDoc
+     * @param array<string, mixed> $claims
      */
     #[Override]
     public function generate(array $claims = []): string

--- a/src/Altair/Http/Middleware/FormContentMiddleware.php
+++ b/src/Altair/Http/Middleware/FormContentMiddleware.php
@@ -21,6 +21,9 @@ class FormContentMiddleware extends AbstractContentHandlerMiddleware
         return ['application/x-www-form-urlencoded'];
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     #[Override]
     protected function parse(string $body): array
     {

--- a/src/Altair/Http/Responder/CompoundResponder.php
+++ b/src/Altair/Http/Responder/CompoundResponder.php
@@ -23,10 +23,14 @@ class CompoundResponder implements ResponderInterface
 {
     use ResolverAwareTrait;
 
+    /**
+     * @var list<class-string<ResponderInterface>>
+     */
     protected array $responders;
 
     /**
      * @param callable(string): object $resolver
+     * @param list<class-string<ResponderInterface>> $responders
      *
      * @throws InvalidResponderException
      */
@@ -58,9 +62,11 @@ class CompoundResponder implements ResponderInterface
     }
 
     /**
+     * @param list<class-string<ResponderInterface>> $responders
+     *
      *
      * @throws InvalidResponderException
-     *
+     * @return list<class-string<ResponderInterface>>
      */
     protected function filterResponders(array $responders): array
     {

--- a/src/Altair/Http/Responder/FormattedResponder.php
+++ b/src/Altair/Http/Responder/FormattedResponder.php
@@ -27,10 +27,14 @@ class FormattedResponder implements ResponderInterface
 {
     use ResolverAwareTrait;
 
+    /**
+     * @var array<class-string<OutputFormatterInterface>, float>
+     */
     protected array $formatters;
 
     /**
      * @param callable(string): object $resolver
+     * @param array<class-string<OutputFormatterInterface>, float> $formatters
      */
     public function __construct(
         protected Negotiator $negotiator,
@@ -66,6 +70,11 @@ class FormattedResponder implements ResponderInterface
         return $cloned;
     }
 
+    /**
+     * @param array<class-string<OutputFormatterInterface>, float> $formatters
+     *
+     * @return array<class-string<OutputFormatterInterface>, float>
+     */
     protected function filterFormatters(array $formatters): array
     {
         $filtered = [];
@@ -86,6 +95,8 @@ class FormattedResponder implements ResponderInterface
 
     /**
      * Retrieve a map of accepted priorities with the responsible formatter.
+     *
+     * @return array<string, class-string<OutputFormatterInterface>>
      */
     protected function priorities(): array
     {

--- a/src/Altair/Http/Rule/RequestMethodRule.php
+++ b/src/Altair/Http/Rule/RequestMethodRule.php
@@ -17,12 +17,17 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class RequestMethodRule implements HttpAuthRuleInterface
 {
+    /**
+     * @var array<string, list<string>>
+     */
     protected array $options = [
         'passthrough' => ['OPTIONS'],
     ];
 
     /**
      * RequestMethodRule constructor.
+     *
+     * @param array<string, list<string>>|null $options
      */
     public function __construct(?array $options = null)
     {

--- a/src/Altair/Http/Rule/RequestPathRule.php
+++ b/src/Altair/Http/Rule/RequestPathRule.php
@@ -17,6 +17,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class RequestPathRule implements HttpAuthRuleInterface
 {
+    /**
+     * @var array<string, list<string>>
+     */
     protected array $options = [
         'path' => ['/'],
         'passthrough' => [],

--- a/src/Altair/Http/Support/BodyCredentialsExtractor.php
+++ b/src/Altair/Http/Support/BodyCredentialsExtractor.php
@@ -27,6 +27,7 @@ class BodyCredentialsExtractor implements CredentialsExtractorInterface
 
     /**
      * @inheritDoc
+     * @return array<string, mixed>|null
      */
     #[Override]
     public function extract(ServerRequestInterface $request): ?array

--- a/src/Altair/Http/Support/DefaultErrorHandler.php
+++ b/src/Altair/Http/Support/DefaultErrorHandler.php
@@ -21,6 +21,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class DefaultErrorHandler implements ErrorHandlerInterface
 {
+    /**
+     * @var array<string, list<string>>
+     */
     protected $handlers = [
         'plain' => [
             'text/plain',

--- a/src/Altair/Http/Support/FormatNegotiator.php
+++ b/src/Altair/Http/Support/FormatNegotiator.php
@@ -22,8 +22,10 @@ use Psr\Http\Message\ServerRequestInterface;
 class FormatNegotiator implements FormatNegotiatorInterface
 {
     /**
-     * @var array Available formats with the mime types
+     * Available formats with the mime types
      * - Thanks oscarotero/psr7-middlewares
+     *
+     * @var array<string, array{0: list<string>, 1: list<string>}>
      */
     protected $formats = [
         //text
@@ -140,7 +142,7 @@ class FormatNegotiator implements FormatNegotiatorInterface
     /**
      * Returns the best format value for server request header.
      *
-     *
+     * @param list<string> $priorities
      */
     protected function negotiateHeader(string $accept, array $priorities): ?string
     {

--- a/src/Altair/Http/Support/MimeType.php
+++ b/src/Altair/Http/Support/MimeType.php
@@ -22,7 +22,9 @@ class MimeType
     public const DEFAULT_MIME_TYPE = 'application/octet-stream';
 
     /**
-     * @var array of mime types according to file extensions
+     * Mime types according to file extensions.
+     *
+     * @var array<string, string>
      */
     protected $mimeTypes = [
         '3dml' => 'text/vnd.in3d.3dml',

--- a/src/Altair/Http/Support/Token.php
+++ b/src/Altair/Http/Support/Token.php
@@ -21,6 +21,7 @@ class Token implements TokenInterface
      *
      * @param $token
      * @param string $token
+     * @param array<string, mixed> $metadata
      */
     public function __construct(private $token, private array $metadata) {}
 

--- a/src/Altair/Http/Traits/HttpAuthenticationAwareTrait.php
+++ b/src/Altair/Http/Traits/HttpAuthenticationAwareTrait.php
@@ -36,7 +36,7 @@ trait HttpAuthenticationAwareTrait
     protected $ssl;
 
     /**
-     * @var array|string
+     * @var list<string>|string
      */
     protected $allowed;
 
@@ -59,6 +59,7 @@ trait HttpAuthenticationAwareTrait
      * Authentication middleware Constructor.
      *
      * @param HttpAuthRuleInterface[] $rules
+     * @param array<string, mixed>|null $options
      */
     public function __construct(IdentityValidatorInterface $identityValidator, ?array $rules = null, ?array $options = null)
     {

--- a/src/Altair/Http/Traits/IpAddressAwareTrait.php
+++ b/src/Altair/Http/Traits/IpAddressAwareTrait.php
@@ -16,6 +16,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 trait IpAddressAwareTrait
 {
+    /**
+     * @return list<string>|null
+     */
     protected function getIps(ServerRequestInterface $request): ?array
     {
         return $request->getAttribute(MiddlewareInterface::ATTRIBUTE_IP_ADDRESS);

--- a/src/Altair/Http/Validator/ArrayIdentityValidator.php
+++ b/src/Altair/Http/Validator/ArrayIdentityValidator.php
@@ -16,10 +16,15 @@ use Override;
 
 class ArrayIdentityValidator implements IdentityValidatorInterface
 {
+    /**
+     * @var array<string, string>
+     */
     protected array $users;
 
     /**
      * ArrayIdentityValidator constructor.
+     *
+     * @param array<string, string>|null $users
      */
     public function __construct(?array $users = null)
     {
@@ -28,6 +33,7 @@ class ArrayIdentityValidator implements IdentityValidatorInterface
 
     /**
      * @inheritDoc
+     * @param array<string, mixed> $arguments
      */
     #[Override]
     public function __invoke(array $arguments): bool

--- a/src/Altair/Http/Validator/DigestSignatureValidator.php
+++ b/src/Altair/Http/Validator/DigestSignatureValidator.php
@@ -17,10 +17,15 @@ use Override;
 
 class DigestSignatureValidator implements IdentityValidatorInterface
 {
+    /**
+     * @var array<string, string>
+     */
     protected array $options;
 
     /**
      * RepositoryIdentityValidator constructor.
+     *
+     * @param array<string, string>|null $options
      */
     public function __construct(protected QueryRepositoryInterface $repository, ?array $options = null)
     {
@@ -30,6 +35,9 @@ class DigestSignatureValidator implements IdentityValidatorInterface
         $this->options = $options ?? ['username' => 'username', 'password' => 'password'];
     }
 
+    /**
+     * @param array<string, mixed> $arguments
+     */
     #[Override]
     public function __invoke(array $arguments): bool
     {

--- a/src/Altair/Http/Validator/RepositoryIdentityValidator.php
+++ b/src/Altair/Http/Validator/RepositoryIdentityValidator.php
@@ -18,10 +18,15 @@ use Override;
 
 class RepositoryIdentityValidator implements IdentityValidatorInterface
 {
+    /**
+     * @var array<string, string>
+     */
     protected array $options;
 
     /**
      * RepositoryIdentityValidator constructor.
+     *
+     * @param array<string, string>|null $options
      */
     public function __construct(protected QueryRepositoryInterface $repository, ?array $options = null)
     {
@@ -34,6 +39,7 @@ class RepositoryIdentityValidator implements IdentityValidatorInterface
 
     /**
      * @inheritDoc
+     * @param array<string, mixed> $arguments
      */
     #[Override]
     public function __invoke(array $arguments): bool


### PR DESCRIPTION
Fourth chunk of the #96 level-6 burn-down — two parallel per-package passes. Baseline `phpstan-baseline.neon`: **437 → 325 entries (−112)**.

| Package | Before → After | Highlights |
|---|---|---|
| Http | 97 → 27 | request/response attribute + header + parsed-body arrays (`array<string, mixed>` / `array<string, list<string>>`), Payload/Action/responder/formatter/validator/auth-trait shapes, interface return types |
| Container | 48 → 6 | definition/parameter arrays `array<int\|string, mixed>`, executable-structure `array{...}` tuples, `ReflectionClass<object>`, reflection-param lists; `mixed`/`object`/`string` params aligned with interfaces |

**Property safety applied:** Http properties were annotated via `@var` (not native types) to avoid the uninitialised-property breakage that bit the previous chunk — the full suite confirms no runtime regressions this time.

**Good judgment by the Http pass:** `CredentialsExtractorInterface::extract()` typed `array<array-key, mixed>` rather than `array<string, mixed>`, because the stricter type would surface a latent positional destructure (`[$user, $password] = $credentials`) in `TokenAuthenticationMiddleware` — a separate bug, out of scope here. The concrete `BodyCredentialsExtractor` keeps the precise `array<string, mixed>|null` (valid covariant subtype).

**Left behind** (need real code work): Http PSR/subtype conflicts, third-party class-not-found, `MapInterface`-return findings; Container `Executable` `ReflectionFunctionAbstract` subtype findings + collections' non-generic `MapInterface` returns.

Rector then applied two annotation-unlocked cleanups (a redundant cast removal, a useless `@return void` removal).

**Gates:** `composer stan` green (325 baselined, 0 live), CS clean, rector `--dry-run` clean, full suite at the **5 pre-existing** `ext-mongodb`/`ext-memcached` environmental errors.

Part of #96. **Progress: 719 → 325 (55% cleared).** Remaining: **Structure (250)** — the generics design effort, its own PR(s) — plus ~75 code-quality/subtype leftovers spread across packages.