### PR TITLE
re #97 PSR-14 object-based dispatcher for Altair\Happen

### DIFF
--- a/src/Altair/Happen/Psr14EventDispatcher.php
+++ b/src/Altair/Happen/Psr14EventDispatcher.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Happen;
+
+use Override;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\ListenerProviderInterface;
+use Psr\EventDispatcher\StoppableEventInterface;
+
+/**
+ * PSR-14 object-based event dispatcher.
+ *
+ * Pairs with any PSR-14 {@see ListenerProviderInterface} (the framework ships
+ * {@see Psr14ListenerProvider}). Listeners receive the event object and may
+ * mutate it; the same instance is returned. When the event is a
+ * {@see StoppableEventInterface}, propagation is checked before each listener
+ * so a stopped event halts the remaining listeners.
+ *
+ * This is the object-based counterpart to the name-keyed {@see EventDispatcher};
+ * the two are independent and a host binds whichever it needs.
+ */
+final readonly class Psr14EventDispatcher implements EventDispatcherInterface
+{
+    public function __construct(private ListenerProviderInterface $provider) {}
+
+    #[Override]
+    public function dispatch(object $event): object
+    {
+        $stoppable = $event instanceof StoppableEventInterface;
+
+        foreach ($this->provider->getListenersForEvent($event) as $listener) {
+            if ($stoppable && $event->isPropagationStopped()) {
+                break;
+            }
+
+            $listener($event);
+        }
+
+        return $event;
+    }
+}

--- a/src/Altair/Happen/Psr14ListenerProvider.php
+++ b/src/Altair/Happen/Psr14ListenerProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Happen;
+
+use Override;
+use Psr\EventDispatcher\ListenerProviderInterface;
+
+/**
+ * Type-keyed, priority-ordered PSR-14 listener provider.
+ *
+ * Listeners are registered against an event class or interface name. An event
+ * matches a registration when it is an instance of that type, so listeners bound
+ * to a parent class or interface also fire for subclasses. Matching listeners
+ * are returned highest-priority first; ties keep registration order.
+ *
+ * This is the object-based counterpart to the name-keyed {@see EventDispatcher};
+ * the two are independent and a host binds whichever it needs.
+ */
+final class Psr14ListenerProvider implements ListenerProviderInterface
+{
+    public const int HIGH_PRIORITY = 100;
+
+    public const int NORMAL_PRIORITY = 0;
+
+    public const int LOW_PRIORITY = -100;
+
+    /**
+     * @var array<class-string, list<array{priority: int, sequence: int, listener: callable}>>
+     */
+    private array $listeners = [];
+
+    private int $sequence = 0;
+
+    /**
+     * Register a listener for an event type (class or interface name).
+     *
+     * @param class-string $eventType
+     */
+    public function listen(
+        string $eventType,
+        callable $listener,
+        int $priority = self::NORMAL_PRIORITY
+    ): self {
+        $this->listeners[$eventType][] = [
+            'priority' => $priority,
+            'sequence' => $this->sequence++,
+            'listener' => $listener,
+        ];
+
+        return $this;
+    }
+
+    /**
+     * @return iterable<int, callable>
+     */
+    #[Override]
+    public function getListenersForEvent(object $event): iterable
+    {
+        $matched = [];
+        foreach ($this->listeners as $type => $entries) {
+            if ($event instanceof $type) {
+                foreach ($entries as $entry) {
+                    $matched[] = $entry;
+                }
+            }
+        }
+
+        usort(
+            $matched,
+            static fn(array $a, array $b): int => $b['priority'] <=> $a['priority']
+                ?: $a['sequence'] <=> $b['sequence'],
+        );
+
+        foreach ($matched as $entry) {
+            yield $entry['listener'];
+        }
+    }
+}

--- a/tests/Happen/Fixtures/BaseEvent.php
+++ b/tests/Happen/Fixtures/BaseEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen\Fixtures;
+
+class BaseEvent implements MarkerInterface
+{
+}

