### PR TITLE
re #84 MCP tool wrappers for introspection commands

### DIFF
--- a/src/Altair/Mcp/Schema/container-inspect-input.json
+++ b/src/Altair/Mcp/Schema/container-inspect-input.json
@@ -1,0 +1,15 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "shared_only": {
+            "type": "boolean",
+            "description": "Only list shared (singleton) bindings.",
+            "default": false
+        },
+        "filter": {
+            "type": "string",
+            "description": "Case-insensitive substring filter on the binding id."
+        }
+    }
+}

--- a/src/Altair/Mcp/Schema/listener-show-input.json
+++ b/src/Altair/Mcp/Schema/listener-show-input.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["event"],
+    "properties": {
+        "event": {
+            "type": "string",
+            "description": "The event name whose listeners to show (priority-sorted)."
+        }
+    }
+}

--- a/src/Altair/Mcp/Schema/route-show-input.json
+++ b/src/Altair/Mcp/Schema/route-show-input.json
@@ -1,0 +1,11 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["path"],
+    "properties": {
+        "path": {
+            "type": "string",
+            "description": "The route path to describe (e.g. /users)."
+        }
+    }
+}

--- a/src/Altair/Mcp/Support/ContainerLookup.php
+++ b/src/Altair/Mcp/Support/ContainerLookup.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Support;
+
+use Altair\Container\Container;
+use Throwable;
+
+/**
+ * Best-effort optional resolution of an already-registered binding. Returns
+ * null (never throws) when the id is unbound or its construction fails, so
+ * introspection tools can degrade to an "unavailable" note instead of
+ * surfacing a raw container error.
+ */
+final class ContainerLookup
+{
+    public static function optional(Container $container, string $id): ?object
+    {
+        if (!$container->isset($id)) {
+            return null;
+        }
+
+        try {
+            $value = $container->get($id);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return \is_object($value) ? $value : null;
+    }
+
+    /**
+     * Resolve the first of several candidate ids that yields an object —
+     * e.g. a concrete class registered directly OR under its interface key.
+     */
+    public static function firstOf(Container $container, string ...$ids): ?object
+    {
+        foreach ($ids as $id) {
+            $value = self::optional($container, $id);
+            if ($value !== null) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Mcp/Tool/BuiltinTools.php
+++ b/src/Altair/Mcp/Tool/BuiltinTools.php
@@ -27,6 +27,14 @@ use Altair\Mcp\Tool\Generation\EmitSdkTool;
 use Altair\Mcp\Tool\Generation\RewindSpecTool;
 use Altair\Mcp\Tool\Generation\ScaffoldTool;
 use Altair\Mcp\Tool\Generation\WriteSpecTool;
+use Altair\Mcp\Tool\Introspection\ConfigDumpTool;
+use Altair\Mcp\Tool\Introspection\ContainerInspectTool;
+use Altair\Mcp\Tool\Introspection\ListenerShowTool;
+use Altair\Mcp\Tool\Introspection\ListenersListTool;
+use Altair\Mcp\Tool\Introspection\ManifestDiffTool;
+use Altair\Mcp\Tool\Introspection\MiddlewareListTool;
+use Altair\Mcp\Tool\Introspection\RouteShowTool;
+use Altair\Mcp\Tool\Introspection\RoutesListTool;
 use Altair\Mcp\Tool\Verification\CheckDriftTool;
 use Altair\Mcp\Tool\Verification\DoctorTool;
 use Altair\Mcp\Tool\Verification\PhpstanTool;
@@ -67,6 +75,15 @@ final class BuiltinTools
             DbQueryTool::class,
             DbSchemaTool::class,
             DbMigrateTool::class,
+            // Introspection (read-only wrappers over the inspector commands)
+            ContainerInspectTool::class,
+            ConfigDumpTool::class,
+            RoutesListTool::class,
+            RouteShowTool::class,
+            ListenersListTool::class,
+            ListenerShowTool::class,
+            MiddlewareListTool::class,
+            ManifestDiffTool::class,
         ];
     }
 }

--- a/src/Altair/Mcp/Tool/Introspection/ConfigDumpTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/ConfigDumpTool.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Introspection\Inspector\ConfigInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Override;
+
+#[McpTool(
+    name: 'framework__config_dump',
+    description: 'Dump merged env + container parameters with secrets masked.',
+    inputSchema: __DIR__ . '/../../Schema/no-args.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class ConfigDumpTool implements McpToolInterface
+{
+    /**
+     * Extra name patterns masked at the agent boundary, on top of
+     * {@see ConfigInspector::DEFAULT_SECRET_PATTERNS} — the MCP surface masks
+     * more aggressively than the CLI since output goes to an LLM context.
+     */
+    private const array EXTRA_SECRET_PATTERNS = ['PASS', 'PWD', 'OAUTH', 'DSN', 'SALT', 'CERT', 'SIGNATURE', 'WEBHOOK'];
+
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        // Secrets are masked unconditionally at the MCP boundary — the caller
+        // cannot opt into raw secret values.
+        return (new ConfigInspector($this->container, self::EXTRA_SECRET_PATTERNS))->dump(maskSecrets: true)->toArray();
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/ContainerInspectTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/ContainerInspectTool.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Introspection\Inspector\ContainerInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Override;
+
+#[McpTool(
+    name: 'framework__container_inspect',
+    description: 'List container bindings: aliases, shares, delegates and parameter definitions.',
+    inputSchema: __DIR__ . '/../../Schema/container-inspect-input.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class ContainerInspectTool implements McpToolInterface
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $sharedOnly = ($input['shared_only'] ?? false) === true;
+        $filter = \is_string($input['filter'] ?? null) && $input['filter'] !== '' ? $input['filter'] : null;
+
+        return (new ContainerInspector($this->container))->inspectAll($sharedOnly, $filter)->toArray();
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/ListenerShowTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/ListenerShowTool.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Happen\Contracts\EventDispatcherInterface;
+use Altair\Happen\EventDispatcher;
+use Altair\Introspection\Exception\NotFoundException;
+use Altair\Introspection\Inspector\ListenerInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Altair\Mcp\Support\ContainerLookup;
+use Override;
+
+#[McpTool(
+    name: 'framework__listener_show',
+    description: 'Show the listeners for one event, in priority order.',
+    inputSchema: __DIR__ . '/../../Schema/listener-show-input.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class ListenerShowTool implements McpToolInterface
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $dispatcher = ContainerLookup::firstOf($this->container, EventDispatcher::class, EventDispatcherInterface::class);
+        if (!$dispatcher instanceof EventDispatcher) {
+            return ['available' => false, 'note' => 'No Happen EventDispatcher is bound; this project registers no listeners.'];
+        }
+
+        $event = \is_string($input['event'] ?? null) ? $input['event'] : '';
+
+        try {
+            return (new ListenerInspector($dispatcher))->inspectOne($event)->toArray();
+        } catch (NotFoundException) {
+            return ['found' => false, 'event' => $event];
+        }
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/ListenersListTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/ListenersListTool.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Happen\Contracts\EventDispatcherInterface;
+use Altair\Happen\EventDispatcher;
+use Altair\Introspection\Inspector\ListenerInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Altair\Mcp\Support\ContainerLookup;
+use Override;
+
+#[McpTool(
+    name: 'framework__listeners_list',
+    description: 'List event listeners registered on the Happen dispatcher, by event name.',
+    inputSchema: __DIR__ . '/../../Schema/no-args.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class ListenersListTool implements McpToolInterface
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $dispatcher = ContainerLookup::firstOf($this->container, EventDispatcher::class, EventDispatcherInterface::class);
+        if (!$dispatcher instanceof EventDispatcher) {
+            return ['available' => false, 'note' => 'No Happen EventDispatcher is bound; this project registers no listeners.'];
+        }
+
+        return (new ListenerInspector($dispatcher))->inspectAll()->toArray();
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/ManifestDiffTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/ManifestDiffTool.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Introspection\Exception\IntrospectionException;
+use Altair\Introspection\Inspector\ManifestDiffInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Altair\Mcp\Support\ProjectContext;
+use Override;
+
+#[McpTool(
+    name: 'framework__manifest_diff',
+    description: 'Report drift between the on-disk .agent/ manifests and a fresh regeneration.',
+    inputSchema: __DIR__ . '/../../Schema/no-args.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class ManifestDiffTool implements McpToolInterface
+{
+    public function __construct(private ProjectContext $context) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $manifestRoot = $this->context->path('.agent');
+        if (!is_dir($manifestRoot)) {
+            return ['available' => false, 'note' => 'No .agent/ manifest directory in this project.'];
+        }
+
+        try {
+            // No regenerator wired here: the on-disk tree is treated as canonical,
+            // mirroring `bin/altair manifest:diff`'s default behaviour.
+            return (new ManifestDiffInspector($manifestRoot))->diff([])->toArray();
+        } catch (IntrospectionException $introspectionException) {
+            return ['available' => false, 'note' => $introspectionException->getMessage()];
+        }
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/MiddlewareListTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/MiddlewareListTool.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Http\Collection\MiddlewareCollection;
+use Altair\Introspection\Inspector\PipelineInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Altair\Mcp\Support\ContainerLookup;
+use Override;
+
+#[McpTool(
+    name: 'framework__middleware_list',
+    description: 'List the middleware pipeline in dispatch order.',
+    inputSchema: __DIR__ . '/../../Schema/no-args.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class MiddlewareListTool implements McpToolInterface
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $queue = ContainerLookup::optional($this->container, MiddlewareCollection::class);
+        if (!$queue instanceof MiddlewareCollection) {
+            return ['available' => false, 'note' => 'No MiddlewareCollection is bound; this project registers no middleware.'];
+        }
+
+        return (new PipelineInspector($queue))->inspectAll()->toArray();
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/RouteShowTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/RouteShowTool.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Http\Collection\RouteCollection;
+use Altair\Introspection\Exception\NotFoundException;
+use Altair\Introspection\Inspector\RouteInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Altair\Mcp\Support\ContainerLookup;
+use Override;
+
+#[McpTool(
+    name: 'framework__route_show',
+    description: 'Show the registrations for one route path (across methods).',
+    inputSchema: __DIR__ . '/../../Schema/route-show-input.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class RouteShowTool implements McpToolInterface
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $routes = ContainerLookup::optional($this->container, RouteCollection::class);
+        if (!$routes instanceof RouteCollection) {
+            return ['available' => false, 'note' => 'No RouteCollection is bound; this project registers no HTTP routes.'];
+        }
+
+        $path = \is_string($input['path'] ?? null) ? $input['path'] : '';
+
+        try {
+            return (new RouteInspector($routes))->inspectOne($path)->toArray();
+        } catch (NotFoundException) {
+            return ['found' => false, 'path' => $path];
+        }
+    }
+}

--- a/src/Altair/Mcp/Tool/Introspection/RoutesListTool.php
+++ b/src/Altair/Mcp/Tool/Introspection/RoutesListTool.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Mcp\Tool\Introspection;
+
+use Altair\Container\Container;
+use Altair\Http\Collection\RouteCollection;
+use Altair\Introspection\Inspector\RouteInspector;
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Altair\Mcp\Support\ContainerLookup;
+use Override;
+
+#[McpTool(
+    name: 'framework__routes_list',
+    description: 'List every registered HTTP route (method, path, action).',
+    inputSchema: __DIR__ . '/../../Schema/no-args.json',
+    outputSchema: __DIR__ . '/../../Schema/object-output.json',
+)]
+final readonly class RoutesListTool implements McpToolInterface
+{
+    public function __construct(private Container $container) {}
+
+    /**
+     * @param array<string, mixed> $input
+     *
+     * @return array<string, mixed>
+     */
+    #[Override]
+    public function call(array $input): array
+    {
+        $routes = ContainerLookup::optional($this->container, RouteCollection::class);
+        if (!$routes instanceof RouteCollection) {
+            return ['available' => false, 'note' => 'No RouteCollection is bound; this project registers no HTTP routes.'];
+        }
+
+        return (new RouteInspector($routes))->inspectAll()->toArray();
+    }
+}

