### PR TITLE
re #96 clear PHPStan 'unsafe new static()' via @phpstan-consistent-constructor

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,17 +81,7 @@ parameters:
 			path: src/Altair/Cookie/Collection/CookieCollection.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/CookieCollection.php
-
-		-
 			message: "#^Class Altair\\\\Cookie\\\\Collection\\\\SetCookieCollection extends generic class Altair\\\\Structure\\\\Map but does not specify its types\\: TKey, TValue$#"
-			count: 1
-			path: src/Altair/Cookie/Collection/SetCookieCollection.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Altair/Cookie/Collection/SetCookieCollection.php
 
@@ -106,11 +96,6 @@ parameters:
 			path: src/Altair/Courier/Middleware/CommandLockerMiddleware.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Altair/Courier/Service/InMemoryCommandLocatorService.php
-
-		-
 			message: "#^Method Altair\\\\Courier\\\\Strategy\\\\CommandRunnerMiddlewareStrategy\\:\\:__construct\\(\\) has parameter \\$middlewares with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
@@ -122,11 +107,6 @@ parameters:
 
 		-
 			message: "#^Property Altair\\\\Courier\\\\Strategy\\\\CommandRunnerMiddlewareStrategy\\:\\:\\$middlewares type has no value type specified in iterable type array\\.$#"
-			count: 1
-			path: src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
 			count: 1
 			path: src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
 
@@ -296,16 +276,6 @@ parameters:
 			path: src/Altair/Session/Handler/PdoSessionHandler.php
 
 		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 10
-			path: src/Altair/Structure/Map.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Altair/Structure/Pair.php
-
-		-
 			message: "#^Property Altair\\\\Structure\\\\PriorityNode\\<TValue\\>\\:\\:\\$priority \\(int\\) does not accept null\\.$#"
 			count: 1
 			path: src/Altair/Structure/PriorityNode.php
@@ -314,26 +284,6 @@ parameters:
 			message: "#^Property Altair\\\\Structure\\\\PriorityNode\\<TValue\\>\\:\\:\\$stamp \\(int\\) does not accept null\\.$#"
 			count: 1
 			path: src/Altair/Structure/PriorityNode.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 1
-			path: src/Altair/Structure/PriorityQueue.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 2
-			path: src/Altair/Structure/Queue.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 7
-			path: src/Altair/Structure/Set.php
-
-		-
-			message: "#^Unsafe usage of new static\\(\\)\\.$#"
-			count: 2
-			path: src/Altair/Structure/Stack.php
 
 		-
 			message: "#^Binary operation \"\\*\\=\" between non\\-empty\\-string and 2 results in an error\\.$#"

--- a/src/Altair/Courier/Service/InMemoryCommandLocatorService.php
+++ b/src/Altair/Courier/Service/InMemoryCommandLocatorService.php
@@ -17,6 +17,9 @@ use Altair\Courier\Exception\UnknownCommandMessageNameException;
 use Altair\Courier\Support\MessageCommandMap;
 use Override;
 