--- a/tests/Happen/Fixtures/DerivedEvent.php
+++ b/tests/Happen/Fixtures/DerivedEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen\Fixtures;
+
+final class DerivedEvent extends BaseEvent
+{
+}

--- a/tests/Happen/Fixtures/MarkerInterface.php
+++ b/tests/Happen/Fixtures/MarkerInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen\Fixtures;
+
+interface MarkerInterface
+{
+}

--- a/tests/Happen/Fixtures/StoppableEvent.php
+++ b/tests/Happen/Fixtures/StoppableEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen\Fixtures;
+
+use Psr\EventDispatcher\StoppableEventInterface;
+
+final class StoppableEvent implements StoppableEventInterface
+{
+    public function __construct(private bool $stopped = false)
+    {
+    }
+
+    public function stop(): void
+    {
+        $this->stopped = true;
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return $this->stopped;
+    }
+}

--- a/tests/Happen/Fixtures/UnrelatedEvent.php
+++ b/tests/Happen/Fixtures/UnrelatedEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen\Fixtures;
+
+final class UnrelatedEvent
+{
+}

--- a/tests/Happen/Psr14EventDispatcherTest.php
+++ b/tests/Happen/Psr14EventDispatcherTest.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen;
+
+use Altair\Happen\Psr14EventDispatcher;
+use Altair\Happen\Psr14ListenerProvider;
+use Altair\Tests\Happen\Fixtures\BaseEvent;
+use Altair\Tests\Happen\Fixtures\DerivedEvent;
+use Altair\Tests\Happen\Fixtures\StoppableEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Psr14EventDispatcher::class)]
+final class Psr14EventDispatcherTest extends TestCase
+{
+    public function testDispatchReturnsTheSameEventInstance(): void
+    {
+        $dispatcher = new Psr14EventDispatcher(new Psr14ListenerProvider());
+        $event = new BaseEvent();
+
+        $this->assertSame($event, $dispatcher->dispatch($event));
+    }
+
+    public function testDispatchInvokesMatchingListenerWithTheEvent(): void
+    {
+        $received = null;
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(BaseEvent::class, static function (BaseEvent $e) use (&$received): void {
+            $received = $e;
+        });
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $event = new BaseEvent();
+        $dispatcher->dispatch($event);
+
+        $this->assertSame($event, $received);
+    }
+
+    public function testDispatchInvokesNothingWhenNoListenersMatch(): void
+    {
+        $dispatcher = new Psr14EventDispatcher(new Psr14ListenerProvider());
+        $event = new BaseEvent();
+
+        $this->assertSame($event, $dispatcher->dispatch($event));
+    }
+
+    public function testDispatchInvokesListenersInPriorityOrder(): void
+    {
+        $calls = [];
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+            $calls[] = 'normal';
+        });
+        $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+            $calls[] = 'high';
+        }, Psr14ListenerProvider::HIGH_PRIORITY);
+        $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+            $calls[] = 'low';
+        }, Psr14ListenerProvider::LOW_PRIORITY);
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $dispatcher->dispatch(new BaseEvent());
+
+        $this->assertSame(['high', 'normal', 'low'], $calls);
+    }
+
+    public function testStoppableEventHaltsRemainingListeners(): void
+    {
+        $calls = [];
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(StoppableEvent::class, static function (StoppableEvent $e) use (&$calls): void {
+            $calls[] = 'first';
+            $e->stop();
+        });
+        $provider->listen(StoppableEvent::class, static function () use (&$calls): void {
+            $calls[] = 'second';
+        });
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $dispatcher->dispatch(new StoppableEvent());
+
+        $this->assertSame(['first'], $calls);
+    }
+
+    public function testNonStoppableEventInvokesAllListeners(): void
+    {
+        $calls = [];
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+            $calls[] = 'first';
+        });
+        $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+            $calls[] = 'second';
+        });
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $dispatcher->dispatch(new BaseEvent());
+
+        $this->assertSame(['first', 'second'], $calls);
+    }
+
+    public function testAlreadyStoppedEventInvokesNoListeners(): void
+    {
+        $calls = [];
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(StoppableEvent::class, static function () use (&$calls): void {
+            $calls[] = 'listener';
+        });
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $dispatcher->dispatch(new StoppableEvent(stopped: true));
+
+        $this->assertSame([], $calls);
+    }
+
+    public function testInheritanceMatchingDispatchesParentListenersToSubclass(): void
+    {
+        $calls = [];
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+            $calls[] = 'base';
+        });
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $dispatcher->dispatch(new DerivedEvent());
+
+        $this->assertSame(['base'], $calls);
+    }
+
+    public function testListenerRegisteredDuringDispatchDoesNotFireInTheSameCycle(): void
+    {
+        $calls = [];
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(BaseEvent::class, static function () use ($provider, &$calls): void {
+            $calls[] = 'first';
+            $provider->listen(BaseEvent::class, static function () use (&$calls): void {
+                $calls[] = 'registered-during-dispatch';
+            });
+        });
+        $dispatcher = new Psr14EventDispatcher($provider);
+
+        $dispatcher->dispatch(new BaseEvent());
+
+        $this->assertSame(['first'], $calls);
+    }
+}