--- a/tests/Mcp/Tool/IntrospectionToolsTest.php
+++ b/tests/Mcp/Tool/IntrospectionToolsTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Mcp\Tool;
+
+use Altair\Container\Container;
+use Altair\Happen\Contracts\EventDispatcherInterface;
+use Altair\Happen\EventDispatcher;
+use Altair\Http\Collection\MiddlewareCollection;
+use Altair\Http\Collection\RouteCollection;
+use Altair\Mcp\Support\ProjectContext;
+use Altair\Mcp\Tool\Introspection\ConfigDumpTool;
+use Altair\Mcp\Tool\Introspection\ContainerInspectTool;
+use Altair\Mcp\Tool\Introspection\ListenersListTool;
+use Altair\Mcp\Tool\Introspection\ListenerShowTool;
+use Altair\Mcp\Tool\Introspection\ManifestDiffTool;
+use Altair\Mcp\Tool\Introspection\MiddlewareListTool;
+use Altair\Mcp\Tool\Introspection\RouteShowTool;
+use Altair\Mcp\Tool\Introspection\RoutesListTool;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContainerInspectTool::class)]
+#[CoversClass(ConfigDumpTool::class)]
+#[CoversClass(RoutesListTool::class)]
+#[CoversClass(RouteShowTool::class)]
+#[CoversClass(ListenersListTool::class)]
+#[CoversClass(ListenerShowTool::class)]
+#[CoversClass(MiddlewareListTool::class)]
+#[CoversClass(ManifestDiffTool::class)]
+final class IntrospectionToolsTest extends TestCase
+{
+    private function container(): Container
+    {
+        $container = new Container();
+        $container->share($container);
+
+        return $container;
+    }
+
+    public function testContainerInspectReturnsBindings(): void
+    {
+        $result = (new ContainerInspectTool($this->container()))->call([]);
+
+        self::assertArrayHasKey('rows', $result);
+        self::assertContains('id', $result['columns']);
+    }
+
+    public function testConfigDumpMasksSecretsUnconditionally(): void
+    {
+        $container = $this->container();
+        $container->defineParameter('db_password', 'supersecret');
+        $container->defineParameter('app_name', 'altair');
+
+        $result = (new ConfigDumpTool($container))->call([]);
+
+        self::assertTrue($result['extras']['masked']);
+
+        $byKey = [];
+        foreach ($result['rows'] as $row) {
+            $byKey[$row['key']] = $row['value'];
+        }
+
+        self::assertSame('***', $byKey['$db_password']);
+        self::assertSame('altair', $byKey['$app_name']);
+    }
+
+    public function testRoutesListReportsUnavailableWithoutRouteCollection(): void
+    {
+        self::assertFalse((new RoutesListTool($this->container()))->call([])['available']);
+    }
+
+    public function testRoutesListReturnsRoutesWhenBound(): void
+    {
+        $container = $this->container();
+        $container->share(new RouteCollection(['GET /users' => 'App\\ListUsers']));
+
+        $result = (new RoutesListTool($container))->call([]);
+
+        self::assertSame('/users', $result['rows'][0]['path']);
+        self::assertSame('GET', $result['rows'][0]['method']);
+    }
+
+    public function testRouteShowFindsAndMisses(): void
+    {
+        $container = $this->container();
+        $container->share(new RouteCollection(['GET /users' => 'App\\ListUsers']));
+
+        $found = (new RouteShowTool($container))->call(['path' => '/users']);
+        self::assertSame('/users', $found['rows'][0]['path']);
+
+        $missing = (new RouteShowTool($container))->call(['path' => '/nope']);
+        self::assertFalse($missing['found']);
+    }
+
+    public function testListenersListReportsUnavailableWithoutDispatcher(): void
+    {
+        self::assertFalse((new ListenersListTool($this->container()))->call([])['available']);
+    }
+
+    public function testListenersListAndShowWhenBound(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('user.created', static fn(): null => null);
+
+        $container = $this->container();
+        $container->share($dispatcher);
+
+        $list = (new ListenersListTool($container))->call([]);
+        self::assertContains('user.created', array_column($list['rows'], 'event'));
+
+        $show = (new ListenerShowTool($container))->call(['event' => 'user.created']);
+        self::assertNotEmpty($show['rows']);
+
+        $missing = (new ListenerShowTool($container))->call(['event' => 'no.such.event']);
+        self::assertFalse($missing['found']);
+    }
+
+    public function testListenersListResolvesDispatcherBoundUnderInterfaceKey(): void
+    {
+        $dispatcher = new EventDispatcher();
+        $dispatcher->addListener('order.placed', static fn(): null => null);
+
+        $container = $this->container();
+        $container->delegate(EventDispatcherInterface::class, static fn(): EventDispatcher => $dispatcher)
+            ->share(EventDispatcherInterface::class);
+
+        $result = (new ListenersListTool($container))->call([]);
+
+        self::assertContains('order.placed', array_column($result['rows'], 'event'));
+    }
+
+    public function testMiddlewareListReportsUnavailableThenLists(): void
+    {
+        self::assertFalse((new MiddlewareListTool($this->container()))->call([])['available']);
+
+        $container = $this->container();
+        $container->share(new MiddlewareCollection(['App\\Middleware\\Cors']));
+
+        $result = (new MiddlewareListTool($container))->call([]);
+        self::assertSame('App\\Middleware\\Cors', $result['rows'][0]['middleware']);
+    }
+
+    public function testManifestDiffNotesMissingAgentDir(): void
+    {
+        $context = new ProjectContext(sys_get_temp_dir() . '/mcp-no-agent-' . bin2hex(random_bytes(3)), ProjectContext::detect()->altairSrcDir);
+
+        self::assertFalse((new ManifestDiffTool($context))->call([])['available']);
+    }
+}


