### PR TITLE
re #96 specify generics on Structure consumers

### DIFF
--- a/docs/strategy/ai-driven-strategy.md
+++ b/docs/strategy/ai-driven-strategy.md
@@ -67,8 +67,13 @@ Three pillars:
 2. **Reliability by construction.** Features come from proven, tested,
    reversible spec modules — not freehand generation. Mistakes cost one
    `rewind`.
-3. **You own the code.** Real PHP, real database, exportable, no lock-in. This
-   is the answer to both no-code (lock-in) and JS builders (throwaway).
+3. **You own the outcome — not source-as-a-chore.** For an outcome-seeker,
+   meaningful ownership is *control of the running service* (publish, update,
+   roll back, custom domain, take it down), *your data* (exportable), and the
+   *right to take the code and leave* (the escape hatch that keeps us honest and
+   lock-in-free). They never have to touch the code day-to-day — but they can
+   always claim it. This answers both no-code (lock-in) and the JS builders
+   (throwaway, and you still have to operate it). See §10.
 
 ## 4. The "X, Y, Z features" product: a capability catalog
 
@@ -104,10 +109,12 @@ This reframes the roadmap: **stop building "framework features"; start building
 | 2 | **Intent compiler (Gii-for-AI)**, framework-agnostic | Boilerplate elimination; the Yii lever | A → B substrate | CLI, no lock-in | One spec → CRUD + persistence + OpenAPI + SDK + tests | the 90-second build |
 | 3 | **Stripe payments kit** (builds on #1) | Correct billing plumbing nobody owns generically | A + B | module | Idempotent webhooks, state machine, reconciliation, sandbox | "subscriptions that don't double-charge" |
 | 4 | **MCP "ship a feature" server** (generative + reversible) | Agent operability in *any* project | B | point your agent at it | Agent scaffolds / migrates / rewinds anywhere | agent live-builds an endpoint on camera |
-| 5 | **Capability catalog + composer** ("describe app → working app") | The Tier-B destination | B | hosted / agent-driven | Natural-language app assembly from proven modules | the flagship demo |
+| 5 | **Ship / deploy (reversible)** | "built" isn't "working" until it's reachable; deploy is unowned in the framework world and scary for agents | A + B | `altair ship` / managed publish | Push-button deploy + migrations; **rollback = `rewind` for prod** | "agent ships to a live URL, then rolls back in one command" |
+| 6 | **Capability catalog + composer** ("describe app → working app") | The Tier-B destination | B | hosted / agent-driven | Natural-language app assembly from proven modules | the flagship demo |
 
-**Sequence:** #1 → #2 → (#3 ∥ #4) → #5. Each ships real value and a marketing
-moment on its own; #5 is the synthesis everything builds toward.
+**Sequence:** #1 → #2 → (#3 ∥ #4) → #5 → #6. Each ships real value and a
+marketing moment on its own; #5 (shipping) turns "built" into "live," and #6 is
+the synthesis everything builds toward.
 
 **First move:** #1 (webhook+idempotency+outbox). It's cheap to adopt, broadly
 useful beyond payments, demonstrable in 60 seconds, fills a *real* gap, and is
@@ -152,14 +159,48 @@ purest showcase.
 
 ## 9. Open questions to resolve before building #5
 
-1. **Hosted vs. self-hosted** for the "describe → app" experience? Hosted =
-   monetization + control of the experience; self-hosted = ownership purity.
-   (Likely: hosted experience that *exports* an owned, self-hostable codebase —
-   best of both.)
+1. **Hosted vs. self-hosted** — *resolving toward hybrid.* A hosted "publish it,
+   it's live now" experience (instant gratification + monetization) with a
+   **sacred export escape hatch** to an owned, self-hostable codebase. Tier B
+   owns the running service + data + the right to leave; they don't operate the
+   code day-to-day. Honest constraint: a fully *managed* PaaS is a company-sized
+   build — start by *generating* a deploy pipeline to existing platforms (Fly,
+   Railway, Render, VPS via Docker/IaC), not by building our own cloud. See §10.
 2. **Which five catalog modules ship first?** Decide by "most-requested real app
    features," not by what's easiest to build.
 3. **Brand** for the Tier-B experience — probably distinct from "Altair the
    framework," since Tier B never needs to know the framework's name.
+
+---
+
+## 10. Creation + shipping: deployment as a reversible primitive
+
+A working app nobody can reach isn't working. **"Describe → built → live"** in
+one motion is the whole Tier-B promise — creation and shipping are one flow, not
+two products. Deployment slots into the existing thesis instead of bolting on:
+
+- **Reversible by construction.** A deploy is just another journaled mutation:
+  `ship` records an event; **`rollback` is `rewind` for production.** The agent
+  ships boldly because undo is one command — the property that makes scaffolding
+  safe makes deployment safe.
+- **Both tiers, one engine.** Tier A: `altair ship` deploys an *owned* app to
+  *their* infra (build, migrate, zero-downtime swap, rollback). Tier B: the same
+  engine behind a managed "publish it" button — describe → live, export intact.
+- **Ownership, reframed (Pillar 3).** "They don't own the code, they own the
+  power to publish it" is right for Tier B — *with* the right to claim the code
+  and leave. Operational control + data + escape hatch is the ownership that
+  matters to someone who can't read the source.
+
+**Honest sequencing.** Do **not** start by building a managed PaaS — infra,
+secrets, billing, scaling, on-call, and compliance are a company unto themselves
+and wrong for a solo+agent flagship. Start by *generating* a deploy pipeline
+(Dockerfile + IaC + one `altair ship` command) targeting existing platforms; add
+a thin managed layer or a hosting partnership later, only once demand is proven.
+
+**Security.** Deploy touches secrets and mutates production — both
+outward/high-stakes. Reuse the event log's secret **Scrubber**, require explicit
+confirmation before prod deploys (no silent agent push-to-prod), and keep every
+deploy/rollback in the journal for audit.
 
 ---
 
@@ -171,5 +212,9 @@ making the framework's *operator* an agent. The unclaimed seam is **reliable,
 owned, maintainable AI-built apps** — which our deterministic, reversible,
 spec-driven core is uniquely suited to. Build it as a **catalog of
 agent-installable capability modules**; each module is a cheap developer tool
-*and* a building block for "describe → app." Start with webhook+idempotency, then
-the intent compiler. Honest benchmarks and live demos are the marketing.
+*and* a building block for "describe → app." Creation isn't done until it ships:
+deployment is built in and reversible (**rollback = rewind**), so "describe →
+built → live" is one motion — and for Tier B, ownership means control of the
+running service plus the right to leave, not babysitting source. Start with
+webhook+idempotency, then the intent compiler. Honest benchmarks and live demos
+are the marketing.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -56,64 +56,9 @@ parameters:
 			path: src/Altair/Common/Support/Arr.php
 
 		-
-			message: "#^Class Altair\\\\Configuration\\\\Collection\\\\ConfigurationCollection extends generic class Altair\\\\Structure\\\\Set but does not specify its types\\: TValue$#"
-			count: 1
-			path: src/Altair/Configuration/Collection/ConfigurationCollection.php
-
-		-
-			message: "#^Class Altair\\\\Container\\\\Collection\\\\AliasesCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
+			message: "#^Method Altair\\\\Container\\\\Collection\\\\AliasesCollection\\:\\:define\\(\\) should return Altair\\\\Container\\\\Collection\\\\AliasesCollection but returns Altair\\\\Structure\\\\Contracts\\\\MapInterface\\<string, string\\>\\.$#"
 			count: 1
 			path: src/Altair/Container/Collection/AliasesCollection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\AliasesCollection\\:\\:define\\(\\) should return Altair\\\\Container\\\\Collection\\\\AliasesCollection but returns Altair\\\\Structure\\\\Contracts\\\\MapInterface\\<mixed, mixed\\>\\.$#"
-			count: 1
-			path: src/Altair/Container/Collection/AliasesCollection.php
-
-		-
-			message: "#^Class Altair\\\\Container\\\\Collection\\\\ClassDefinitionsCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/ClassDefinitionsCollection.php
-
-		-
-			message: "#^Class Altair\\\\Container\\\\Collection\\\\DelegatesCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/DelegatesCollection.php
-
-		-
-			message: "#^Class Altair\\\\Container\\\\Collection\\\\ParameterDefinitionsCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/ParameterDefinitionsCollection.php
-
-		-
-			message: "#^Class Altair\\\\Container\\\\Collection\\\\PreparesCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/PreparesCollection.php
-
-		-
-			message: "#^Class Altair\\\\Container\\\\Collection\\\\SharesCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/SharesCollection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\SharesCollection\\:\\:shareClass\\(\\) return type has no value type specified in iterable type Altair\\\\Structure\\\\Contracts\\\\MapInterface\\.$#"
-			count: 1
-			path: src/Altair/Container/Collection/SharesCollection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\SharesCollection\\:\\:shareClass\\(\\) return type with generic interface Altair\\\\Structure\\\\Contracts\\\\MapInterface does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/SharesCollection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\SharesCollection\\:\\:shareInstance\\(\\) return type has no value type specified in iterable type Altair\\\\Structure\\\\Contracts\\\\MapInterface\\.$#"
-			count: 1
-			path: src/Altair/Container/Collection/SharesCollection.php
-
-		-
-			message: "#^Method Altair\\\\Container\\\\Collection\\\\SharesCollection\\:\\:shareInstance\\(\\) return type with generic interface Altair\\\\Structure\\\\Contracts\\\\MapInterface does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Container/Collection/SharesCollection.php
 
 		-
 			message: "#^Call to an undefined method ReflectionFunctionAbstract\\:\\:invokeArgs\\(\\)\\.$#"
@@ -136,72 +81,12 @@ parameters:
 			path: src/Altair/Cookie/Collection/CookieCollection.php
 
 		-
-			message: "#^Generic type Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\> in PHPDoc tag @return specifies 2 template types, but interface Altair\\\\Structure\\\\Contracts\\\\VectorInterface supports only 1\\: TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
-			message: "#^Method Altair\\\\Cookie\\\\Collection\\\\CookieCollection\\:\\:pairsToArray\\(\\) has parameter \\$pairs with generic class Altair\\\\Structure\\\\Pair but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
-			message: "#^Method Altair\\\\Cookie\\\\Collection\\\\CookieCollection\\:\\:values\\(\\) should return Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\> but returns Altair\\\\Structure\\\\Vector\\<mixed\\>\\.$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$pair contains generic class Altair\\\\Structure\\\\Pair but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
-			message: "#^Return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\>\\) of method Altair\\\\Cookie\\\\Collection\\\\CookieCollection\\:\\:values\\(\\) should be compatible with return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<mixed\\>\\) of method Altair\\\\Structure\\\\Contracts\\\\MapInterface\\<mixed,mixed\\>\\:\\:values\\(\\)$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
-			message: "#^Return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\>\\) of method Altair\\\\Cookie\\\\Collection\\\\CookieCollection\\:\\:values\\(\\) should be compatible with return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<mixed\\>\\) of method Altair\\\\Structure\\\\Map\\<mixed,mixed\\>\\:\\:values\\(\\)$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
 			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Altair/Cookie/Collection/CookieCollection.php
 
 		-
 			message: "#^Class Altair\\\\Cookie\\\\Collection\\\\SetCookieCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^Generic type Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\> in PHPDoc tag @return specifies 2 template types, but interface Altair\\\\Structure\\\\Contracts\\\\VectorInterface supports only 1\\: TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^Method Altair\\\\Cookie\\\\Collection\\\\SetCookieCollection\\:\\:pairsToArray\\(\\) has parameter \\$pairs with generic class Altair\\\\Structure\\\\Pair but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^Method Altair\\\\Cookie\\\\Collection\\\\SetCookieCollection\\:\\:values\\(\\) should return Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\> but returns Altair\\\\Structure\\\\Vector\\<mixed\\>\\.$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$pair contains generic class Altair\\\\Structure\\\\Pair but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^Return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\>\\) of method Altair\\\\Cookie\\\\Collection\\\\SetCookieCollection\\:\\:values\\(\\) should be compatible with return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<mixed\\>\\) of method Altair\\\\Structure\\\\Contracts\\\\MapInterface\\<mixed,mixed\\>\\:\\:values\\(\\)$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^Return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<int, string\\|null\\>\\) of method Altair\\\\Cookie\\\\Collection\\\\SetCookieCollection\\:\\:values\\(\\) should be compatible with return type \\(Altair\\\\Structure\\\\Contracts\\\\VectorInterface\\<mixed\\>\\) of method Altair\\\\Structure\\\\Map\\<mixed,mixed\\>\\:\\:values\\(\\)$#"
 			count: 1
 			path: src/Altair/Cookie/Collection/SetCookieCollection.php
 
@@ -246,27 +131,12 @@ parameters:
 			path: src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
 
 		-
-			message: "#^Class Altair\\\\Courier\\\\Support\\\\MessageCommandMap extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Courier/Support/MessageCommandMap.php
-
-		-
 			message: "#^PHPDoc tag @var for property Altair\\\\Http\\\\Base\\\\Payload\\:\\:\\$settingsCollection with type Altair\\\\Structure\\\\Map\\|null is not subtype of native type Altair\\\\Http\\\\Collection\\\\SettingsCollection\\.$#"
 			count: 1
 			path: src/Altair/Http/Base/Payload.php
 
 		-
-			message: "#^Class Altair\\\\Http\\\\Collection\\\\HttpStatusCollection implements generic interface IteratorAggregate but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
 			message: "#^Instanceof between array and Traversable will always evaluate to false\\.$#"
-			count: 1
-			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
-			message: "#^Method Altair\\\\Http\\\\Collection\\\\HttpStatusCollection\\:\\:getIterator\\(\\) return type with generic class ArrayIterator does not specify its types\\: TKey, TValue$#"
 			count: 1
 			path: src/Altair/Http/Collection/HttpStatusCollection.php
 
@@ -289,26 +159,6 @@ parameters:
 			message: "#^Unreachable statement \\- code above always terminates\\.$#"
 			count: 1
 			path: src/Altair/Http/Collection/HttpStatusCollection.php
-
-		-
-			message: "#^Class Altair\\\\Http\\\\Collection\\\\InputCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Http/Collection/InputCollection.php
-
-		-
-			message: "#^Class Altair\\\\Http\\\\Collection\\\\MiddlewareCollection extends generic class Altair\\\\Structure\\\\Queue but does not specify its types\\: TValue$#"
-			count: 1
-			path: src/Altair/Http/Collection/MiddlewareCollection.php
-
-		-
-			message: "#^Class Altair\\\\Http\\\\Collection\\\\RouteCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Http/Collection/RouteCollection.php
-
-		-
-			message: "#^Class Altair\\\\Http\\\\Collection\\\\SettingsCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Http/Collection/SettingsCollection.php
 
 		-
 			message: "#^Class Lcobucci\\\\Jose\\\\Parsing\\\\Decoder not found\\.$#"
@@ -406,49 +256,14 @@ parameters:
 			path: src/Altair/Http/Support/FormatNegotiator.php
 
 		-
-			message: "#^Method Altair\\\\Messaging\\\\Configuration\\\\MessengerConfiguration\\:\\:collectTransportFactories\\(\\) return type with generic interface Symfony\\\\Component\\\\Messenger\\\\Transport\\\\TransportFactoryInterface does not specify its types\\: TTransport$#"
-			count: 1
-			path: src/Altair/Messaging/Configuration/MessengerConfiguration.php
-
-		-
-			message: "#^PHPDoc tag @var for variable \\$instance contains generic interface Symfony\\\\Component\\\\Messenger\\\\Transport\\\\TransportFactoryInterface but does not specify its types\\: TTransport$#"
-			count: 1
-			path: src/Altair/Messaging/Configuration/MessengerConfiguration.php
-
-		-
-			message: "#^Method Altair\\\\Messaging\\\\Transport\\\\TransportRegistry\\:\\:__construct\\(\\) has parameter \\$factory with generic interface Symfony\\\\Component\\\\Messenger\\\\Transport\\\\TransportFactoryInterface but does not specify its types\\: TTransport$#"
-			count: 1
-			path: src/Altair/Messaging/Transport/TransportRegistry.php
-
-		-
-			message: "#^Method Altair\\\\Middleware\\\\Runner\\:\\:__construct\\(\\) has parameter \\$queue with generic class Altair\\\\Structure\\\\Queue but does not specify its types\\: TValue$#"
-			count: 1
-			path: src/Altair/Middleware/Runner.php
-
-		-
-			message: "#^Property Altair\\\\Persistence\\\\Cycle\\\\CycleRepository\\:\\:\\$repository with generic interface Cycle\\\\ORM\\\\RepositoryInterface does not specify its types\\: TEntity$#"
-			count: 1
-			path: src/Altair/Persistence/Cycle/CycleRepository.php
-
-		-
 			message: "#^Unable to resolve the template type TEntity in call to method Cycle\\\\ORM\\\\ORMInterface\\:\\:getRepository\\(\\)$#"
 			count: 1
 			path: src/Altair/Persistence/Cycle/CycleRepository.php
 
 		-
-			message: "#^Class Altair\\\\Sanitation\\\\Collection\\\\FilterCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Sanitation/Collection/FilterCollection.php
-
-		-
 			message: "#^PHPDoc tag @return with type mixed is not subtype of native type int\\|null\\.$#"
 			count: 1
 			path: src/Altair/Sanitation/Filter/IntegerFilter.php
-
-		-
-			message: "#^Method Altair\\\\Sanitation\\\\FiltersRunner\\:\\:__construct\\(\\) has parameter \\$queue with generic class Altair\\\\Structure\\\\Queue but does not specify its types\\: TValue$#"
-			count: 1
-			path: src/Altair/Sanitation/FiltersRunner.php
 
 		-
 			message: "#^PHPDoc tag @param for parameter \\$resolver with type callable is not subtype of native type Altair\\\\Sanitation\\\\Contracts\\\\ResolverInterface\\|null\\.$#"
@@ -521,11 +336,6 @@ parameters:
 			path: src/Altair/Structure/Stack.php
 
 		-
-			message: "#^Class Altair\\\\Validation\\\\Collection\\\\RuleCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Validation/Collection/RuleCollection.php
-
-		-
 			message: "#^Binary operation \"\\*\\=\" between non\\-empty\\-string and 2 results in an error\\.$#"
 			count: 1
 			path: src/Altair/Validation/Rule/CreditCardRule.php
@@ -539,11 +349,6 @@ parameters:
 			message: "#^Strict comparison using \\=\\=\\= between 1 and 0 will always evaluate to false\\.$#"
 			count: 1
 			path: src/Altair/Validation/Rule/IsbnRule.php
-
-		-
-			message: "#^Method Altair\\\\Validation\\\\RulesRunner\\:\\:__construct\\(\\) has parameter \\$queue with generic class Altair\\\\Structure\\\\Queue but does not specify its types\\: TValue$#"
-			count: 1
-			path: src/Altair/Validation/RulesRunner.php
 
 		-
 			message: "#^PHPDoc tag @param for parameter \\$resolver with type callable is not subtype of native type Altair\\\\Validation\\\\Contracts\\\\ResolverInterface\\|null\\.$#"

--- a/src/Altair/Configuration/Collection/ConfigurationCollection.php
+++ b/src/Altair/Configuration/Collection/ConfigurationCollection.php
@@ -17,6 +17,9 @@ use Altair\Container\Container;
 use Altair\Structure\Set;
 use Override;
 
+/**
+ * @extends Set<class-string|ConfigurationInterface>
+ */
 class ConfigurationCollection extends Set implements ConfigurationInterface
 {
     /**

--- a/src/Altair/Container/Collection/AliasesCollection.php
+++ b/src/Altair/Container/Collection/AliasesCollection.php
@@ -15,6 +15,9 @@ use Altair\Container\Exception\InvalidArgumentException;
 use Altair\Container\Traits\NameNormalizerTrait;
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, string>
+ */
 class AliasesCollection extends Map
 {
     use NameNormalizerTrait;

--- a/src/Altair/Container/Collection/ClassDefinitionsCollection.php
+++ b/src/Altair/Container/Collection/ClassDefinitionsCollection.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Altair\Container\Collection;
 
+use Altair\Container\Definition;
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, Definition>
+ */
 class ClassDefinitionsCollection extends Map {}

--- a/src/Altair/Container/Collection/DelegatesCollection.php
+++ b/src/Altair/Container/Collection/DelegatesCollection.php
@@ -13,4 +13,7 @@ namespace Altair\Container\Collection;
 
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, mixed>
+ */
 class DelegatesCollection extends Map {}

--- a/src/Altair/Container/Collection/ParameterDefinitionsCollection.php
+++ b/src/Altair/Container/Collection/ParameterDefinitionsCollection.php
@@ -13,4 +13,7 @@ namespace Altair\Container\Collection;
 
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, mixed>
+ */
 class ParameterDefinitionsCollection extends Map {}

--- a/src/Altair/Container/Collection/PreparesCollection.php
+++ b/src/Altair/Container/Collection/PreparesCollection.php
@@ -13,4 +13,7 @@ namespace Altair\Container\Collection;
 
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, mixed>
+ */
 class PreparesCollection extends Map {}

--- a/src/Altair/Container/Collection/SharesCollection.php
+++ b/src/Altair/Container/Collection/SharesCollection.php
@@ -16,10 +16,16 @@ use Altair\Container\Traits\NameNormalizerTrait;
 use Altair\Structure\Contracts\MapInterface;
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, object|null>
+ */
 class SharesCollection extends Map
 {
     use NameNormalizerTrait;
 
+    /**
+     * @return MapInterface<string, object|null>
+     */
     public function shareClass(string $name, AliasesCollection $aliasesCollection): MapInterface
     {
         [, $normalizedName] = $aliasesCollection->resolve($name);
@@ -27,6 +33,9 @@ class SharesCollection extends Map
         return $this->put($normalizedName, $this[$normalizedName] ?? null);
     }
 
+    /**
+     * @return MapInterface<string, object|null>
+     */
     public function shareInstance(object $instance, AliasesCollection $aliasesCollection): MapInterface
     {
         $normalizedName = $this->normalizeName($instance::class);

--- a/src/Altair/Cookie/Collection/CookieCollection.php
+++ b/src/Altair/Cookie/Collection/CookieCollection.php
@@ -116,7 +116,7 @@ class CookieCollection extends Map
     /**
      * {@inheritDoc}
      *
-     * @return VectorInterface<int, ?string>
+     * @return VectorInterface<?string>
      */
     #[Override]
     public function values(): VectorInterface
@@ -169,7 +169,7 @@ class CookieCollection extends Map
     /**
      * Converts pairs to array.
      *
-     * @param array<int, Pair> $pairs
+     * @param array<int, Pair<string, Cookie>> $pairs
      *
      * @return array<string, string>
      */
@@ -177,7 +177,7 @@ class CookieCollection extends Map
     protected function pairsToArray($pairs): array
     {
         $array = [];
-        /** @var Pair $pair */
+        /** @var Pair<string, Cookie> $pair */
         foreach ($pairs as $pair) {
             $array[$pair->key] = (string) $pair->value;
         }

--- a/src/Altair/Cookie/Collection/SetCookieCollection.php
+++ b/src/Altair/Cookie/Collection/SetCookieCollection.php
@@ -116,7 +116,7 @@ class SetCookieCollection extends Map
     /**
      * {@inheritDoc}
      *
-     * @return VectorInterface<int, ?string>
+     * @return VectorInterface<?string>
      */
     #[Override]
     public function values(): VectorInterface
@@ -174,7 +174,7 @@ class SetCookieCollection extends Map
     /**
      * Converts pairs to array.
      *
-     * @param array<int, Pair> $pairs
+     * @param array<int, Pair<string, SetCookie>> $pairs
      *
      * @return array<string, string>
      */
@@ -182,7 +182,7 @@ class SetCookieCollection extends Map
     protected function pairsToArray($pairs): array
     {
         $array = [];
-        /** @var Pair $pair */
+        /** @var Pair<string, SetCookie> $pair */
         foreach ($pairs as $pair) {
             $array[$pair->key] = (string) $pair->value;
         }

--- a/src/Altair/Courier/Support/MessageCommandMap.php
+++ b/src/Altair/Courier/Support/MessageCommandMap.php
@@ -11,6 +11,10 @@ declare(strict_types=1);
 
 namespace Altair\Courier\Support;
 
+use Altair\Courier\Contracts\CommandInterface;
 use Altair\Structure\Map;
 
+/**
+ * @extends Map<string, class-string<CommandInterface>|CommandInterface>
+ */
 class MessageCommandMap extends Map {}

--- a/src/Altair/Http/Collection/HttpStatusCollection.php
+++ b/src/Altair/Http/Collection/HttpStatusCollection.php
@@ -22,6 +22,9 @@ use Override;
 use ReflectionClass;
 use Traversable;
 
+/**
+ * @implements IteratorAggregate<int, string>
+ */
 class HttpStatusCollection implements Countable, IteratorAggregate
 {
     /**
@@ -53,6 +56,8 @@ class HttpStatusCollection implements Countable, IteratorAggregate
 
     /**
      * {@inheritDoc}
+     *
+     * @return ArrayIterator<int, string>
      */
     #[Override]
     public function getIterator(): ArrayIterator

--- a/src/Altair/Http/Collection/InputCollection.php
+++ b/src/Altair/Http/Collection/InputCollection.php
@@ -13,4 +13,9 @@ namespace Altair\Http\Collection;
 
 use Altair\Structure\Map;
 
+/**
+ * Maps a request input name (attribute, body, cookie, query or upload key) to its value.
+ *
+ * @extends Map<string, mixed>
+ */
 class InputCollection extends Map {}

--- a/src/Altair/Http/Collection/MiddlewareCollection.php
+++ b/src/Altair/Http/Collection/MiddlewareCollection.php
@@ -13,4 +13,9 @@ namespace Altair\Http\Collection;
 
 use Altair\Structure\Queue;
 
+/**
+ * An ordered queue of PSR-15 middleware references (FQCN string, instance, or [class, method] pair).
+ *
+ * @extends Queue<mixed>
+ */
 class MiddlewareCollection extends Queue {}

--- a/src/Altair/Http/Collection/RouteCollection.php
+++ b/src/Altair/Http/Collection/RouteCollection.php
@@ -13,4 +13,9 @@ namespace Altair\Http\Collection;
 
 use Altair\Structure\Map;
 
+/**
+ * Maps a "METHOD /path" route key to its handler reference (an action FQCN).
+ *
+ * @extends Map<string, string>
+ */
 class RouteCollection extends Map {}

--- a/src/Altair/Http/Collection/SettingsCollection.php
+++ b/src/Altair/Http/Collection/SettingsCollection.php
@@ -13,4 +13,9 @@ namespace Altair\Http\Collection;
 
 use Altair\Structure\Map;
 
+/**
+ * Maps a setting name to its value.
+ *
+ * @extends Map<string, mixed>
+ */
 class SettingsCollection extends Map {}

--- a/src/Altair/Introspection/Inspector/ConfigInspector.php
+++ b/src/Altair/Introspection/Inspector/ConfigInspector.php
@@ -60,7 +60,7 @@ final readonly class ConfigInspector
             $rows[] = [
                 'source' => 'container',
                 'key' => '$' . $name,
-                'value' => $this->renderValue((string) $name, $value, $maskSecrets, $patterns),
+                'value' => $this->renderValue($name, $value, $maskSecrets, $patterns),
             ];
         }
 

--- a/src/Altair/Introspection/Inspector/ContainerInspector.php
+++ b/src/Altair/Introspection/Inspector/ContainerInspector.php
@@ -98,7 +98,7 @@ final readonly class ContainerInspector
                 continue; // null placeholder — registered but not yet built.
             }
 
-            $id = $this->displayName((string) $name);
+            $id = $this->displayName($name);
 
             if ($needle !== null && !str_contains(strtolower($id), $needle)) {
                 continue;
@@ -136,7 +136,7 @@ final readonly class ContainerInspector
 
         // Container collections are keyed by lower-cased class names — match the same normalization.
         $lookupKey = strtolower(ltrim($id, '\\'));
-        $aliasTarget = isset($aliases[$lookupKey]) ? (string) $aliases[$lookupKey] : null;
+        $aliasTarget = $aliases[$lookupKey] ?? null;
         $resolved = $aliasTarget ?? ltrim($id, '\\');
 
         $kind = match (true) {
@@ -189,7 +189,7 @@ final readonly class ContainerInspector
         $seen = [];
 
         foreach ($aliases as $original => $target) {
-            $normalized = (string) $original;
+            $normalized = $original;
             $seen[$normalized] = true;
             // An alias's `shared` flag reflects whether the alias name
             // itself is registered as a singleton — which is uncommon.
@@ -200,13 +200,13 @@ final readonly class ContainerInspector
             yield [
                 'id' => $this->displayName($normalized),
                 'kind' => 'alias',
-                'target' => (string) $target,
+                'target' => $target,
                 'shared' => $shares->hasKey($normalized),
             ];
         }
 
         foreach ($shares as $name => $_) {
-            $normalized = (string) $name;
+            $normalized = $name;
             if (isset($seen[$normalized])) {
                 continue;
             }
@@ -222,7 +222,7 @@ final readonly class ContainerInspector
         }
 
         foreach ($delegates as $name => $_) {
-            $normalized = (string) $name;
+            $normalized = $name;
             if (isset($seen[$normalized])) {
                 continue;
             }
@@ -238,7 +238,7 @@ final readonly class ContainerInspector
         }
 
         foreach ($classDefinitions as $name => $_) {
-            $normalized = (string) $name;
+            $normalized = $name;
             if (isset($seen[$normalized])) {
                 continue;
             }

--- a/src/Altair/Introspection/Inspector/RouteInspector.php
+++ b/src/Altair/Introspection/Inspector/RouteInspector.php
@@ -33,7 +33,7 @@ final readonly class RouteInspector
     {
         $rows = [];
         foreach ($this->routes as $request => $action) {
-            [$method, $path] = $this->splitRequest((string) $request);
+            [$method, $path] = $this->splitRequest($request);
             $rows[] = [
                 'method' => $method,
                 'path' => $path,
@@ -63,7 +63,7 @@ final readonly class RouteInspector
     {
         $matches = [];
         foreach ($this->routes as $request => $action) {
-            [$method, $registeredPath] = $this->splitRequest((string) $request);
+            [$method, $registeredPath] = $this->splitRequest($request);
             if ($registeredPath === $path) {
                 $matches[] = [
                     'method' => $method,

--- a/src/Altair/Messaging/Configuration/MessengerConfiguration.php
+++ b/src/Altair/Messaging/Configuration/MessengerConfiguration.php
@@ -40,6 +40,7 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 use Symfony\Component\Messenger\Transport\Sync\SyncTransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactory;
 use Symfony\Component\Messenger\Transport\TransportFactoryInterface;
+use Symfony\Component\Messenger\Transport\TransportInterface;
 
 /**
  * Wires Symfony Messenger into the Altair Container.
@@ -171,7 +172,7 @@ final readonly class MessengerConfiguration implements ConfigurationInterface
     }
 
     /**
-     * @return list<TransportFactoryInterface>
+     * @return list<TransportFactoryInterface<TransportInterface>>
      */
     private static function collectTransportFactories(LazyBus $lazyBus): array
     {
@@ -190,7 +191,7 @@ final readonly class MessengerConfiguration implements ConfigurationInterface
 
         foreach ($optional as $class) {
             if (class_exists($class)) {
-                /** @var TransportFactoryInterface $instance */
+                /** @var TransportFactoryInterface<TransportInterface> $instance */
                 $instance = new $class();
                 $factories[] = $instance;
             }

--- a/src/Altair/Messaging/Transport/TransportRegistry.php
+++ b/src/Altair/Messaging/Transport/TransportRegistry.php
@@ -26,6 +26,9 @@ final class TransportRegistry
     /** @var array<string, TransportInterface> */
     private array $cache = [];
 
+    /**
+     * @param TransportFactoryInterface<TransportInterface> $factory
+     */
     public function __construct(
         private readonly TransportSettings $settings,
         private readonly TransportFactoryInterface $factory,

--- a/src/Altair/Middleware/Runner.php
+++ b/src/Altair/Middleware/Runner.php
@@ -33,7 +33,7 @@ class Runner implements MiddlewareRunnerInterface
      *
      * Constructor.
      *
-     * @param Queue $queue The middleware queue.
+     * @param Queue<mixed> $queue The middleware queue.
      *
      * @param callable|MiddlewareResolverInterface $resolver Converts queue entries to callables.
      *

--- a/src/Altair/Persistence/Cycle/CycleRepository.php
+++ b/src/Altair/Persistence/Cycle/CycleRepository.php
@@ -37,6 +37,7 @@ use Override;
  */
 class CycleRepository implements RepositoryInterface
 {
+    /** @var CycleNativeRepository<TEntity> */
     private readonly CycleNativeRepository $repository;
 
     /**
@@ -47,7 +48,9 @@ class CycleRepository implements RepositoryInterface
         private readonly ORMInterface $orm,
         private readonly UnitOfWorkInterface $unitOfWork,
     ) {
-        $this->repository = $this->orm->getRepository($this->entityClass);
+        /** @var CycleNativeRepository<TEntity> $repository */
+        $repository = $this->orm->getRepository($this->entityClass);
+        $this->repository = $repository;
     }
 
     #[Override]

--- a/src/Altair/Sanitation/Collection/FilterCollection.php
+++ b/src/Altair/Sanitation/Collection/FilterCollection.php
@@ -18,6 +18,9 @@ use Altair\Structure\Map;
 use Override;
 use Traversable;
 
+/**
+ * @extends Map<string, mixed>
+ */
 class FilterCollection extends Map
 {
     /**

--- a/src/Altair/Sanitation/FiltersRunner.php
+++ b/src/Altair/Sanitation/FiltersRunner.php
@@ -34,7 +34,7 @@ class FiltersRunner implements FiltersRunnerInterface
      * Constructor.
      *
      * @param callable|ResolverInterface $resolver Converts queue entries to callables.
-     * @param Queue $queue The middleware queue.
+     * @param Queue<mixed> $queue The middleware queue.
      */
     public function __construct(?ResolverInterface $resolver = null, protected ?Queue $queue = null)
     {

--- a/src/Altair/Sanitation/Sanitizer.php
+++ b/src/Altair/Sanitation/Sanitizer.php
@@ -40,7 +40,7 @@ class Sanitizer implements SanitizerInterface
         $this->payload = $this->buildPayload($sanitizable);
 
         foreach ($sanitizable->getFilters() as $key => $value) {
-            $keys = explode(',', (string) preg_replace('/\s+/', '', (string) $key));
+            $keys = explode(',', (string) preg_replace('/\s+/', '', $key));
             foreach ($keys as $attribute) {
                 $filters = \is_array($value) ? $value : [$value];
                 $runner = $this->runner->withFilters($filters);

--- a/src/Altair/Validation/Collection/RuleCollection.php
+++ b/src/Altair/Validation/Collection/RuleCollection.php
@@ -18,6 +18,9 @@ use Altair\Validation\Exception\InvalidArgumentException;
 use Override;
 use Traversable;
 
+/**
+ * @extends Map<string, mixed>
+ */
 class RuleCollection extends Map
 {
     /**

--- a/src/Altair/Validation/RulesRunner.php
+++ b/src/Altair/Validation/RulesRunner.php
@@ -34,7 +34,7 @@ class RulesRunner implements RulesRunnerInterface
      * Constructor.
      *
      * @param callable|ResolverInterface $resolver Converts queue entries to callables.
-     * @param Queue $queue The middleware queue.
+     * @param Queue<mixed> $queue The middleware queue.
      */
     public function __construct(?ResolverInterface $resolver = null, protected ?Queue $queue = null)
     {


### PR DESCRIPTION
Follow-on to the Structure generics (#106): declares generic args on the collection subclasses/usages across consumer packages, clearing the "does not specify its types" findings that the generic base types created. Baseline `phpstan-baseline.neon`: **111 → 72 (−39)**. PHPDoc-only, runtime-safe (full suite unaffected). Done as 4 parallel per-package passes.

| Package | What |
|---|---|
| Container | `@extends Map<…>` on Aliases/ClassDefinitions/ParameterDefinitions/Prepares/Delegates/Shares collections |
| Http | `RouteCollection` `@extends Map<string,string>`; Input/Settings `Map<string,mixed>`; `MiddlewareCollection` `Queue<mixed>`; `HttpStatusCollection` `@implements IteratorAggregate<int,string>` |
| Validation / Sanitation | `Rule`/`FilterCollection` `@extends Map<string,mixed>`; runners `Queue<mixed>` |
| Messaging | `TransportFactoryInterface<TransportInterface>` args |
| Courier | `MessageCommandMap` `@extends Map<string, class-string<CommandInterface>\|CommandInterface>` |
| Persistence | `$repository` `@var CycleRepository<TEntity>` |
| Middleware / Configuration | `Queue<mixed>` / `Set<class-string\|ConfigurationInterface>` |

## Cookie — surfaced a real issue, left it (correctly)
Fixed the `VectorInterface` arity (it's single-`TValue`, was wrongly `<int, ?string>`) and `Pair<string, Cookie>` args. **Did not** add the class-level `@extends Map<string, Cookie>`: doing so exposes **6 genuine pre-existing Liskov violations** — `CookieCollection::put()` takes `?string` (the cookie *value*), not `Cookie`, so it isn't really a `Map<string, Cookie>`. PHPDoc can't fix a native-signature divergence; it's a real design issue, out of scope for a generics pass, so it stays baselined and is flagged for follow-up. (The agent stopped and surfaced this per CLAUDE.md §5 rather than forcing a wrong type or adding 6 new errors.)

## Gates
`composer stan` green (72 baselined, 0 live), CS clean, rector `--dry-run` clean (after applying the cleanups the new args unlocked). Full suite at the **5 pre-existing** `ext-mongodb`/`ext-memcached` environmental errors — no regressions.

Part of #96. **Progress: 719 → 72 (90% cleared).** Remaining 72 are genuine code-quality/subtype findings (unsafe `new static`, third-party class-not-found, PSR/Liskov conflicts like the Cookie one) needing individual fixes — then raise level 6 → 7 → 8.