--- a/tests/Happen/Psr14ListenerProviderTest.php
+++ b/tests/Happen/Psr14ListenerProviderTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Happen;
+
+use Altair\Happen\Psr14ListenerProvider;
+use Altair\Tests\Happen\Fixtures\BaseEvent;
+use Altair\Tests\Happen\Fixtures\DerivedEvent;
+use Altair\Tests\Happen\Fixtures\MarkerInterface;
+use Altair\Tests\Happen\Fixtures\UnrelatedEvent;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Psr14ListenerProvider::class)]
+final class Psr14ListenerProviderTest extends TestCase
+{
+    /**
+     * @return list<callable>
+     */
+    private function listenersFor(Psr14ListenerProvider $provider, object $event): array
+    {
+        return iterator_to_array($provider->getListenersForEvent($event), false);
+    }
+
+    public function testReturnsNoListenersWhenNoneRegistered(): void
+    {
+        $provider = new Psr14ListenerProvider();
+
+        $this->assertSame([], $this->listenersFor($provider, new UnrelatedEvent()));
+    }
+
+    public function testReturnsListenerRegisteredForTheEventType(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $listener = static function (BaseEvent $e): void {
+        };
+
+        $provider->listen(BaseEvent::class, $listener);
+
+        $this->assertSame([$listener], $this->listenersFor($provider, new BaseEvent()));
+    }
+
+    public function testDoesNotReturnListenersForUnrelatedEvents(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $provider->listen(BaseEvent::class, static function (): void {
+        });
+
+        $this->assertSame([], $this->listenersFor($provider, new UnrelatedEvent()));
+    }
+
+    public function testSubclassEventReceivesParentClassListeners(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $listener = static function (BaseEvent $e): void {
+        };
+        $provider->listen(BaseEvent::class, $listener);
+
+        $this->assertSame([$listener], $this->listenersFor($provider, new DerivedEvent()));
+    }
+
+    public function testInterfaceListenersMatchImplementingEvents(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $listener = static function (MarkerInterface $e): void {
+        };
+        $provider->listen(MarkerInterface::class, $listener);
+
+        $this->assertSame([$listener], $this->listenersFor($provider, new BaseEvent()));
+    }
+
+    public function testListenersAreOrderedByPriorityHighestFirst(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $normal = static function (): void {
+        };
+        $high = static function (): void {
+        };
+        $low = static function (): void {
+        };
+
+        $provider->listen(BaseEvent::class, $normal);
+        $provider->listen(BaseEvent::class, $high, Psr14ListenerProvider::HIGH_PRIORITY);
+        $provider->listen(BaseEvent::class, $low, Psr14ListenerProvider::LOW_PRIORITY);
+
+        $this->assertSame([$high, $normal, $low], $this->listenersFor($provider, new BaseEvent()));
+    }
+
+    public function testEqualPriorityListenersKeepRegistrationOrder(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $first = static function (): void {
+        };
+        $second = static function (): void {
+        };
+
+        $provider->listen(BaseEvent::class, $first);
+        $provider->listen(BaseEvent::class, $second);
+
+        $this->assertSame([$first, $second], $this->listenersFor($provider, new BaseEvent()));
+    }
+
+    public function testListenersAcrossMatchingTypesAreMergedAndSortedByPriority(): void
+    {
+        $provider = new Psr14ListenerProvider();
+        $baseNormal = static function (): void {
+        };
+        $derivedHigh = static function (): void {
+        };
+
+        $provider->listen(BaseEvent::class, $baseNormal);
+        $provider->listen(DerivedEvent::class, $derivedHigh, Psr14ListenerProvider::HIGH_PRIORITY);
+
+        $this->assertSame([$derivedHigh, $baseNormal], $this->listenersFor($provider, new DerivedEvent()));
+    }
+
+    public function testListenReturnsSelfForChaining(): void
+    {
+        $provider = new Psr14ListenerProvider();
+
+        $result = $provider->listen(BaseEvent::class, static function (): void {
+        });
+
+        $this->assertSame($provider, $result);
+    }
+}