### PR DESCRIPTION
## Summary

Wraps the framework's introspection inspectors (#71) as **8 read-only MCP tools**, so an agent can inspect a running Altair app natively through `univeros/mcp` (#69) without shelling out. The server now exposes **28 tools**. Closes #84.

## Tools added

| MCP tool | Wraps | Notes |
|---|---|---|
| `framework__container_inspect` | `ContainerInspector::inspectAll` | `shared_only` / `filter` inputs |
| `framework__config_dump` | `ConfigInspector` | **secrets always masked at the boundary** |
| `framework__routes_list` / `framework__route_show` | `RouteInspector` | |
| `framework__listeners_list` / `framework__listener_show` | `ListenerInspector` | |
| `framework__middleware_list` | `PipelineInspector` | |
| `framework__manifest_diff` | `ManifestDiffInspector` | mirrors `bin/altair manifest:diff` default |

`spec_list` / `spec_show` from the issue table are already covered by #69's `list_specs` / `read_spec`, so they're not duplicated.

## Design

- **Graceful degradation**: tools that need host-app runtime state (`RouteCollection`, Happen `EventDispatcher`, `MiddlewareCollection`) resolve it via a new `ContainerLookup` helper (`isset` → `get` in try/catch, instanceof-guarded) and return `{available: false, note: ...}` when absent — so the server works in a bare framework checkout, not just a full app. `*_show` tools return `{found: false, ...}` on a miss.
- **`config_dump` secret safety**: the tool takes no arguments and hard-codes `maskSecrets: true` (the caller cannot opt out), and adds a hardened extra-pattern set (`PASS`, `PWD`, `OAUTH`, `DSN`, `SALT`, `CERT`, `SIGNATURE`, `WEBHOOK`) on top of `ConfigInspector`'s defaults since output lands in an LLM context.
- **Listener resolution** probes both `EventDispatcher::class` and the `EventDispatcherInterface` key (the canonical `IntrospectionConfiguration` wiring binds the dispatcher under the interface).

## Acceptance criteria
- [x] Each tool's JSON schema matches its CLI `--format=json` output shape (`InspectionTable::toArray()`)
- [x] Tools are read-only (no writes, no subprocess, no SQL)
- [x] `config_dump` defaults to masked secrets and cannot leak full secrets even if the caller forgets a flag
- [x] Tests invoke each tool and assert the response shape (available + degraded paths)

## Test plan
- [x] 10 new unit tests (incl. secret-masking, degraded `available:false` paths, dispatcher-bound-under-interface)
- [x] Full suite green: 5698 tests, only pre-existing env-only failures (ext-mongodb etc.)
- [x] PHPStan level 8, Rector dry-run, php-cs-fixer (cache-free) — all clean
- [x] `bin/altair mcp:tools` lists 28 tools
- [ ] CI green on 8.3 + 8.4