+/**
+ * @phpstan-consistent-constructor
+ */
 class InMemoryCommandLocatorService implements InMemoryCommandLocatorServiceInterface
 {
     protected MessageCommandMap $map;

--- a/src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
+++ b/src/Altair/Courier/Strategy/CommandRunnerMiddlewareStrategy.php
@@ -19,6 +19,9 @@ use Altair\Courier\Exception\InvalidCommandMiddlewareException;
 use Closure;
 use Override;
 
+/**
+ * @phpstan-consistent-constructor
+ */
 class CommandRunnerMiddlewareStrategy implements CommandRunnerStrategyInterface
 {
     /**

--- a/src/Altair/Structure/Map.php
+++ b/src/Altair/Structure/Map.php
@@ -43,6 +43,8 @@ use UnderflowException;
  * @implements MapInterface<TKey, TValue>
  * @implements IteratorAggregate<TKey, TValue>
  * @implements ArrayAccess<TKey, TValue>
+ *
+ * @phpstan-consistent-constructor
  */
 class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInterface
 {

--- a/src/Altair/Structure/Pair.php
+++ b/src/Altair/Structure/Pair.php
@@ -26,6 +26,8 @@ use Stringable;
  * @template TValue
  *
  * @implements PairInterface<TKey, TValue>
+ *
+ * @phpstan-consistent-constructor
  */
 class Pair implements PairInterface, JsonSerializable, Stringable
 {

--- a/src/Altair/Structure/PriorityQueue.php
+++ b/src/Altair/Structure/PriorityQueue.php
@@ -35,6 +35,8 @@ use UnderflowException;
  *
  * @implements CollectionInterface<int, TValue>
  * @implements IteratorAggregate<int, TValue>
+ *
+ * @phpstan-consistent-constructor
  */
 class PriorityQueue implements IteratorAggregate, CollectionInterface
 {

--- a/src/Altair/Structure/Queue.php
+++ b/src/Altair/Structure/Queue.php
@@ -36,6 +36,8 @@ use Traversable;
  * @implements QueueInterface<TValue>
  * @implements IteratorAggregate<int, TValue>
  * @implements ArrayAccess<int, TValue>
+ *
+ * @phpstan-consistent-constructor
  */
 class Queue implements IteratorAggregate, ArrayAccess, QueueInterface, CapacityInterface
 {

--- a/src/Altair/Structure/Set.php
+++ b/src/Altair/Structure/Set.php
@@ -42,6 +42,8 @@ use Traversable;
  * @implements SetInterface<TValue>
  * @implements IteratorAggregate<int, TValue>
  * @implements ArrayAccess<int, TValue>
+ *
+ * @phpstan-consistent-constructor
  */
 class Set implements IteratorAggregate, ArrayAccess, SetInterface, CapacityInterface
 {

--- a/src/Altair/Structure/Stack.php
+++ b/src/Altair/Structure/Stack.php
@@ -37,6 +37,8 @@ use Traversable;
  * @implements StackInterface<TValue>
  * @implements IteratorAggregate<int, TValue>
  * @implements ArrayAccess<int, TValue>
+ *
+ * @phpstan-consistent-constructor
  */
 class Stack implements IteratorAggregate, ArrayAccess, StackInterface, CapacityInterface
 {


### PR DESCRIPTION
## Summary

Part of the #96 PHPStan burn-down (Phase 4). Clears **all 27 `Unsafe usage of new static()`** findings from the level-6 baseline.

- Annotates the Structure base collections (`Map`, `Set`, `Queue`, `Stack`, `Pair`, `PriorityQueue`) and the two Courier classes (`InMemoryCommandLocatorService`, `CommandRunnerMiddlewareStrategy`) that copy themselves via `new static()` with `@phpstan-consistent-constructor`.
- Verified first that **no subclass overrides the inherited constructor**, so the annotation documents and enforces a real invariant (subclasses must keep a compatible constructor) rather than silencing the checker. PHPStan now errors if that invariant is ever broken.
- `Map`'s annotation propagates to `CookieCollection` / `SetCookieCollection`, clearing their `new static()` findings without touching those files.
- Regenerated `phpstan-baseline.neon`: **92 → 65 errors (72 → 62 entries)**, no entries added.

## Out of scope (follow-ups)

The remaining baseline entries that looked like "optional-dep class-not-found" turned out to be **real API-version-mismatch bugs**, not ignorable artifacts — they will be handled in dedicated PRs:
- `Altair\Http\Jwt\*` targets the lcobucci/jwt **3.x** API while `^5.3` is required/installed (security-sensitive; needs migration + security review).
- `FormatNegotiator` uses `AcceptHeader::getValue()` which is gone in willdurand/negotiation 3.x.

## Test plan

- [x] `composer cs` — clean
- [x] `composer stan` — `[OK] No errors`
- [x] `vendor/bin/rector process --dry-run` (touched files) — clean
- [x] `composer test` — 5541 pass (the only local errors are `MongoSessionHandlerTest`, a pre-existing env issue when ext-mongodb is absent; CI loads mongodb)