### PR DESCRIPTION
## Summary

Implements PSR-14's object-based interfaces in `Altair\Happen` **alongside** the existing name-keyed `EventDispatcher` — no BC break to the name-based dispatch surface. Closes #97 (Phase 3d, AGENT.md §7).

### Design decision (the reason #97 was its own issue)

The issue offered two shapes. **Option 2 (dual-mode, one class) is infeasible**: a single class cannot declare a `dispatch()` that satisfies both Altair's `dispatch(string $name, ?EventInterface $event): EventInterface` and PSR-14's `dispatch(object $event): object` — same method name, incompatible signatures. So this ships **option 1 (separate classes)**, which is also the cleanest separation: hosts bind whichever dispatcher they need.

### What's added

- **`Altair\Happen\Psr14EventDispatcher`** — `Psr\EventDispatcher\EventDispatcherInterface`. Dispatches an event object to its matching listeners, returns the same instance, and honours `StoppableEventInterface::isPropagationStopped()` **before each listener** (so an already-stopped event invokes nothing, and a listener that stops halts the rest). `final readonly`.
- **`Altair\Happen\Psr14ListenerProvider`** — `Psr\EventDispatcher\ListenerProviderInterface`. Type-keyed registration via `listen(class-string $eventType, callable $listener, int $priority)`; inheritance/interface-aware matching (a listener on a parent class or interface fires for subclasses); deterministic ordering — highest priority first, ties keep registration order via a global sequence counter. `getListenersForEvent()` snapshots and sorts before yielding, so a listener registered mid-dispatch does not fire in the same cycle.

The name-based `EventDispatcher`, `Event`, and all existing contracts are untouched. `EventInterface` already extended PSR-14's `StoppableEventInterface`, and `composer.json` already required `psr/event-dispatcher`.

## Acceptance criteria

- [x] A class implements `Psr\EventDispatcher\EventDispatcherInterface` (`dispatch(object): object`, returns same instance)
- [x] A provider implements `Psr\EventDispatcher\ListenerProviderInterface`
- [x] Stoppable propagation halts further listeners on the PSR-14 path
- [x] Existing name-based API unchanged (no BC break)
- [x] Tests cover dispatch-by-object, propagation-stop, listener ordering (80%+ on new code)
- [x] `composer qa` + `rector --dry-run` green

## Test plan

- [x] PHPStan level 8, zero baseline — `[OK] No errors`
- [x] Rector 2.x `process --dry-run` (full tree) — `[OK] Rector is done!`
- [x] `php-cs-fixer fix --dry-run --using-cache=no` — clean
- [x] Full Happen suite (51 tests) green; new PSR-14 tests cover dispatch-by-object, return-same-instance, priority + FIFO ordering, cross-type merge, inheritance + interface matching, already-stopped short-circuit, stop-mid-dispatch halt, and mid-dispatch registration isolation
- [ ] CI confirms ext-dependent / 8.3 + 8.4 matrix (run locally on PHP 8.5 without some extensions)