### PR TITLE
re #96 raise PHPStan to level 8, zero baseline (completes #96)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 7
+    level: 8
     phpVersion: 80300
     paths:
         - src

--- a/src/Altair/Cache/CacheItemPool.php
+++ b/src/Altair/Cache/CacheItemPool.php
@@ -400,7 +400,9 @@ class CacheItemPool implements CacheItemPoolInterface, LoggerAwareInterface
     protected function makeId(string $key): string
     {
         if (!$this->cacheItemKeyValidator->validate($key)) {
-            throw new InvalidArgumentException($this->cacheItemKeyValidator->getFailureReason());
+            throw new InvalidArgumentException(
+                $this->cacheItemKeyValidator->getFailureReason() ?? \sprintf('The cache key "%s" is invalid.', $key)
+            );
         }
 
         if (null === $this->store->getMaxIdLength()) {

--- a/src/Altair/Common/Support/Inflector.php
+++ b/src/Altair/Common/Support/Inflector.php
@@ -76,7 +76,7 @@ class Inflector
         return '_' === $separator
             ? strtolower(trim((string) preg_replace($regex, '_\0', $name), '_'))
             : trim(
-                strtolower(str_replace('_', $separator, preg_replace($regex, $separator . '\0', $name))),
+                strtolower(str_replace('_', $separator, preg_replace($regex, $separator . '\0', $name) ?? $name)),
                 $separator
             );
     }
@@ -90,7 +90,7 @@ class Inflector
             '-',
             '_',
             '.',
-        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name))));
+        ], ' ', preg_replace('/(?<![A-Z])[A-Z]/', ' \0', $name) ?? $name)));
         return $uppercase ? ucwords($label) : $label;
     }
 
@@ -102,7 +102,7 @@ class Inflector
      */
     public function humanize(string $value, bool $upper = false): string
     {
-        $value = str_replace('_', ' ', preg_replace('/_id$/', '', $value));
+        $value = str_replace('_', ' ', preg_replace('/_id$/', '', $value) ?? $value);
         return $upper ? ucwords($value) : ucfirst($value);
     }
 

--- a/src/Altair/Common/Support/Pluralizer.php
+++ b/src/Altair/Common/Support/Pluralizer.php
@@ -227,7 +227,7 @@ class Pluralizer
 
         foreach ($this->singulars as $rule => $replacement) {
             if (preg_match($rule, $value)) {
-                return preg_replace($rule, (string) $replacement, $value);
+                return preg_replace($rule, (string) $replacement, $value) ?? $value;
             }
         }
 
@@ -245,7 +245,7 @@ class Pluralizer
 
         foreach ($this->plurals as $rule => $replacement) {
             if (preg_match($rule, $value)) {
-                return preg_replace($rule, (string) $replacement, $value);
+                return preg_replace($rule, (string) $replacement, $value) ?? $value;
             }
         }
 

--- a/src/Altair/Container/Collection/AliasesCollection.php
+++ b/src/Altair/Container/Collection/AliasesCollection.php
@@ -40,11 +40,13 @@ class AliasesCollection extends Map
 
         $original = $this->normalizeName($original);
 
-        if (isset($sharesCollection[$original])) {
+        $shared = $sharesCollection->get($original);
+
+        if (\is_object($shared)) {
             throw new InvalidArgumentException(
                 \sprintf(
                     'Cannot alias class %s to %s because it is currently shared',
-                    $this->normalizeName($sharesCollection->get($original)::class),
+                    $this->normalizeName($shared::class),
                     $alias
                 )
             );

--- a/src/Altair/Container/Container.php
+++ b/src/Altair/Container/Container.php
@@ -423,9 +423,12 @@ class Container implements ContainerInterface
                 throw new InjectionException(\sprintf("'%s' does not have public constructor.", $className));
             } elseif ($constructorParameters = $this->reflector->getConstructorParameters($className)) {
                 $reflectionClass = $this->reflector->getClass($className);
-                $definition = isset($this->classDefinitions[$normalizedClass])
-                    ? $definition->replace($this->classDefinitions->get($normalizedClass))
-                    : $definition;
+                $classDefinition = $this->classDefinitions->get($normalizedClass);
+
+                if ($classDefinition instanceof Definition) {
+                    $definition = $definition->replace($classDefinition);
+                }
+
                 $arguments = $this->argumentsBuilder->build($constructor, $definition, $constructorParameters);
                 $object = $reflectionClass->newInstanceArgs($arguments);
             } else {

--- a/src/Altair/Cookie/Factory/SetCookieFactory.php
+++ b/src/Altair/Cookie/Factory/SetCookieFactory.php
@@ -45,7 +45,7 @@ class SetCookieFactory
     {
         $cookieStr = new CookieStr();
         $attributes = $cookieStr->split($string);
-        [$name, $value] = $cookieStr->splitPair(array_shift($attributes));
+        [$name, $value] = $cookieStr->splitPair(array_shift($attributes) ?? '');
         $cookie = new SetCookie($name, $value);
 
         while ($attribute = array_shift($attributes)) {

--- a/src/Altair/Http/Exception/HttpNotFoundException.php
+++ b/src/Altair/Http/Exception/HttpNotFoundException.php
@@ -16,12 +16,7 @@ use Exception;
 
 class HttpNotFoundException extends HttpBadRequestException
 {
-    /**
-     * Constructor.
-     * @param string $message error message
-     * @param Exception $previous The previous exception used for the exception chaining.
-     */
-    public function __construct($message = null, ?Exception $previous = null)
+    public function __construct(string $message = '', ?Exception $previous = null)
     {
         parent::__construct($message, HttpStatusCodeInterface::HTTP_NOT_FOUND, $previous);
     }

--- a/src/Altair/Http/Validator/DigestSignatureValidator.php
+++ b/src/Altair/Http/Validator/DigestSignatureValidator.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Altair\Http\Validator;
 
+use Altair\Data\Contracts\EntityInterface;
 use Altair\Data\Contracts\QueryRepositoryInterface;
 use Altair\Http\Contracts\IdentityValidatorInterface;
 use Override;
@@ -45,6 +46,10 @@ class DigestSignatureValidator implements IdentityValidatorInterface
         $realm = $arguments['realm'];
         $method = $arguments['method'];
         $user = $this->repository->findOneBy([$this->options['username'] => $authorization['username']]);
+        if (!$user instanceof EntityInterface) {
+            return false;
+        }
+
         $data = [
             md5(\sprintf('%s:%s:%s', $authorization['username'], $realm, $user->get($this->options['password']))),
             $authorization['nonce'],

--- a/src/Altair/Middleware/Runner.php
+++ b/src/Altair/Middleware/Runner.php
@@ -24,7 +24,7 @@ class Runner implements MiddlewareRunnerInterface
      *
      * A callable to convert queue entries to callables.
      *
-     * @var callable|MiddlewareResolverInterface
+     * @var callable|MiddlewareResolverInterface|null
      *
      */
     protected $resolver;
@@ -35,7 +35,7 @@ class Runner implements MiddlewareRunnerInterface
      *
      * @param Queue<mixed> $queue The middleware queue.
      *
-     * @param callable|MiddlewareResolverInterface $resolver Converts queue entries to callables.
+     * @param callable|MiddlewareResolverInterface|null $resolver Converts queue entries to callables.
      *
      */
     public function __construct(protected Queue $queue, ?callable $resolver = null)

--- a/src/Altair/Sanitation/FiltersRunner.php
+++ b/src/Altair/Sanitation/FiltersRunner.php
@@ -22,12 +22,10 @@ class FiltersRunner implements FiltersRunnerInterface
 {
     /**
      *
-     * A callable to convert queue entries to callables.
-     *
-     * @var callable|ResolverInterface
+     * A resolver to convert queue entries to callables.
      *
      */
-    protected $resolver;
+    protected ?ResolverInterface $resolver;
 
     /**
      *
@@ -48,7 +46,7 @@ class FiltersRunner implements FiltersRunnerInterface
     #[Override]
     public function __invoke(PayloadInterface $payload): PayloadInterface
     {
-        $entry = $this->queue->isEmpty() ? null : $this->queue->pop();
+        $entry = !$this->queue instanceof Queue || $this->queue->isEmpty() ? null : $this->queue->pop();
         $middleware = $this->resolve($entry);
         return $middleware($payload, $this);
     }
@@ -77,7 +75,7 @@ class FiltersRunner implements FiltersRunnerInterface
             return static fn(PayloadInterface $payload): PayloadInterface => $payload;
         }
 
-        if (!$this->resolver) {
+        if (!$this->resolver instanceof ResolverInterface) {
             return $entry;
         }
 

--- a/src/Altair/Scaffold/Sdk/Python/PythonEmitter.php
+++ b/src/Altair/Scaffold/Sdk/Python/PythonEmitter.php
@@ -196,8 +196,9 @@ final readonly class PythonEmitter implements EmitterInterface
             $params[] = $this->snake($param) . ': str';
         }
 
-        if ($operation->hasRequestBody()) {
-            $params[] = 'body: ' . $this->typeHint($operation->requestBody);
+        $requestBody = $operation->requestBody;
+        if ($requestBody instanceof SchemaType) {
+            $params[] = 'body: ' . $this->typeHint($requestBody);
         }
 
         $returnType = $this->returnType($operation);
@@ -205,7 +206,7 @@ final readonly class PythonEmitter implements EmitterInterface
         $await = $async ? 'await ' : '';
 
         $pathExpr = $this->pathExpression($operation);
-        $bodyArg = $operation->hasRequestBody()
+        $bodyArg = $requestBody instanceof SchemaType
             ? ', json=body.model_dump(by_alias=True, exclude_none=True) if hasattr(body, "model_dump") else body'
             : '';
 

--- a/src/Altair/Scaffold/Sdk/TypeScript/TypeScriptEmitter.php
+++ b/src/Altair/Scaffold/Sdk/TypeScript/TypeScriptEmitter.php
@@ -160,14 +160,15 @@ final readonly class TypeScriptEmitter implements EmitterInterface
             $params[] = $this->camel($param) . ': string';
         }
 
-        if ($operation->hasRequestBody()) {
-            $params[] = 'body: ' . $this->typeExpr($operation->requestBody);
+        $requestBody = $operation->requestBody;
+        if ($requestBody instanceof SchemaType) {
+            $params[] = 'body: ' . $this->typeExpr($requestBody);
         }
 
         $params[] = 'options: ApiOptions = {}';
 
         $pathExpr = $this->pathExpression($operation);
-        $requestArgs = $operation->hasRequestBody() ? 'body, ...options' : '...options';
+        $requestArgs = $requestBody instanceof SchemaType ? 'body, ...options' : '...options';
 
         $summary = $operation->summary !== '' ? '/** ' . $operation->summary . " */\n" : '';
 

--- a/src/Altair/Session/Adapter/PostgreSqlPdoSessionAdapter.php
+++ b/src/Altair/Session/Adapter/PostgreSqlPdoSessionAdapter.php
@@ -93,7 +93,7 @@ class PostgreSqlPdoSessionAdapter implements PdoSessionAdapterInterface
     #[Override]
     public function getMergePdoStatement(string $sessionId, string $data): ?PDOStatement
     {
-        if (version_compare($this->pdo->getAttribute(PDO::ATTR_SERVER_VERSION), '9.5', '>=')) {
+        if (version_compare($this->getConnection()->getAttribute(PDO::ATTR_SERVER_VERSION), '9.5', '>=')) {
             $maxlifetime = (int) \ini_get('session.gc_maxlifetime');
             $sql = \sprintf(
                 'INSERT INTO %s (id, content, session_lifetime, session_time) ' .

--- a/src/Altair/Session/Traits/PdoSessionAdapterAwareTrait.php
+++ b/src/Altair/Session/Traits/PdoSessionAdapterAwareTrait.php
@@ -114,11 +114,13 @@ trait PdoSessionAdapterAwareTrait
      */
     public function getConnection(): PDO
     {
-        if (null === $this->pdo) {
-            $this->connect();
+        $pdo = $this->pdo;
+        if (null === $pdo) {
+            $pdo = $this->createConnection();
+            $this->pdo = $pdo;
         }
 
-        return $this->pdo;
+        return $pdo;
     }
 
     /**
@@ -126,8 +128,7 @@ trait PdoSessionAdapterAwareTrait
      */
     public function connect(): void
     {
-        $this->pdo = new PDO($this->dsn, $this->username, $this->password, $this->options);
-        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo = $this->createConnection();
     }
 
     /**
@@ -388,5 +389,13 @@ trait PdoSessionAdapterAwareTrait
     protected function getIsLockModeTransactional(): bool
     {
         return PdoSessionAdapterInterface::LOCK_TRANSACTIONAL === $this->lockMode;
+    }
+
+    private function createConnection(): PDO
+    {
+        $pdo = new PDO($this->dsn, $this->username, $this->password, $this->options);
+        $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+        return $pdo;
     }
 }

--- a/src/Altair/Structure/Contracts/MapInterface.php
+++ b/src/Altair/Structure/Contracts/MapInterface.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace Altair\Structure\Contracts;
 
-use OutOfBoundsException;
 use OutOfRangeException;
 use Traversable;
 use UnderflowException;
@@ -227,14 +226,15 @@ interface MapInterface extends CollectionInterface
     public function hasValue(mixed $value): bool;
 
     /**
-     * Returns the value associated with a key, or an optional default if the
-     * key is not associated with a value.
+     * Returns the value associated with a key, or an optional default (null by
+     * default) if the key is not associated with a value.
+     *
+     * @template TDefault
      *
      * @param TKey $key
-     * @param TValue|null $default
+     * @param TDefault $default
      *
-     * @throws OutOfBoundsException if no default was provided and the key isnot associated with a value.
-     * @return TValue The associated value or fallback default if provided.
+     * @return TValue|TDefault The associated value, or the fallback default if the key is not present.
      *
      */
     public function get(mixed $key, mixed $default = null);
@@ -257,13 +257,15 @@ interface MapInterface extends CollectionInterface
     public function sum();
 
     /**
-     * Removes a key's association from the map and returns the associated value or a provided default if provided.
+     * Removes a key's association from the map and returns the associated value,
+     * or the provided default (null by default) if the key is not present.
+     *
+     * @template TDefault
      *
      * @param TKey $key
-     * @param TValue|null $default
+     * @param TDefault $default
      *
-     * @throws OutOfBoundsException if no default was provided and the key is not associated with a value.
-     * @return TValue The associated value or fallback default if provided.
+     * @return TValue|TDefault The associated value, or the fallback default if the key is not present.
      *
      */
     public function remove(mixed $key, mixed $default = null);

--- a/src/Altair/Structure/Map.php
+++ b/src/Altair/Structure/Map.php
@@ -450,10 +450,12 @@ class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInter
     /**
      * {@inheritDoc}
      *
-     * @param TKey $key
-     * @param TValue|null $default
+     * @template TDefault
      *
-     * @return TValue
+     * @param TKey $key
+     * @param TDefault $default
+     *
+     * @return TValue|TDefault
      */
     #[Override]
     public function get($key, $default = null)
@@ -492,10 +494,12 @@ class Map implements IteratorAggregate, ArrayAccess, MapInterface, CapacityInter
     /**
      * {@inheritDoc}
      *
-     * @param TKey $key
-     * @param TValue|null $default
+     * @template TDefault
      *
-     * @return TValue
+     * @param TKey $key
+     * @param TDefault $default
+     *
+     * @return TValue|TDefault
      */
     #[Override]
     public function remove($key, $default = null)

--- a/src/Altair/Structure/PriorityQueue.php
+++ b/src/Altair/Structure/PriorityQueue.php
@@ -111,7 +111,7 @@ class PriorityQueue implements IteratorAggregate, CollectionInterface
      */
     public function pop()
     {
-        if ($this->isEmpty()) {
+        if ($this->heap === []) {
             throw new UnderflowException('Queue is empty');
         }
 

--- a/src/Altair/Structure/Traits/SequenceTrait.php
+++ b/src/Altair/Structure/Traits/SequenceTrait.php
@@ -190,7 +190,7 @@ trait SequenceTrait
      */
     public function pop()
     {
-        if ($this->isEmpty()) {
+        if ($this->internal === []) {
             throw new UnderflowException('Is empty');
         }
 
@@ -290,7 +290,7 @@ trait SequenceTrait
      */
     public function shift()
     {
-        if ($this->isEmpty()) {
+        if ($this->internal === []) {
             throw new UnderflowException('Is empty');
         }
 

--- a/src/Altair/Validation/Rule/CreditCardRule.php
+++ b/src/Altair/Validation/Rule/CreditCardRule.php
@@ -191,6 +191,6 @@ class CreditCardRule extends AbstractRule
      */
     protected function sanitize(string $value): string
     {
-        return preg_replace('/[ -]+/', '', $value);
+        return preg_replace('/[ -]+/', '', $value) ?? $value;
     }
 }

--- a/src/Altair/Validation/Rule/IbanRule.php
+++ b/src/Altair/Validation/Rule/IbanRule.php
@@ -166,8 +166,8 @@ class IbanRule extends AbstractRule
     protected function sanitize(string $value): string
     {
         $value = strtoupper(ltrim($value));
-        $value = preg_replace('/^I?IBAN/', '', $value);
+        $value = preg_replace('/^I?IBAN/', '', $value) ?? $value;
 
-        return preg_replace('/[^a-zA-Z0-9]/', '', (string) $value);
+        return preg_replace('/[^a-zA-Z0-9]/', '', $value) ?? $value;
     }
 }

--- a/src/Altair/Validation/Rule/IpRule.php
+++ b/src/Altair/Validation/Rule/IpRule.php
@@ -128,8 +128,12 @@ class IpRule extends AbstractRule
         return $input;
     }
 
-    protected function assertAddress(string $address): bool
+    protected function assertAddress(?string $address): bool
     {
+        if ($address === null) {
+            return false;
+        }
+
         return (bool) filter_var($address, FILTER_VALIDATE_IP, ['flags' => $this->options,]);
     }
 
@@ -143,9 +147,15 @@ class IpRule extends AbstractRule
             return $this->assertSubnet($value);
         }
 
+        $min = $this->range['min'];
+        $max = $this->range['max'];
+        if ($min === null || $max === null) {
+            return false;
+        }
+
         $value = \sprintf('%u', ip2long($value));
-        return bccomp($value, \sprintf('%u', ip2long($this->range['min']))) >= 0
-            && bccomp($value, \sprintf('%u', ip2long($this->range['max']))) <= 0;
+        return bccomp($value, \sprintf('%u', ip2long($min))) >= 0
+            && bccomp($value, \sprintf('%u', ip2long($max))) <= 0;
     }
 
     /**

--- a/src/Altair/Validation/Validator.php
+++ b/src/Altair/Validation/Validator.php
@@ -85,6 +85,6 @@ class Validator implements ValidatorInterface
 
     protected function sanitize(string $value): string
     {
-        return preg_replace('/\s+/', '', $value);
+        return preg_replace('/\s+/', '', $value) ?? $value;
     }
 }


### PR DESCRIPTION
## Summary

Final step of #96: raises `phpstan.neon.dist` **level 7 → 8** and fixes **all 35 new findings at root cause** across 11 packages. No baseline; PHPStan `[OK]` at level 8.

Level 8 is null-safety (`method.nonObject`, `return.type`, `argument.type` from nullable/`mixed` flows). Representative fixes:
- **`Map::get()`/`remove()`** typed with `@template TDefault` → `@return TValue|TDefault`, so the optional-default fallback is expressed honestly (`TValue|null` when no default) instead of a false non-null `@return TValue`. Behaviour unchanged (body still returns the default).
- `preg_replace` `string|null` returns coalesced to the original input (`Inflector`, `Pluralizer`, `Validator`/`CreditCardRule`/`IbanRule` `sanitize()`).
- `PdoSessionAdapterAwareTrait` extracts `createConnection(): PDO` so `getConnection()` provably returns non-null; `DigestSignatureValidator` returns `false` for unknown users; SDK emitters narrow `?SchemaType` via a local `!== null` guard; `IpRule`/`FiltersRunner` null guards; `HttpNotFoundException` typed `string $message`.

## #96 complete

This completes the static-analysis program:
- **Level 8** with **no baseline file**.
- The only `ignoreErrors` remaining are **documented, justified exceptions**: ext-* stubs, public-API mixin traits, the intentional Cookie/`CollectionTrait` adapter-storage design, and Cycle's loose-union `getRepository` generic.

## Test plan
- [x] `composer stan` (level 8, no baseline) — `[OK] No errors`
- [x] `composer cs` (cache-free) — clean
- [x] `vendor/bin/rector process --dry-run` (full) — clean
- [x] `composer test` — 5555 tests; only pre-existing local `MongoSessionHandlerTest` env errors (CI loads ext-mongodb)