### PR TITLE
re #15 docs for the 7 undocumented packages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,7 +48,14 @@ Talking to external systems and managing cryptographic primitives.
 
 Developer experience and AI-agent ergonomics.
 
+- [Cli](./packages/cli.md) — attribute-driven CLI: write a `#[Command]` invokable, decorate its `__invoke()` params with `#[Argument]`/`#[Option]`, and `bin/altair` discovers and autowires it. The substrate every other tool's commands ride on.
 - [AgentSpec](./packages/agent-spec.md) — turns every framework package into a deterministic Markdown manifest under `.agent/` so AI agents can be productive without reading source. Ships `manifest:generate` and `manifest:show` CLI commands with a `--check` drift gate for CI.
+- [Scaffold](./packages/scaffold.md) — the spec-driven core: a YAML endpoint spec in, Action / Input / Responder / domain stub / test / OpenAPI fragment / route entry out, plus a rewind/replay journal, drift linting, and TypeScript/Python SDK emitters.
+- [Introspection](./packages/introspection.md) — a read-only X-ray of a booted app — container bindings, routes, listeners, middleware, specs, masked config — as `bin/altair` commands with `--format=json` for agents.
+- [Doctor](./packages/doctor.md) — a health-check runner (`bin/altair doctor`) with a deterministic JSON report: PHP/extension/composer checks, CS/PHPStan/test gates, container and database probes, and opt-in fixes.
+- [Events](./packages/events.md) — the append-only `.altair/events.jsonl` mutation log, so agents and developers can answer "what just changed?" across sessions. (Not the PSR-14 dispatcher — that's Happen.)
+- [TestReporter](./packages/test-reporter.md) — an AI-native PHPUnit 11 extension that emits a structured JSON report, mapping each failure back to the production source under test with structured diffs.
+- [Mcp](./packages/mcp.md) — a first-party Model Context Protocol server exposing the framework as 28 agent-callable tools over stdio/HTTP, so any MCP client can build, inspect, test, and ship an Altair API through tool calls.
 
 ## How these docs are structured
 

--- a/docs/packages/cli.md
+++ b/docs/packages/cli.md
@@ -1,0 +1,297 @@
+# Cli
+
+> An attribute-driven CLI runtime layered over **Symfony Console** — you write a `final` invokable class, decorate its parameters with `#[Argument]` / `#[Option]`, and the framework turns it into a fully wired console command resolved through the container.
+
+**Composer:** `univeros/cli`
+**Namespace:** `Altair\Cli`
+
+## Introduction
+
+Every framework needs a command line. Most of them make you extend a base `Command` class, override `configure()` to register each argument and option by hand, override `execute()` to pull those values back out of an `InputInterface`, cast the strings yourself, and remember to return an exit code. That is a lot of ceremony for "take an email and a role, create a user".
+
+This package removes the ceremony. You write one `final` class with an `__invoke()` method, you tag its parameters with attributes, and `Altair\Cli` reflects the rest. The parameter's native type *is* the argument's type: declare `int $count` and you get integer coercion plus a clean error message when someone passes `--count=banana`. Declare a backed enum and only its valid cases are accepted. The class is constructed through `Altair\Container`, so your command's collaborators (repositories, services, configuration) are autowired the same way they are everywhere else in the framework.
+
+The runtime is a thin shell around Symfony Console, not a replacement for it. `Application` extends `Symfony\Component\Console\Application`, so you keep Symfony's help output, `--no-interaction`, `list`, shell completion, and the entire `CommandTester` testing harness. What the package adds is the bridge: a way to author commands as plain invokables and have them register, autowire, and bind their input without you touching Symfony's `InputDefinition` API directly.
+
+This is the substrate the rest of the framework's tooling sits on. `bin/altair manifest:generate`, `bin/altair spec:scaffold`, `bin/altair db:migrate`, `bin/altair doctor`, and the MCP server commands are all plain `#[Command]` classes discovered through this package. When you add your own application commands, you write them the same way.
+
+## Installation
+
+Standalone:
+
+```bash
+composer require univeros/cli
+```
+
+That pulls in `symfony/console ^7.0`, `univeros/container ^2.0`, and `univeros/configuration ^2.0`. No PHP extensions beyond what core PHP 8.3 already requires.
+
+If you are installing the full framework, `composer require univeros/framework` already bundles it — and you already have the `bin/altair` entry point on disk.
+
+## Quick start
+
+A command is a `final` class carrying `#[Command]`, with an `__invoke()` whose parameters carry `#[Argument]` / `#[Option]`. Save this as `src/Cli/GreetCommand.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cli;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+
+#[Command(name: 'greet', description: 'Print a friendly greeting.')]
+final readonly class GreetCommand
+{
+    public function __invoke(
+        #[Argument(description: 'Who to greet.')]
+        string $name,
+        #[Option(description: 'Repeat the greeting N times.', short: 'c')]
+        int $count = 1,
+        #[Option(description: 'Shout in upper case.')]
+        bool $loud = false,
+    ): int {
+        $message = "Hello, {$name}!";
+        if ($loud) {
+            $message = strtoupper($message);
+        }
+
+        for ($i = 0; $i < $count; $i++) {
+            echo $message, PHP_EOL;
+        }
+
+        return 0;
+    }
+}
+```
+
+Point the binary at the directory that holds it and run it:
+
+```bash
+ALTAIR_CLI_PATHS="$(pwd)/src/Cli" bin/altair greet World --count=2 --loud
+# HELLO, WORLD!
+# HELLO, WORLD!
+```
+
+Symfony Console gives you `--help` for free, derived entirely from your attributes:
+
+```bash
+ALTAIR_CLI_PATHS="$(pwd)/src/Cli" bin/altair greet --help
+```
+
+No `configure()`, no `execute()`, no manual `InputArgument`/`InputOption` registration. The `string $name` became a required argument, `int $count = 1` became an optional value option that only accepts integers, and `bool $loud = false` became a value-less flag.
+
+## Concepts
+
+The package has a small number of moving parts, and they line up one-to-one with the namespaces under `Altair\Cli\*`:
+
+- **Attribute-driven invokable commands.** A command is any class with the `#[Command]` attribute (`Altair\Cli\Attribute\Command`) and an `__invoke()` method. There is no base class to extend and no interface to implement. `Command` carries `name`, `description`, `aliases`, `hidden`, and `help`; `#[Argument]` and `#[Option]` describe the `__invoke()` parameters.
+
+- **`Application` extends Symfony Console.** `Altair\Cli\Application` is a `Symfony\Component\Console\Application` subclass. Its one addition is `discover(iterable $commandClasses)`, which wraps each discovered class in an `AltairCommand` and registers it. Everything else — argument parsing, help rendering, exit-code handling — is Symfony's.
+
+- **The `AltairCommand` bridge.** `AltairCommand` is the adapter between your invokable and Symfony's `Command` surface. One `AltairCommand` wraps exactly one of your classes. In `configure()` it reflects `__invoke()` and registers each parameter as an argument or option; in `execute()` it pulls each value back out of the `InputInterface`, coerces it to the parameter's declared type, constructs your class via the container, and calls `__invoke()`.
+
+- **Container autowiring of command constructors.** When a command runs, `AltairCommand::execute()` calls `$container->make($commandClass)` — so your command's *constructor* dependencies are autowired by `Altair\Container`, exactly like any other service. The fixture command `CreateUserIntegrationCommand` takes a `SpyUserRepository` in its constructor and never news it up; the container provides it. Your `__invoke()` parameters are the CLI inputs; your `__construct()` parameters are your collaborators.
+
+- **Discovery via attribute scan.** `Discovery\AttributeCommandDiscoverer` (which implements `Contracts\CommandLocatorInterface`) walks the registered directories, tokenizes every `.php` file to read its namespace and class declarations *without including the file*, then reflects on each candidate to check for the `#[Command]` attribute. Abstract classes, interfaces, and traits are skipped. Each class is yielded once, even if a path is listed twice.
+
+The shape that ties them together at boot:
+
+```
+ALTAIR_CLI_PATHS + built-in Cli/ dirs
+        │
+        ▼
+AttributeCommandDiscoverer::scan() ──► [class-string, ...]
+        │
+        ▼
+Application::discover() ──► AltairCommand (one per class)
+        │
+   Application::run()
+        │
+        ▼
+AltairCommand::execute() ──► Container::make() ──► __invoke(...$coercedArgs)
+```
+
+## Usage
+
+### Writing a command
+
+Three rules, all enforced at registration time so mistakes surface loudly rather than silently misbehaving:
+
+1. The class carries `#[Command(name: ..., description: ...)]`. A class without it is ignored by discovery, and `AltairCommand` throws `InvalidCommandException` if you wire one up directly.
+2. The class defines `__invoke()`. Missing it is an `InvalidCommandException`.
+3. Every `__invoke()` parameter carries either `#[Argument]` or `#[Option]`. A naked parameter throws `InvalidCommandException` — there is no implicit positional binding.
+
+`__invoke()` returns `int` or `void`. Return `0` (or nothing) for success and a non-zero int to signal failure; the value becomes the process exit code. Returning anything else throws `InvalidCommandException`.
+
+Here is a realistic command — the one the package's own integration test exercises — showing constructor autowiring, an argument, a nullable option, an enum option, a short alias, and a boolean flag:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Cli;
+
+use Altair\Cli\Attribute\Argument;
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+use App\User\Role;
+use App\User\UserRepository;
+
+#[Command(
+    name: 'users:create',
+    description: 'Create a new user account',
+    aliases: ['users:add'],
+    help: 'Detailed help block shown by `users:create --help`.',
+)]
+final readonly class CreateUserCommand
+{
+    public function __construct(
+        private UserRepository $repository,   // autowired by the container
+    ) {}
+
+    public function __invoke(
+        #[Argument(description: 'The user email')]
+        string $email,
+        #[Option(description: 'Initial password (random if omitted)', short: 'p')]
+        ?string $password = null,
+        #[Option(description: 'User role', short: 'r')]
+        Role $role = Role::Member,
+        #[Option(description: 'Skip welcome email')]
+        bool $silent = false,
+    ): int {
+        $this->repository->create($email, $password, $role, $silent);
+
+        return 0;
+    }
+}
+```
+
+Invoked as:
+
+```bash
+bin/altair users:create jane@example.com --password=s3cret --role=admin --silent
+bin/altair users:add  jane@example.com -p s3cret -r admin        # alias + shorts
+```
+
+### How arguments and options are bound
+
+The two binders translate reflection into Symfony's input model:
+
+- **`#[Argument]`** (positional). `Binding\ArgumentBinder` makes it `InputArgument::REQUIRED` when the parameter has no default, `InputArgument::OPTIONAL` when it does. An `array`-typed parameter becomes a variadic (`IS_ARRAY`) argument. The public name defaults to the parameter name; override it with `#[Argument(name: 'custom')]`.
+
+- **`#[Option]`** (named, `--flag`). `Binding\OptionBinder` makes a `bool` parameter a value-less flag (`VALUE_NONE` — presence means `true`), and everything else a `VALUE_REQUIRED` option. An `array`-typed option becomes repeatable (`VALUE_IS_ARRAY`). The public name defaults to the parameter name **kebab-cased** — `$dryRun` becomes `--dry-run` — and `#[Option(short: 'p')]` adds a single-character alias. Override the long name with `#[Option(name: 'custom')]`.
+
+### How values are coerced
+
+Symfony Console hands you strings (and `true` for value-less flags). `Binding\ValueCoercer` casts each raw value to the parameter's declared native type before `__invoke()` is called, and throws `ValueCoercionException` — surfaced as Symfony's own `InvalidArgumentException`, so the user sees a clean console error — when a value does not fit:
+
+| Declared type | Accepted input | Notes |
+|---|---|---|
+| `string` | any scalar | cast with `(string)` |
+| `int` | `-?\d+` strings | rejects `1.5`, `banana` |
+| `float` | numeric strings | accepts `1`, `1.5`, `1e3` |
+| `bool` | `1/true/yes/on/y` → true; `0/false/no/off/n/''` → false | case-insensitive |
+| `array` | repeated option values, or a single comma-separated string | `--tag=a,b` and `--tag=a --tag=b` both yield `['a', 'b']` |
+| `DateTimeImmutable` | any ISO-8601 string | parsed via the `DateTimeImmutable` constructor |
+| backed enum | a valid case value | invalid cases throw with a "not a valid case of enum" message |
+
+A nullable parameter (`?string $password = null`) passes `null` straight through when the option is absent; a non-nullable parameter that receives `null` throws. Untyped parameters are passed through unchanged.
+
+### Registering a command's directory
+
+The framework's CLI binary, `bin/altair`, builds its list of command paths at startup from two sources:
+
+1. **Built-in package directories.** It adds each framework sub-package's `Cli/` directory that exists on disk — `src/Altair/AgentSpec/Cli`, `src/Altair/Doctor/Cli`, `src/Altair/Mcp/Cli`, `src/Altair/Messaging/Cli`, `src/Altair/Persistence/Cli`, and `src/Altair/Scaffold/Cli`. This is why installing the full framework gives you `manifest:*`, `spec:*`, `db:*`, and the rest with zero configuration.
+
+2. **The `ALTAIR_CLI_PATHS` environment variable.** A `PATH_SEPARATOR`-delimited list of additional directories to scan (the legacy singular `ALTAIR_CLI_PATH` is also honored). This is how *your* application's commands get picked up:
+
+```bash
+# one directory
+export ALTAIR_CLI_PATHS="/abs/path/to/app/src/Cli"
+
+# several, colon-separated on Unix
+export ALTAIR_CLI_PATHS="/app/src/Cli:/app/modules/billing/Cli"
+
+bin/altair greet World
+```
+
+Each entry that is not an existing directory is silently skipped, so a stale path in the env var will not crash the binary. Discovery is recursive — nested sub-directories are scanned too.
+
+## Configuration
+
+`Configuration\CliConfiguration` is the single wiring point, and it implements the framework's `ConfigurationInterface`. Construct it with the list of paths to scan (plus optional application name and version) and call `apply()` on a container. It does three things: shares the `AttributeCommandDiscoverer` so the scan result is reused, aliases `CommandLocatorInterface` to that discoverer, and delegates `Application` construction so the app auto-discovers commands the first time it is resolved.
+
+`bin/altair` does exactly this for you — but if you embed the CLI in your own bootstrap (a custom binary, a test, a long-running worker that shells out to commands), wire it by hand:
+
+```php
+use Altair\Cli\Application;
+use Altair\Cli\Configuration\CliConfiguration;
+use Altair\Container\Container;
+
+$container = new Container();
+
+(new CliConfiguration(
+    paths: [__DIR__ . '/src/Cli'],
+    name: 'My App',
+    version: '1.0.0',
+))->apply($container);
+
+$application = $container->make(Application::class);
+
+exit($application->run());
+```
+
+`name` and `version` default to `Application::DEFAULT_NAME` (`'Altair'`) and `Application::DEFAULT_VERSION` (`'2.x-dev'`) — what you see in `bin/altair --version`. Because command classes are resolved through the same `$container`, anything you have bound (repositories, configuration, env-driven services) is available to command constructors. See [container.md](./container.md) for the binding API and [configuration.md](./configuration.md) for the `ConfigurationInterface` contract.
+
+## Testing
+
+You do not need the `bin/altair` binary to test a command. Wrap your class in an `AltairCommand` against a container, hand it to Symfony's `CommandTester`, and assert on the exit code and your collaborators. The package's own suite under `tests/Cli/` is the canonical reference:
+
+```php
+use Altair\Cli\AltairCommand;
+use Altair\Container\Container;
+use Symfony\Component\Console\Tester\CommandTester;
+
+$container = new Container();
+$container->share($spyRepository);                 // autowired into the command's constructor
+
+$command = new AltairCommand(CreateUserCommand::class, $container);
+$tester = new CommandTester($command);
+
+$exitCode = $tester->execute([
+    'email'      => 'jane@example.com',
+    '--password' => 's3cret',
+    '--role'     => 'admin',
+    '--silent'   => true,
+]);
+
+self::assertSame(0, $exitCode);
+```
+
+Tests worth reading before you write your own:
+
+- `tests/Cli/IntegrationTest.php` — the end-to-end story: container autowiring, default fall-through, enum coercion producing a clean Symfony error, `CliConfiguration` auto-discovery, and help output assembled from attributes.
+- `tests/Cli/Binding/ArgumentBinderTest.php` / `OptionBinderTest.php` — exactly how parameters map to required/optional/array/flag modes and how names are derived.
+- `tests/Cli/Binding/ValueCoercerTest.php` — every coercion rule in the table above, including the failure messages.
+- `tests/Cli/Discovery/AttributeCommandDiscovererTest.php` — what the scanner does and does not pick up (see its `fixtures/` directory, including `NotACommand.php`).
+
+## Related packages
+
+- [container.md](./container.md) — the DI container `CliConfiguration` writes into and `AltairCommand` uses (`make()`) to construct your command. Command constructor dependencies are autowired here.
+- [configuration.md](./configuration.md) — the `ConfigurationInterface` contract `CliConfiguration` implements.
+- [agent-spec.md](./agent-spec.md) — exposes `manifest:generate` / `manifest:show` as `#[Command]` invokables through this runtime.
+- [scaffold.md](./scaffold.md) — exposes `spec:scaffold`, `spec:lint`, `journal:*`, and the SDK/OpenAPI emitters as commands; `ScaffoldCommand` is the canonical real-world example of this package's attributes.
+- [doctor.md](./doctor.md) — its diagnostic checks are surfaced as `#[Command]` classes discovered from `src/Altair/Doctor/Cli`.
+- [mcp.md](./mcp.md) — the MCP server commands plug into the same attribute-driven discovery.
+
+## Limitations
+
+- **Console input only.** Coercion covers scalars, `array`, `DateTimeImmutable`, and backed enums. Arbitrary value objects, union types, and intersection types are not coerced — a `__invoke()` parameter typed as something the `ValueCoercer` does not recognize throws `ValueCoercionException`. Resolve such collaborators through the *constructor* (where the container autowires them) instead of through `__invoke()`.
+- **No interactive prompting layer.** The package binds input and dispatches; it does not add a question/prompt helper on top of Symfony. Use Symfony Console's `QuestionHelper` directly if you need it — but a command authored here receives plain `__invoke()` parameters, not the `InputInterface`/`OutputInterface` pair, so interactive prompts mean reaching for Symfony's API around the framework's bridge.
+- **Discovery is filesystem-based.** `AttributeCommandDiscoverer` scans directories you point it at; it does not read PSR-4 maps or composer metadata. Commands shipped inside a vendored package are not auto-discovered unless that package's `Cli/` directory is a built-in path or you add it to `ALTAIR_CLI_PATHS`.
+- **One `#[Command]` per class.** Each `AltairCommand` wraps exactly one invokable. A class that needs to expose several sub-commands should be several classes.
+- **No global flags of its own.** Beyond what Symfony Console provides (`--help`, `--quiet`, `--no-interaction`, `--verbose`, `--version`), the package adds no framework-wide options. Cross-cutting behavior belongs in your command constructors via the container.

--- a/docs/packages/doctor.md
+++ b/docs/packages/doctor.md
@@ -1,0 +1,419 @@
+# Doctor
+
+> A health-check runner that probes your project — PHP version, extensions, container wiring, code style, tests, database, spec drift — and reports back in two shapes: scannable text for you, and deterministic JSON an AI agent can act on without guessing.
+
+**Composer:** `univeros/doctor`
+**Namespace:** `Altair\Doctor`
+
+## Introduction
+
+When an agent (or a human) sits down in a fresh checkout and something is subtly wrong — the wrong PHP on PATH, a missing `ext-redis`, a Configuration that never got applied, stale `vendor/` — the failure usually surfaces three steps later as an inscrutable boot error. By then the agent has burned context chasing a symptom instead of the cause. Doctor exists to front-load that diagnosis: run one command, get a list of everything that is wrong *and* the exact next action for each problem.
+
+That last part is the difference between Doctor and a plain "lint everything" script. Every failing check carries an `agent_action` — a structured "do this next" block (`run_command`, `edit_file`, `install_dep`) — alongside human-readable detail. An agent reads the JSON, sees `{"type": "run_command", "command": "composer install"}`, and runs it. No prose parsing, no heuristics.
+
+The package is deliberately small and contract-first. A check is a side-effect-free probe (`CheckInterface`); a check that can fix itself opts into `FixableCheckInterface`; sub-processes go through `ProcessRunnerInterface` so process-backed checks stay unit-testable; output goes through `ReportRendererInterface` so `human` and `json` are just two registered renderers. Everything else — the default check set, the env-derived requirements, the host-app hooks — is wiring you can replace.
+
+What Doctor deliberately does *not* do: it does not mutate anything in `run()` (probing is read-only), it does not perform destructive fixes (`fix()` is contractually safe and non-destructive), and it does not invent its own quality tooling — `cs_clean` shells out to `composer cs`, `phpstan_clean` to `composer stan`, and so on. Doctor is the orchestrator and the reporter, not a re-implementation of the tools it drives.
+
+## Installation
+
+Standalone:
+
+```bash
+composer require --dev univeros/doctor
+```
+
+You will usually want this as a dev dependency — it diagnoses your *checkout*, not your runtime. If you install the full framework, `composer require univeros/framework` already bundles it.
+
+The package depends only on `univeros/cli` (the `doctor` command plugs into attribute-driven command discovery), `univeros/configuration` (the `DoctorConfiguration` wiring), and `univeros/container` (binding resolution). No PHP extensions beyond core PHP 8.3.
+
+## Quick start
+
+Run every registered check and print a scannable report:
+
+```bash
+bin/altair doctor
+```
+
+The output is one line per check, with the remediation indented directly beneath any non-ok result:
+
+```
+[ok   ] php_version — PHP 8.3.10 satisfies >=8.3
+[ok   ] extensions_loaded — All required extensions loaded: mbstring, pdo.
+[warn ] composer_deps — Composer dependencies are out of date or composer.lock has drifted.
+        fix: Run `composer install`.
+        $ composer install
+[ok   ] cs_clean — Code style is clean.
+
+WARN — 14 checks in 8421ms
+```
+
+Run only a named subset (comma-separated) when you want a fast feedback loop — skip the slow suite, keep the cheap probes:
+
+```bash
+bin/altair doctor --only=php_version,extensions_loaded,cs_clean
+```
+
+Run everything *except* the slow checks (the PHPUnit suite is the usual one to drop):
+
+```bash
+bin/altair doctor --skip=tests_passing
+```
+
+Emit machine-readable JSON — this is what an agent or a CI step parses:
+
+```bash
+bin/altair doctor --format=json
+```
+
+```json
+{
+    "status": "warn",
+    "duration_ms": 8421,
+    "checks": [
+        {
+            "name": "composer_deps",
+            "status": "warn",
+            "detail": "Composer dependencies are out of date or composer.lock has drifted.",
+            "fix": "Run `composer install`.",
+            "agent_action": { "type": "run_command", "command": "composer install" }
+        }
+    ]
+}
+```
+
+Attempt safe auto-fixes for any check that supports one, then re-report the post-fix state:
+
+```bash
+bin/altair doctor --fix
+```
+
+The process exit code is the worst status observed: `0` for all-ok (or skipped), `1` if any check warned, `2` if any errored. That makes `bin/altair doctor` a drop-in CI gate.
+
+> **Host-application boot is required for the host-aware checks.** `bin/altair` only wires CLI discovery (`CliConfiguration`); it does **not** apply `DoctorConfiguration` on your behalf. The default check set — the env-derived `php_version`/`extensions_loaded`, the process-backed checks, and the `container_boots` / `container_resolves` / `database_reachable` hooks — is registered when *your* entry point applies `DoctorConfiguration`. A typical host entry looks like:
+>
+> ```php
+> #!/usr/bin/env php
+> <?php
+> require __DIR__ . '/../vendor/autoload.php';
+>
+> use Altair\Cli\Application;
+> use Altair\Cli\Configuration\CliConfiguration;
+> use Altair\Container\Container;
+> use Altair\Doctor\Configuration\DoctorConfiguration;
+>
+> $container = new Container();
+> (new CliConfiguration([__DIR__ . '/../app/Cli']))->apply($container);
+> (new DoctorConfiguration(
+>     projectRoot: __DIR__ . '/..',
+>     appBooter: static fn() => require __DIR__ . '/bootstrap.php',
+>     criticalBindings: [\Psr\Http\Server\MiddlewareInterface::class],
+> ))->apply($container);
+>
+> exit($container->make(Application::class)->run());
+> ```
+
+## Concepts
+
+**Checks are side-effect-free.** `CheckInterface::run()` is a read-only probe — it inspects PHP, reads `composer.json`, or shells out to a *read-only* sub-command (`composer install --dry-run`, `db:migrate:status`, `git diff --exit-code`). It must never mutate the project. Any remediation lives behind a separate method:
+
+```php
+interface CheckInterface
+{
+    public function name(): string;       // stable id: 'php_version', used by --only/--skip and dependsOn()
+    public function dependsOn(): array;    // names of checks that must pass first
+    public function run(): CheckResult;
+}
+```
+
+**Fixes are opt-in and contractually safe.** A check that can remediate itself implements `FixableCheckInterface`, and `fix()` only runs under `--fix`:
+
+```php
+interface FixableCheckInterface extends CheckInterface
+{
+    public function fix(): bool;            // never destructive: no deletes, downgrades, force-pushes
+}
+```
+
+When you pass `--fix`, the runner calls `fix()` on any non-ok fixable check, then re-runs `run()` so the report reflects the *post-fix* state. `composer_deps`, `cs_clean`, `migrations_pending`, and `manifests_current` are fixable; `phpstan_clean`, `tests_passing`, `database_reachable`, and the spec checks are not — a type error or a failing test needs a root-cause edit, not a mechanical re-run.
+
+**Dependency gating turns cascades into skips.** Each check declares `dependsOn()`. When a prerequisite errored or was skipped, the runner reports the dependent as `skipped` rather than running it — there is no point running the PHPUnit suite when `vendor/` is stale, or probing migrations when the database is unreachable. This keeps a single root failure from producing a wall of downstream noise.
+
+**Skipped is not a false pass.** The host-aware checks (`container_boots`, `container_resolves`, `database_reachable`, `determinism_check`) report `skipped` when their host-supplied hook is absent, never `ok`. A library-only checkout with no database simply skips `database_reachable` — it does not claim the database is fine. `skipped` contributes `0` to the exit code, exactly like `ok`, but is visibly distinct in the report.
+
+**The JSON report is deterministic.** `Report::toArray()` and `CheckResult::toArray()` emit a fixed key order, omit absent optional fields (no `null`s, no stray keys), and carry no timestamps. The single varying field is `duration_ms` — the one timing value the framework's determinism standard permits. Two runs with the same outcomes produce byte-identical JSON apart from that field, which is what makes Doctor safe to diff in CI and stable for agents that cache by content hash.
+
+**`ProcessRunnerInterface` keeps process-backed checks unit-testable.** Every check that shells out takes a `ProcessRunnerInterface` rather than calling `proc_open()` directly. In production that is `ShellProcessRunner` (argv form, no shell, no injection surface); in tests it is a fake that scripts results per command. The check logic gets exercised without ever spawning `composer`.
+
+## Usage
+
+### Running programmatically
+
+`Doctor::run()` is the entry point — the CLI command and the MCP tool are both thin wrappers over it:
+
+```php
+use Altair\Doctor\Doctor;
+
+/** @var Doctor $doctor */          // resolve from the Container after DoctorConfiguration::apply()
+$doctor = $container->make(Doctor::class);
+
+$report = $doctor->run(
+    only: ['php_version', 'extensions_loaded'],   // empty = all checks
+    skip: ['tests_passing'],
+    fix: false,
+);
+```
+
+The signature is:
+
+```php
+public function run(array $only = [], array $skip = [], bool $fix = false): Report
+```
+
+### Reading the report
+
+A `Report` carries every `CheckResult` plus the run duration, and exposes the rolled-up status and exit code:
+
+```php
+$report->status();      // CheckStatus enum: worst observed (Ok | Warn | Error | Skipped)
+$report->exitCode();    // 0 ok/skipped, 1 warn, 2 error
+$report->checks;        // list<CheckResult>
+
+$data = $report->toArray();
+// ['status' => 'warn', 'duration_ms' => 8421, 'checks' => [ ... ]]
+
+foreach ($report->checks as $result) {
+    $result->name;          // 'composer_deps'
+    $result->status;        // CheckStatus::Warn
+    $result->detail;        // human-readable line
+    $result->fix;           // ?string — the remediation hint
+    $result->agentAction;   // ?AgentAction — the structured next action
+    $result->source;        // ?string — production file the failure maps to, when known
+}
+```
+
+`CheckResult` is built through named constructors — `CheckResult::ok()`, `::warn()`, `::error()`, `::skipped()` — so the optional remediation fields only ever appear on results that have a remediation.
+
+### Branching on the structured action
+
+The `AgentAction` block is what lets an agent act without parsing prose. It is one of three shapes:
+
+```php
+use Altair\Doctor\Result\AgentAction;
+
+AgentAction::runCommand('composer install');               // {"type":"run_command","command":"composer install"}
+AgentAction::editFile('phpstan.neon.dist', 'raise level'); // {"type":"edit_file","file":"...","hint":"..."}
+AgentAction::installDep('ext-redis');                       // {"type":"install_dep","package":"ext-redis"}
+```
+
+An orchestrator reads `agent_action.type` and dispatches to the matching tool — run the command, open the file, install the dependency — then re-runs `doctor` to confirm the fix took.
+
+### Writing and registering a custom check
+
+A check is one small class. Here is one that verifies a `.env` file exists — a read-only probe with an `edit_file` action when it is missing:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Doctor;
+
+use Altair\Doctor\Contracts\CheckInterface;
+use Altair\Doctor\Result\AgentAction;
+use Altair\Doctor\Result\CheckResult;
+use Override;
+
+final readonly class EnvFilePresentCheck implements CheckInterface
+{
+    public function __construct(private string $projectRoot) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'env_file_present';
+    }
+
+    #[Override]
+    public function dependsOn(): array
+    {
+        return [];
+    }
+
+    #[Override]
+    public function run(): CheckResult
+    {
+        if (is_file($this->projectRoot . '/.env')) {
+            return CheckResult::ok($this->name(), '.env is present.');
+        }
+
+        return CheckResult::error(
+            $this->name(),
+            'No .env file found at the project root.',
+            'Copy .env.example to .env and fill in the required values.',
+            AgentAction::editFile('.env', 'Create from .env.example and set DB_* and APP_KEY.'),
+        );
+    }
+}
+```
+
+Register it on the `CheckRegistry`. Order matters — checks run top-to-bottom, and `dependsOn()` references resolve against checks that already ran — so hosts typically `add()` their checks via a Container `prepare` hook after `DoctorConfiguration` has populated the default set:
+
+```php
+use Altair\Container\Container;
+use Altair\Doctor\CheckRegistry;
+use App\Doctor\EnvFilePresentCheck;
+
+$container->prepare(
+    CheckRegistry::class,
+    static fn(CheckRegistry $registry) => $registry->add(new EnvFilePresentCheck($projectRoot)),
+);
+```
+
+### Host-app hooks
+
+Three checks come inert until you hand them a host-specific hook through `DoctorConfiguration`. Without the hook they report `skipped`, never a false pass:
+
+| Check | Hook | What it verifies |
+|---|---|---|
+| `container_boots` | `appBooter: Closure(): mixed` | The application Container constructs from scratch without throwing — the most common "agent got stuck" failure mode. |
+| `container_resolves` | `criticalBindings: list<class-string>` | Each declared PSR-11 id actually resolves (boot succeeding does not guarantee every contract is wired). |
+| `database_reachable` | `databaseProbe: Closure(): bool` | The DB is reachable — a typical probe is `static fn() => $em->getConnection()->isConnected()`. |
+
+## Configuration
+
+`DoctorConfiguration` wires the runner, the default check set, the `ShellProcessRunner`, and the `RendererRegistry` into the Container in one `apply()` call:
+
+```php
+use Altair\Doctor\Configuration\DoctorConfiguration;
+
+(new DoctorConfiguration(
+    projectRoot: __DIR__ . '/..',                       // defaults to getcwd()
+    appBooter: static fn() => require __DIR__ . '/boot.php',
+    criticalBindings: [MiddlewareInterface::class, EntityManagerInterface::class],
+    databaseProbe: static fn(): bool => $em->getConnection()->isConnected(),
+))->apply($container);
+```
+
+The PHP floor and the required `ext-*` list are **not** hand-configured — they are read from your project's `composer.json` `require` block, so `php_version` and `extensions_loaded` always reflect what your project itself declares:
+
+- The `php` constraint (e.g. `">=8.3"`) is parsed down to its version floor (`8.3`) and compared against the running runtime by `PhpVersionCheck`.
+- Every `ext-*` requirement (e.g. `ext-redis`, `ext-pdo`) becomes an entry in the `extensions_loaded` probe, sorted for determinism.
+- When `composer.json` is absent or unreadable, the floor falls back to the running PHP's `major.minor` and the extension list is empty — the checks degrade gracefully rather than erroring.
+
+### The default check set
+
+`DoctorConfiguration` registers these checks, in this order (the order defines `dependsOn()` resolution):
+
+| Check name | What it probes | Fixable? |
+|---|---|---|
+| `php_version` | Runtime PHP satisfies the `composer.json` floor. | no |
+| `extensions_loaded` | Every required `ext-*` is loaded. | no |
+| `composer_deps` | `vendor/` is current with `composer.lock` (`composer install --dry-run`). | `composer install` |
+| `container_boots` | Host Container constructs without errors (needs `appBooter`). | no |
+| `container_resolves` | Critical bindings resolve (needs `criticalBindings`). Depends on `container_boots`. | no |
+| `database_reachable` | DB is reachable (needs `databaseProbe`). | no |
+| `migrations_pending` | No unapplied migrations (`db:migrate:status`). Depends on `database_reachable`. | `db:migrate` |
+| `spec_drift` | Scaffolded files still match their YAML specs (`spec:lint`). | no |
+| `openapi_valid` | Specs emit a well-formed OpenAPI document (`spec:emit-openapi`). | no |
+| `manifests_current` | `.agent/` manifests match current source (`manifest:diff`). | `manifest:generate` |
+| `cs_clean` | Code style is clean (`composer cs`). | `composer cs:fix` |
+| `phpstan_clean` | Static analysis is clean (`composer stan`). | no |
+| `tests_passing` | PHPUnit exits 0. Depends on `composer_deps`. | no |
+| `determinism_check` | Generators are byte-stable across regeneration (needs `generators` + `paths`). | no |
+
+### Output formats
+
+`RendererRegistry::default()` ships `human` and `json`. To add your own format, bind a populated registry before bootstrapping:
+
+```php
+use Altair\Doctor\Output\HumanRenderer;
+use Altair\Doctor\Output\JsonRenderer;
+use Altair\Doctor\Output\RendererRegistry;
+
+$container->delegate(
+    RendererRegistry::class,
+    static fn(): RendererRegistry => new RendererRegistry([
+        'human'    => new HumanRenderer(),
+        'json'     => new JsonRenderer(),
+        'markdown' => new App\Doctor\MarkdownRenderer(),
+    ]),
+);
+```
+
+An unknown `--format` raises a `DoctorException` listing the formats that are available.
+
+## Testing
+
+The published tests under `tests/Doctor/` double as worked examples of every extension point:
+
+- [tests/Doctor/DoctorTest.php](../../tests/Doctor/DoctorTest.php) — the runner: `--only`/`--skip` filtering, dependency-skip behaviour, `--fix` re-run.
+- [tests/Doctor/Check/PureChecksTest.php](../../tests/Doctor/Check/PureChecksTest.php) — `php_version`, `extensions_loaded` (using the injectable probe).
+- [tests/Doctor/Check/ProcessChecksTest.php](../../tests/Doctor/Check/ProcessChecksTest.php) — the process-backed checks against the fake runner.
+- [tests/Doctor/Check/HostAppChecksTest.php](../../tests/Doctor/Check/HostAppChecksTest.php) — the host-hook checks, including the `skipped`-when-absent path.
+- [tests/Doctor/Output/RenderersTest.php](../../tests/Doctor/Output/RenderersTest.php) — human + JSON rendering, determinism of the JSON projection.
+- [tests/Doctor/Result/ResultObjectsTest.php](../../tests/Doctor/Result/ResultObjectsTest.php) — `CheckResult`/`Report`/`AgentAction` shape and `toArray()`.
+- [tests/Doctor/Configuration/DoctorConfigurationTest.php](../../tests/Doctor/Configuration/DoctorConfigurationTest.php) — env-derived requirements + Container wiring.
+
+The key testing tool is the in-memory `FakeProcessRunner` ([tests/Doctor/Support/FakeProcessRunner.php](../../tests/Doctor/Support/FakeProcessRunner.php)): you script a result per command and assert on the calls made, so a process-backed check is exercised end-to-end without ever spawning a subprocess.
+
+```php
+use Altair\Tests\Doctor\Support\FakeProcessRunner;
+use Altair\Doctor\Check\CsCleanCheck;
+use Altair\Doctor\Process\ProcessResult;
+use Altair\Doctor\Result\CheckStatus;
+
+$runner = new FakeProcessRunner();
+$runner->on(['composer', 'cs'], new ProcessResult(1));   // simulate a style violation
+
+$result = (new CsCleanCheck($runner, '/project'))->run();
+
+self::assertSame(CheckStatus::Warn, $result->status);
+```
+
+When you add a new check, mirror this: inject the dependency that touches the outside world (a `Closure` probe or the `ProcessRunnerInterface`), script it in the test, and assert on the resulting `CheckStatus`. No new check should require a real PHP, a real `composer`, or a real database to test.
+
+## Extending
+
+The two natural extension points are the check set and the renderer set.
+
+**A new check** implements `CheckInterface` (or `FixableCheckInterface` for self-remediation) and is `add()`-ed to the `CheckRegistry`, as shown in [Usage](#writing-and-registering-a-custom-check) above. If it touches the filesystem or a sub-process, inject the dependency rather than calling it directly so the check stays testable. Set `dependsOn()` to the names of any checks that must pass first — the runner will skip yours if a prerequisite breaks.
+
+**A new renderer** implements `ReportRendererInterface` and is registered in a `RendererRegistry` under its `--format` key:
+
+```php
+use Altair\Doctor\Contracts\ReportRendererInterface;
+use Altair\Doctor\Result\Report;
+use Override;
+
+final readonly class MarkdownRenderer implements ReportRendererInterface
+{
+    #[Override]
+    public function render(Report $report): string
+    {
+        $rows = array_map(
+            static fn($c): string => \sprintf('| %s | %s | %s |', $c->name, $c->status->value, $c->detail),
+            $report->checks,
+        );
+
+        return "| Check | Status | Detail |\n|---|---|---|\n" . implode("\n", $rows) . "\n";
+    }
+}
+```
+
+The contract requires determinism — same `Report`, byte-identical output (the `duration_ms` field aside) — so avoid `microtime()` and unordered iteration in your renderer.
+
+## Related packages
+
+- [`univeros/cli`](./cli.md) — the attribute-driven CLI substrate. `DoctorCommand` is a plain invokable registered through `#[Command(name: 'doctor')]`; `--format`/`--only`/`--skip`/`--fix` are `#[Option]`s.
+- [`univeros/introspection`](./introspection.md) — the broader "what is this project?" tooling. Doctor answers "is this project healthy?"; introspection answers "what does it contain?".
+- [`univeros/scaffold`](./scaffold.md) — the spec scaffolder. `spec_drift` and `openapi_valid` drive its `spec:lint` / `spec:emit-openapi` commands; `manifests_current` and `determinism_check` guard the same generated content.
+- [`univeros/mcp`](./mcp.md) — the MCP server. Its `framework__doctor` tool wraps `Doctor::run()` and returns `Report::toArray()`, so an MCP-connected agent gets the same structured report the CLI emits as JSON.
+- [`univeros/container`](./container.md) — resolves `Doctor`, `CheckRegistry`, and the renderers; `container_resolves` probes bindings through its PSR-11 `get()`.
+
+## Limitations
+
+- **The host-aware checks need a host.** `container_boots`, `container_resolves`, `database_reachable`, and `determinism_check` are inert (`skipped`) until you supply their hooks via `DoctorConfiguration`. `bin/altair doctor` from a bare framework checkout, with no host entry point applying `DoctorConfiguration`, will not run the default check set — wire the Configuration in your application's entry point (see the [Quick start](#quick-start) callout).
+- **Process-backed checks shell out.** `composer_deps`, `cs_clean`, `phpstan_clean`, `tests_passing`, and the spec/manifest checks invoke `composer`, `vendor/bin/phpunit`, `git`, and `bin/altair` as sub-processes. If those binaries are not on PATH (or PHP is not installed), the underlying `proc_open()` fails and the check reports a non-ok status — Doctor diagnoses tool availability rather than guaranteeing it.
+- **`--fix` is intentionally conservative.** Fixes are limited to safe, mechanical operations (`composer install`, `cs:fix`, `db:migrate`, `manifest:generate`). Type errors, failing tests, and unreachable databases are reported, never auto-resolved — they need a root-cause edit a human or agent must make.
+- **No parallelism.** Checks run sequentially, top-to-bottom, so the registry order is also the report order. The slow members (`tests_passing`, `phpstan_clean`) dominate wall-clock time; use `--skip` for a fast inner-loop run.

--- a/docs/packages/events.md
+++ b/docs/packages/events.md
@@ -1,0 +1,291 @@
+# Events
+
+> An append-only mutation event log at `.altair/events.jsonl`, so an agent or a human can answer "what just changed?" across sessions — every scaffold, migration, rewind, rector run, or worker consume leaves one line behind.
+
+**Composer:** `univeros/events`
+**Namespace:** `Altair\Events`
+
+## Introduction
+
+When you (or an agent acting on your behalf) run a sequence of mutating commands — scaffold three endpoints, apply a migration, rewind one of them, run `cs:fix` — the working tree tells you the *current* state, but it loses the *story*. Git history only captures what you committed; it says nothing about the dozen iterations between commits, and it certainly doesn't survive a fresh agent session that starts with an empty context window. This package fills that gap. Every mutating framework operation appends one JSON line to `.altair/events.jsonl`, and a small read/query layer lets you ask "what happened since my last good state?" without re-reading the whole tree.
+
+The format is deliberately humble: newline-delimited JSON, flat fields, `jq`-friendly. The log is local-first and trusted-but-careful — it lives under `.altair/` next to your checkout, never leaves the machine, and a [Scrubber](#scrubber-secret-redaction) strips secret-bearing flags before anything is written. Recording is *best-effort*: if the disk is full or the filesystem is read-only, the event drops silently and your command still returns the value it was going to return. The log is observability, never load-bearing logic.
+
+This is **not** a PSR-14 event dispatcher. If you want to publish an in-process domain event (`order.shipped`) and have listeners react to it within the same request, reach for [Happen](./happen.md) — that package owns synchronous, listener-driven dispatch. This package (`univeros/events`) owns the *persistent, append-only record of mutations* that already happened. The two share the word "event" and nothing else: Happen is fire-and-observe inside one process; Events is write-and-recall across many sessions. Keep them straight by asking what you need — to *react* to something now (Happen) or to *remember* something later (Events).
+
+## Installation
+
+```bash
+composer require univeros/events
+```
+
+The runtime dependencies are `psr/log ^3.0` (warnings when recording fails), `symfony/uid ^7.0` (the ULID that stamps every event), and the framework's `univeros/cli`, `univeros/configuration`, and `univeros/container` packages — the CLI commands plug into attribute-driven command discovery, and `EventsConfiguration` wires everything from environment variables. No database, no extension.
+
+## Quick start
+
+The log fills itself as you use the framework. The commands you reach for most read it back. To see the newest events first, tail the log — the `-n` flag controls how many lines you get back:
+
+```bash
+bin/altair events:tail -n 50
+```
+
+When you start a fresh session and want to know what changed since the last time everything was green, ask for events since the most recent successful one. This walks newest-first and stops at the first `ok` event, so you see exactly the run of failures/partials that followed your last good state:
+
+```bash
+bin/altair events:since-last-success
+```
+
+To narrow the log to one kind of operation, or only the failures, filter by kind and/or status — both flags take comma-separated values and default to "all":
+
+```bash
+bin/altair events:filter --kind=scaffold,migration --status=fail
+```
+
+For a bird's-eye view — totals by kind, by status, and the cumulative wall-clock time the framework has spent mutating this checkout — print the aggregate stats:
+
+```bash
+bin/altair events:stats
+```
+
+Every read command also accepts `--format=json` when you want to pipe the output into `jq` or hand it to an agent instead of reading it yourself.
+
+## Concepts
+
+### The Event record
+
+An `Event` is a `final readonly` value object — one immutable line in the log. You almost never construct one directly; you use the named-constructor factory `Event::create()`, which stamps a fresh ULID and the current UTC instant for you so identity and ordering stay consistent:
+
+```php
+public static function create(
+    Actor $actor,
+    string $command,
+    EventKind $kind,
+    EventStatus $status,
+    int $durationMs,
+    ?string $user = null,
+    ?string $client = null,
+    ?Changes $changes = null,
+    ?string $error = null,
+    array $extra = [],
+): self;
+```
+
+The constructor validates at the boundary: the `id` and `command` must be non-empty, `durationMs` must be non-negative, and a `Fail` status *must* carry a non-empty `error` string — a failed event with no explanation is a contradiction the constructor refuses to build. `Event::toArray()` and `Event::toJsonLine()` serialise it; `Event::fromArray()` hydrates it back (tolerating timestamps with or without microseconds). The ULID gives you sortable-by-creation identity for free, which is why `events:since <id>` works.
+
+### EventKind, EventStatus, Actor
+
+Three string-backed enums classify each event. `EventKind` is the catalogue of mutating operations the framework records — kept alphabetical so the enum diffs cleanly:
+
+```
+CsFix = 'cs_fix'                       ManualEdit = 'manual_edit'
+Eval = 'eval'                          Migration = 'migration'
+IndexBuild = 'index_build'            RectorRun = 'rector_run'
+ManifestGenerate = 'manifest_generate' Replay = 'replay'
+                                       Rewind = 'rewind'
+                                       Scaffold = 'scaffold'
+                                       WorkerConsume = 'worker_consume'
+```
+
+`EventStatus` is the three-valued outcome: `Ok = 'ok'`, `Fail = 'fail'`, `Partial = 'partial'`. `Partial` is for the half-succeeded case — a batch scaffold that wrote four files and choked on the fifth. `Actor` records *who* triggered the event: `Cli = 'cli'` (a `bin/altair` invocation by a human or agent shell), `Mcp = 'mcp'` (an MCP client like Claude Desktop invoking a framework tool), `Worker = 'worker'` (a long-running consumer), and `Script = 'script'` (a one-off PHP script). Use `EventKind::fromString()` when reading untrusted input — it throws on an unknown value rather than returning null.
+
+### Changes — the "what changed" payload
+
+`Changes` is an immutable map of verb buckets plus an optional snapshot reference. The vocabulary is open-ended on purpose: a scaffold names buckets like `created` and `modified`, a migration names `applied`, a rewind names `restored` — the type doesn't lock you into one set of words. You build it up immutably with `withBucket()` and `withSnapshotRef()`, each returning a new copy:
+
+```php
+use Altair\Events\Changes;
+
+$changes = (new Changes())
+    ->withBucket('created', 'src/App/User.php', 'src/App/UserRepository.php')
+    ->withBucket('modified', 'config/routes.php');
+```
+
+When the change set is too large to inline on one line — a 200-file rector run — write the heavy diff to a snapshot and reference it (`->withSnapshotRef('snapshots/<id>.json')`) instead of bloating the log line.
+
+### Best-effort recording
+
+`RecorderInterface` has one method, `record(Event $event): void`, and its contract is the important part: **implementations MUST NOT throw.** The default `Recorder` pipes the event through the `Scrubber`, hands it to storage, and swallows any storage failure (logging it at warning level through an injected PSR-3 logger). The consequence is liberating — you can call `record()` from inside any command without wrapping it in a try/catch or worrying that a read-only filesystem will break the command's real work. `NullRecorder` is the no-op binding used when recording is switched off.
+
+### Scrubber — secret redaction
+
+Command lines routinely carry secrets by accident — a copy-pasted `--password`, a `--token` flag. The `Scrubber` redacts them to `***` before the command string is persisted, so "tail the log to debug" never becomes the way credentials leak. It recognises a default list (`--password`, `--passwd`, `--pass`, `--token`, `--api-key`, `--secret`, `--bearer`, `--access-token`, `--db-password`, and more) in both `--flag=value` and `--flag value` forms, case-insensitively on the flag name. Add your own via `withSecrets()` or the `ALTAIR_EVENTS_EXTRA_SECRET_FLAGS` env var (see [Configuration](#configuration)).
+
+### Storage: JSONL, snapshots, checkpoints
+
+Three storage classes back the log, each with a single responsibility:
+
+- **`JsonlStorage`** is the main append-only file. Writes take an exclusive advisory lock (`flock LOCK_EX`) so concurrent `bin/altair` processes don't tear each other's lines; reads take no lock and simply skip any line that fails to JSON-decode. The parent `.altair/` directory is created on demand, so you never have to provision it.
+- **`SnapshotStorage`** holds the oversized change sets — one atomically-written (`tmp` + `rename`) JSON file per event at `.altair/snapshots/<event_id>.json`, referenced from the log line via `changes.snapshot_ref`.
+- **`CheckpointStorage`** holds named bookmarks at `.altair/checkpoints/<name>.json`, each pointing at the event id that was the head of the stream when you created it. Names are filesystem-safe (alphanumeric plus `_ . - /`, no `..`).
+
+`JsonlStorage` implements `EventStorageInterface` (`append`, `readAll` oldest→newest, `readReverse` newest→oldest, `count`); the `Reader` queries on top of it.
+
+## Usage
+
+### Recording an event from your own mutating command
+
+If you write a new command that mutates the checkout, record an event so it joins the same log. Type-hint `RecorderInterface` in your constructor — the container hands you either the real `Recorder` or a `NullRecorder` depending on configuration, so you never branch on whether recording is enabled. Time the work, build a `Changes` payload describing what moved, and call `record(Event::create(...))` once on the way out:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Command;
+
+use Altair\Events\Actor;
+use Altair\Events\Changes;
+use Altair\Events\Contracts\RecorderInterface;
+use Altair\Events\Event;
+use Altair\Events\EventKind;
+use Altair\Events\EventStatus;
+
+final readonly class ImportFixturesCommand
+{
+    public function __construct(
+        private RecorderInterface $recorder,
+    ) {}
+
+    public function __invoke(): int
+    {
+        $start = hrtime(true);
+
+        try {
+            $written = $this->doImport(); // returns list<string> of touched paths
+
+            // Success: stamp a fresh ULID + UTC instant via the factory.
+            $this->recorder->record(Event::create(
+                actor: Actor::Cli,
+                command: 'app:import-fixtures',
+                kind: EventKind::Scaffold,
+                status: EventStatus::Ok,
+                durationMs: $this->elapsedMs($start),
+                changes: (new Changes())->withBucket('created', ...$written),
+            ));
+
+            return 0;
+        } catch (\Throwable $e) {
+            // A Fail event MUST carry a non-empty error — the constructor enforces it.
+            $this->recorder->record(Event::create(
+                actor: Actor::Cli,
+                command: 'app:import-fixtures',
+                kind: EventKind::Scaffold,
+                status: EventStatus::Fail,
+                durationMs: $this->elapsedMs($start),
+                error: $e->getMessage(),
+            ));
+
+            return 1;
+        }
+    }
+
+    private function elapsedMs(float $start): int
+    {
+        return (int) ((hrtime(true) - $start) / 1_000_000);
+    }
+}
+```
+
+Note the single `record()` call per outcome and the fact that you never guard it — best-effort recording means a storage failure won't sabotage your import. Always go through `Event::create()` so the ULID and timestamp stamping stays consistent; never hand-build the JSON line.
+
+### Reading the log programmatically
+
+The `Reader` is the query layer over storage. Inject it (it's bound as a shared service) and call the projection you need — every method returns a generator so a large log streams rather than loading whole:
+
+```php
+use Altair\Events\Reader;
+use Altair\Events\EventKind;
+use Altair\Events\EventStatus;
+
+final readonly class DiagnosticsService
+{
+    public function __construct(private Reader $reader) {}
+
+    public function recentFailures(): array
+    {
+        // Newest-first, only failed migrations.
+        return iterator_to_array(
+            $this->reader->filter([EventKind::Migration], [EventStatus::Fail]),
+            false,
+        );
+    }
+}
+```
+
+`Reader` also exposes `tail($n)`, `since($threshold)`, `sinceId($eventId)`, `sinceLastSuccess()`, `findById($eventId)`, and `stats()` — the same projections the CLI commands sit on top of.
+
+### Checkpoints — bookmarking the stream
+
+Before you start a risky multi-step run, bookmark the current head. Later, ask what happened since the bookmark:
+
+```bash
+bin/altair events:checkpoint:create feat/posts   # bookmark current head
+# ... do work: scaffold, migrate, edit ...
+bin/altair events:checkpoint:diff feat/posts     # events recorded after the bookmark
+bin/altair events:checkpoint:list                # all stored checkpoints
+bin/altair events:checkpoint:delete feat/posts   # remove one
+```
+
+A checkpoint stores only the event id of the head at creation time, so `checkpoint:diff` is just `sinceId` under the hood.
+
+### Compaction — keeping the log small
+
+The log is meant to be compacted before it gets gigantic. Archive everything older than a cutoff into `.altair/events.archive/`, leaving the active log lean:
+
+```bash
+bin/altair events:compact --before=2026-04-01
+```
+
+## Configuration
+
+`EventsConfiguration` wires every primitive into the container from environment variables. It parses `EventsSettings` once, then binds `Scrubber`, `JsonlStorage` (aliased to `EventStorageInterface`), `SnapshotStorage`, `CheckpointStorage`, `Reader`, and `RecorderInterface` as shared services. The one branch that matters: when `ALTAIR_EVENTS_ENABLED=false`, `RecorderInterface` resolves to `NullRecorder` instead of `Recorder` — every other binding is unconditional.
+
+```php
+use Altair\Events\Configuration\EventsConfiguration;
+
+// projectRoot defaults to the current working directory when omitted.
+$configuration = new EventsConfiguration(projectRoot: __DIR__);
+$configuration->apply($container);
+```
+
+The settings come from these variables (parsed in `EventsSettings::fromEnv`):
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ALTAIR_EVENTS_ENABLED` | `true` | Set `false` to bind `NullRecorder` and stop persisting. |
+| `ALTAIR_EVENTS_DIR` | `.altair` | Base directory, relative to the project root. |
+| `ALTAIR_EVENTS_LOG_FILE` | `events.jsonl` | Log filename inside the base directory. |
+| `ALTAIR_EVENTS_SNAPSHOTS_DIR` | `snapshots` | Snapshot subdirectory. |
+| `ALTAIR_EVENTS_CHECKPOINTS_DIR` | `checkpoints` | Checkpoints subdirectory. |
+| `ALTAIR_EVENTS_EXTRA_SECRET_FLAGS` | (empty) | Comma-separated extra flag names to redact, beyond the Scrubber defaults. |
+
+`ALTAIR_EVENTS_ENABLED` reads truthily: `0`, `false`, `off`, `no`, and empty disable it; anything else enables it. Set `ALTAIR_EVENTS_DIR` to relocate the whole `.altair/` tree — useful in a read-only image build, where you'd point it at a writable tmp path or simply disable recording.
+
+## Testing
+
+The tests under `tests/Events/` document the contract component by component:
+
+- `tests/Events/EventTest.php` and `tests/Events/ChangesTest.php` — the value objects: factory stamping, validation rejections (empty id/command, negative duration, errorless `Fail`), and the `toArray`/`fromArray` round-trip.
+- `tests/Events/RecorderTest.php` — that the `Recorder` scrubs secrets before storage and that a throwing storage layer never propagates out of `record()`.
+- `tests/Events/ReaderTest.php` — every projection (`tail`, `since`, `sinceId`, `sinceLastSuccess`, `filter`, `stats`).
+- `tests/Events/ScrubberTest.php` — both flag forms, case-insensitivity, and custom-secret extension.
+- `tests/Events/Storage/` — `JsonlStorageTest`, `SnapshotStorageTest`, `CheckpointStorageTest`: append/read/atomicity per medium.
+- `tests/Events/Integration/ConcurrentWriteTest.php` — that the `flock` guard keeps interleaved writers from tearing lines.
+- `tests/Events/Cli/CommandsTest.php` and `tests/Events/Configuration/` — the CLI surface and the env-to-container wiring.
+
+When you add a recording call to a new command, assert it with a spy: bind a fake `RecorderInterface` that captures the `Event` it receives, run the command, and assert the captured event's `kind`, `status`, and `changes`. Because the real `Recorder` is best-effort, a spy is the only reliable way to prove your command records what you think it does.
+
+## Related packages
+
+- [scaffold.md](./scaffold.md) — the scaffolder writes a `scaffold` event on every successful `spec:scaffold`, and its own journal sub-feature (`journal:rewind`/`journal:replay`) is the heavier, content-restoring sibling of this log. The two are complementary: the journal can undo a scaffold; this log records that one happened.
+- [cli.md](./cli.md) — the attribute-driven CLI substrate. Every `events:*` command is a plain invokable registered through `Altair\Cli\Attribute\Command`, with options declared via `#[Option]` and `#[Argument]`.
+- [mcp.md](./mcp.md) — the MCP server exposes the same Reader projections as tools, which is why `Actor::Mcp` exists: events recorded through an MCP client are tagged distinctly from CLI ones.
+- [happen.md](./happen.md) — the PSR-14 in-process event **dispatcher**. Do not confuse it with this package: Happen is for *reacting* to a notification synchronously within one request; Events is for *remembering* a mutation persistently across sessions. Different problems, no shared API.
+
+## Limitations
+
+- **Local-only.** The log lives under `.altair/` next to your checkout and never leaves the machine. There is no remote aggregation, no shared store — if you want a team-wide audit trail, ship the lines somewhere yourself.
+- **Keep `.altair/` gitignored.** Events are per-checkout local state, not source. Committing the log creates merge conflicts and leaks machine-specific noise into history; add `.altair/` to the host application's `.gitignore`.
+- **Recording is best-effort.** A failed `record()` drops the event silently (logged at warning level, if you injected a logger). Never build logic that depends on a particular event having been written — the log is observability, not a transactional ledger.
+- **Reads are unlocked and skip-tolerant.** A torn concurrent write surfaces as one line that fails to decode; the Reader skips it rather than aborting. That's the right trade-off for a best-effort log, but it means line-level loss is possible under pathological concurrency.
+- **Compact before it grows.** `readReverse` loads the whole file into memory by design. The log is meant to be compacted (`events:compact`) periodically; an uncompacted multi-gigabyte log will degrade the newest-first commands.

--- a/docs/packages/introspection.md
+++ b/docs/packages/introspection.md
@@ -1,0 +1,262 @@
+# Introspection
+
+> A read-only X-ray of a booted application: container bindings, routes, listeners, middleware, specs, and config — surfaced for humans and agents alike, and never triggering a single dispatch, `make()`, or migration.
+
+**Composer:** `univeros/introspection`
+**Namespace:** `Altair\Introspection`
+
+## Introduction
+
+When you (or an agent acting for you) sit down in front of an unfamiliar Altair application, the first question is always the same: *what is actually wired into this thing right now?* Which services did the container register? Which routes will dispatch? In what order does middleware run? Which event listeners fire, and at what priority? Are the YAML specs on disk the ones the scaffolder will read? Did somebody hand-edit a `.agent/` manifest out of sync with the source?
+
+This package answers those questions without you having to read a single line of bootstrap code. You boot the application as usual, then point an inspector at the live container and collections. Every inspector is read-only by construction — it walks the data structures the framework already built and reports their shape and state. It never calls `make()`, never dispatches an event, never resolves the middleware Relay, never runs a migration. That property is the whole point: you can run `container:inspect` against a project whose database is down, whose `prepare` hooks have side effects, or whose worker process you do not want to perturb, and nothing happens except a table comes back.
+
+The output is uniform. Every inspector returns the same value object — an `InspectionTable` — and that single shape feeds two renderers: a fixed-width human table for your terminal and pretty-printed JSON for machine consumption. The JSON output is deterministic, so an AI agent can parse it, branch on it, and diff it against a previous run. The same `framework__*_inspect` MCP tools in [mcp.md](./mcp.md) wrap these very inspectors, which is why an agent gets the same answer through the MCP bridge that you get from the CLI.
+
+What this package deliberately does **not** do: it does not modify anything (no inspector has a write path), it does not describe *behaviour* (it tells you a listener is registered, not what it will do when it fires), and it does not boot the application for you — you bring a container that has already had its configurations applied, and the inspectors read what is there.
+
+## Installation
+
+Standalone:
+
+```bash
+composer require univeros/introspection
+```
+
+This pulls in `symfony/yaml` (for the spec inspector) plus the four framework packages the inspectors read from: `univeros/cli` (the attribute-driven command runtime that hosts the `bin/altair` commands), `univeros/container`, `univeros/happen`, and `univeros/http`. No PHP extensions beyond core 8.3 are required.
+
+If you are installing the full framework, `composer require univeros/framework` already bundles this package.
+
+## Quick start
+
+The fastest way to see what introspection gives you is the `bin/altair` commands. Every command takes `--format=human` (the default, a terminal table) or `--format=json` (deterministic, agent-readable). Start with the container — it shows every binding the application registered:
+
+```bash
+bin/altair container:inspect
+bin/altair container:inspect --shared            # only singletons
+bin/altair container:inspect --filter=Repository # case-insensitive substring on the id
+bin/altair container:inspect --realized          # only services actually instantiated so far
+bin/altair container:inspect "App\\User\\UserRepository" --format=json   # drill into one binding
+```
+
+Routes, listeners, and middleware follow the same shape — list everything, or zoom into one entry:
+
+```bash
+bin/altair routes:list --format=json
+bin/altair routes:show /users
+bin/altair listeners:list
+bin/altair listeners:show user.created --format=json
+bin/altair middleware:list
+```
+
+Specs and config round it out. `config:dump` masks secret-looking keys by default — pass `--no-secrets=false` only inside a trusted shell to see raw values:
+
+```bash
+bin/altair spec:list
+bin/altair spec:show users/create.yaml --format=json
+bin/altair config:dump                  # secrets masked
+bin/altair config:dump --no-secrets=false
+bin/altair manifest:diff --format=json  # exits non-zero on drift
+```
+
+All of these auto-load: the `bin/altair` entry point discovers the commands through the `univeros/cli` attribute scanner (each command class carries a `#[Command]` attribute), so installing the package is enough — no opt-in registration.
+
+## Concepts
+
+There are three moving parts, and they compose cleanly.
+
+**Inspectors are read-only wrappers over already-shared collections.** Each inspector takes, in its constructor, the live collection it reads — `ContainerInspector` takes the `Container`, `RouteInspector` takes the `Http\Collection\RouteCollection`, `PipelineInspector` takes the `Http\Collection\MiddlewareCollection`, `ListenerInspector` takes the concrete `Happen\EventDispatcher`. None of them instantiate anything. `ContainerInspector`, for example, walks the container's six binding collections (aliases, shares, delegates, class definitions, parameters, prepares) via reflection only; its `inspectRealized()` view reads the *already-constructed* instances sitting in the shares collection and calls `::class` on them, but it never serialises (which would fire `__sleep`) and never `make()`s.
+
+**`InspectionTable` is the uniform result.** Every inspector method returns:
+
+```php
+final readonly class InspectionTable
+{
+    public function __construct(
+        public string $title,
+        public array $columns,   // list<string> — authoritative column order
+        public array $rows,      // list<array<string, mixed>> — keyed by column
+        public array $extras = [],   // sidecar data shown only in JSON (totals, paths)
+    ) {}
+
+    public function isEmpty(): bool;
+
+    // array{ title, columns, rows, extras? }
+    public function toArray(): array;
+}
+```
+
+The `columns` list is authoritative: the renderer iterates it to project each row, so a missing key just becomes an empty cell. `extras` carries metadata — totals, source paths, an `in_sync` flag — that the JSON renderer emits but the human table omits.
+
+**One table feeds two renderers.** `InspectionTable → RendererInterface → human|json`. `RendererRegistry::default()` ships `human` (a `TableRenderer` that sizes each column to its widest value) and `json` (a `JsonRenderer` that emits pretty-printed, deterministic, byte-stable JSON). Hosts can pre-bind their own renderer (HTML, CSV) into the registry before bootstrapping the CLI; the CLI commands resolve the right one from the `--format` flag.
+
+One renderer detail worth knowing: `config:dump` masks secrets **by key-name pattern, not by value**. `ConfigInspector` flags any key whose name contains one of `PASSWORD`, `SECRET`, `TOKEN`, `KEY`, `CREDENTIAL`, `PRIVATE`, `AUTH`, `BEARER`, `API_KEY`, or `ACCESS_KEY` (case-insensitive substring) and replaces the value with `***`. This is a heuristic — a key named `MONKEY_COUNT` will be masked because it contains `KEY` — but it fails *safe*: it would rather over-redact than leak.
+
+## Usage
+
+### Calling an inspector programmatically
+
+You do not have to go through the CLI. Resolve an inspector from the container and read its `InspectionTable` directly — `toArray()` gives you a structure you can assert against in a test, ship to a dashboard, or hand to an agent. Here is a real end-to-end example against the container inspector:
+
+```php
+use Altair\Container\Container;
+use Altair\Introspection\Configuration\IntrospectionConfiguration;
+use Altair\Introspection\Inspector\ContainerInspector;
+
+$container = new Container();
+
+// ... your application's Configurations have already run, registering bindings ...
+
+(new IntrospectionConfiguration())->apply($container);
+
+/** @var ContainerInspector $inspector */
+$inspector = $container->make(ContainerInspector::class);
+
+// Full inventory, singletons only, names containing "repository".
+$table = $inspector->inspectAll(sharedOnly: true, filter: 'repository');
+
+foreach ($table->rows as $row) {
+    printf("%-50s %-10s shared=%s\n", $row['id'], $row['kind'], $row['shared'] ? 'yes' : 'no');
+}
+
+echo "total: {$table->extras['total']}\n";
+
+// Drill into one binding — includes its constructor dependencies via reflection.
+$detail = $inspector->inspectOne(App\User\UserRepository::class);
+var_export($detail->toArray());
+```
+
+Because `toArray()` is the same shape the JSON renderer emits, you can also feed it straight through a renderer when you want a string instead of an array:
+
+```php
+use Altair\Introspection\Renderer\RendererRegistry;
+
+$registry = RendererRegistry::default();
+echo $registry->get('json')->render($table);   // deterministic JSON
+echo $registry->get('human')->render($table);  // fixed-width table
+```
+
+### The inspectors, and when to reach for each
+
+Each inspector solves one question. The relevant signatures are quoted so you know exactly what you can call.
+
+**`ContainerInspector`** — *"what did the application register, and what has it built?"*
+
+```php
+public function inspectAll(bool $sharedOnly = false, ?string $filter = null): InspectionTable
+public function inspectRealized(?string $filter = null): InspectionTable
+public function inspectOne(string $id): InspectionTable
+public function collectBindings(): iterable   // raw row stream, no filters
+```
+
+`inspectAll()` reports definitions — what *would* be built. `inspectRealized()` reports the complementary view — singletons the container has *actually* constructed so far, which is the tool you want when debugging worker memory growth, a surprised-by-singleton, or `prepare`-hook ordering in a long-running process. `inspectOne()` adds constructor dependencies (via reflection) and throws `NotFoundException` when no binding matches. `collectBindings()` is the unfiltered generator behind `inspectAll()` — reach for it when you want to walk every row yourself.
+
+**`RouteInspector`** — *"which routes will dispatch, to which actions?"* Constructed with a `RouteCollection`.
+
+```php
+public function inspectAll(): InspectionTable
+public function inspectOne(string $path): InspectionTable   // throws NotFoundException
+```
+
+Walking the collection never triggers dispatch or middleware resolution. A path can appear under several HTTP methods, so `inspectOne()` returns every registration for that path.
+
+**`ListenerInspector`** — *"what fires on this event, and in what order?"* Constructed with the **concrete** `Altair\Happen\EventDispatcher` (not just the PSR-14 interface — the priority-sorted listener map lives on the concrete class; pass anything else and the constructor throws `IntrospectionException`).
+
+```php
+public function inspectAll(): InspectionTable
+public function inspectOne(string $event): InspectionTable   // listeners in priority order
+```
+
+**`PipelineInspector`** — *"in what order does middleware run?"* Constructed with a `MiddlewareCollection` (and an optional pipeline name).
+
+```php
+public function inspectAll(): InspectionTable   // in dispatch order
+```
+
+It walks the collection's items directly rather than instantiating the Relay, so it stays lazy-binding safe. Hosts with multiple named pipelines register one inspector per pipeline.
+
+**`SpecInspector`** — *"what scaffolder specs are on disk, and is this one well-formed?"* Constructed with the spec root.
+
+```php
+public function inspectAll(): InspectionTable
+public function inspectOne(string $path): InspectionTable   // throws NotFoundException
+```
+
+It parses YAML directly with `symfony/yaml` rather than going through the scaffolder's `SpecLoader`, so it will list and flatten specs that do *not yet* pass scaffolder validation — exactly what you want when debugging "why won't this spec scaffold?"
+
+**`ConfigInspector`** — *"what configuration is this process actually seeing?"* Constructed with the `Container` plus optional extra secret patterns.
+
+```php
+public function dump(bool $maskSecrets = true): InspectionTable
+public const array DEFAULT_SECRET_PATTERNS = ['PASSWORD', 'SECRET', 'TOKEN', 'KEY', /* ... */];
+public const string REDACTED = '***';
+```
+
+It merges `getenv()`, `$_SERVER`, and `$_ENV` (in that precedence order, `$_ENV` winning) plus the container's parameter definitions, so the output matches what `Altair\Configuration\Support\Env` would see at runtime. Secret masking is on by default and described in [Concepts](#concepts) above.
+
+**`ManifestDiffInspector`** — *"have the `.agent/` manifests drifted from the source?"* Constructed with the manifest root.
+
+```php
+public function diff(array $regenerated): InspectionTable   // path => expected content
+```
+
+Pure by design: it does no manifest regeneration of its own. You pass in a freshly-regenerated `path => content` map (produced by [agent-spec.md](./agent-spec.md)); it SHA-256s both sides and buckets the result into `stale`, `missing`, and `extra`. The `extras['in_sync']` flag drives the CLI exit code.
+
+### A note on secret masking
+
+Because `ConfigInspector` masks by key *name*, you control the policy two ways: extend the pattern list at the container level (see [Configuration](#configuration)), or pass `maskSecrets: false` to `dump()` when you genuinely need raw values inside a trusted, non-logged shell. The default — masking on — is the right choice for anything an agent or CI job will read.
+
+## Configuration
+
+`IntrospectionConfiguration` binds every inspector as a **shared** service. The inspectors are stateless wrappers over already-shared collections, so sharing them costs nothing:
+
+```php
+use Altair\Container\Container;
+use Altair\Introspection\Configuration\IntrospectionConfiguration;
+
+$container = new Container();
+
+(new IntrospectionConfiguration(
+    projectRoot: '/path/to/app',          // defaults to getcwd()
+    specRoot: '/path/to/app/api',         // defaults to <project>/api
+    manifestRoot: '/path/to/app/.agent',  // defaults to <project>/.agent
+    extraSecretPatterns: ['PASSPHRASE'],  // appended to ConfigInspector's defaults
+))->apply($container);
+```
+
+The important design property is **graceful degradation by optional dependency**. The route, listener, and middleware inspectors need collections that a minimal host might not bind — `RouteCollection`, `EventDispatcher`, `MiddlewareCollection`. Because each inspector is bound through an independent `delegate`, applying this configuration against such a host is still safe: nothing resolves until you actually ask for an inspector. The CLI commands type-hint individual inspectors, so a missing dependency fails *only the command that needs it* — `config:dump` and `container:inspect` keep working on a host that never wired FastRoute, Happen, or Relay. You apply the configuration once and get whatever subset of inspectors your application supports.
+
+See [container.md](./container.md) for the `delegate` / `share` binding API the configuration uses.
+
+## Testing
+
+The test suite under `tests/Introspection/` is the most honest description of how each piece behaves:
+
+- `tests/Introspection/Inspector/ContainerInspectorTest.php` — binding inventory, filters, the realised view, and `inspectOne()` detail.
+- `tests/Introspection/Inspector/LazyBindingSafetyTest.php` — the load-bearing guarantee: inspecting never triggers instantiation. Read this one to understand why the package is safe against a project with side-effecting `prepare` hooks.
+- `tests/Introspection/Inspector/RouteInspectorTest.php`, `ListenerInspectorTest.php`, `PipelineInspectorTest.php` — one per collection-backed inspector.
+- `tests/Introspection/Inspector/ConfigInspectorTest.php` — secret masking, env-source precedence.
+- `tests/Introspection/Inspector/SpecInspectorTest.php`, `ManifestDiffInspectorTest.php` — filesystem-backed inspectors against fixture trees.
+- `tests/Introspection/Renderer/RenderersTest.php` — the human and JSON renderers, including JSON determinism.
+- `tests/Introspection/Configuration/IntrospectionConfigurationTest.php` — that every inspector binds as a shared service and degrades gracefully.
+- `tests/Introspection/Cli/CommandsSmokeTest.php` — each `bin/altair` command boots and returns the right exit code.
+
+When you add a new inspector, mirror the pattern: a focused inspector test asserting `toArray()`, a lazy-binding-safety assertion if it touches the container, and a smoke test for its CLI command.
+
+## Related packages
+
+- [container.md](./container.md) — the binding collections `ContainerInspector` and `ConfigInspector` read from, and the `delegate`/`share` API `IntrospectionConfiguration` uses.
+- [http.md](./http.md) — the `RouteCollection` and `MiddlewareCollection` behind `routes:*` and `middleware:list`.
+- [happen.md](./happen.md) — the `EventDispatcher` whose priority-sorted listener map drives `listeners:*`.
+- [scaffold.md](./scaffold.md) — the YAML specs that `spec:list` / `spec:show` surface (parsed independently of the scaffolder so malformed specs still list).
+- [agent-spec.md](./agent-spec.md) — the manifest generator whose `.agent/` output `manifest:diff` compares against.
+- [mcp.md](./mcp.md) — the `framework__*_inspect` MCP tools wrap these inspectors so an agent gets identical answers through the MCP bridge.
+- [cli.md](./cli.md) — the attribute-driven CLI runtime that hosts every `bin/altair` introspection command.
+
+## Limitations
+
+- **Collection inspectors need the host to bind their collections.** `routes:*`, `listeners:*`, and `middleware:list` require the host to have wired `RouteCollection`, the concrete `EventDispatcher`, and `MiddlewareCollection` respectively. On a host that does not, those specific commands fail (with a clear message) while the rest keep working — see [Configuration](#configuration).
+- **Shape and state, not behaviour.** An inspector tells you a listener is registered for `user.created` at a given priority; it cannot tell you what that listener *does* when it fires. For behaviour, read the source or the per-package guides under `docs/packages/`.
+- **`ListenerInspector` requires the concrete dispatcher.** Hosts running a custom PSR-14 dispatcher (not `Altair\Happen\EventDispatcher`) need their own inspector — the priority-sorted listener map this one reads lives on the concrete class.
+- **`config:dump` masks by key name, not value.** The substring heuristic over-redacts before it under-redacts. A non-secret key that happens to contain `KEY`, `AUTH`, etc. will be masked; pass `--no-secrets=false` in a trusted shell when that gets in your way.
+- **`manifest:diff` needs a regenerator to find drift.** With no `path => content` map supplied, it treats the on-disk `.agent/` tree as canonical and reports in-sync. Real drift detection requires the host to feed it freshly-regenerated manifests from [agent-spec.md](./agent-spec.md).

--- a/docs/packages/mcp.md
+++ b/docs/packages/mcp.md
@@ -1,0 +1,193 @@
+# Mcp
+
+> A first-party Model Context Protocol server that exposes the framework as agent-callable tools, so any MCP client can build, inspect, test, and ship an Altair API through tool calls — without reading a line of source.
+
+**Composer:** `univeros/mcp`
+**Namespace:** `Altair\Mcp`
+
+## Introduction
+
+The rest of the framework makes your project agent-*readable* — typed code, deterministic manifests, JSON-emitting CLI commands. This package makes it agent-*drivable*. The [Model Context Protocol](https://modelcontextprotocol.io/) is the open standard MCP clients (Claude Desktop, Cursor, Zed, …) speak to local tooling: a server advertises named, typed "tools"; the client discovers them; the agent calls them as first-class actions in its conversation. You point your MCP client at `bin/altair mcp:serve` once, and from then on "add a `POST /users` endpoint that creates a user" becomes a sequence of `framework__write_spec` + `framework__scaffold` + `framework__run_tests` calls — no file reading, no shelling out.
+
+You'll reach for this package when you want an agent to operate the project the way a developer would: list the endpoints, read a spec, scaffold a new one, run the tests, inspect a container binding, run a read-only query against the dev database. It ships **28 built-in tools** out of the box and lets you register your own with a single attribute.
+
+The server is implemented directly on JSON-RPC 2.0 — there is no third-party MCP SDK in the dependency tree. The protocol is small (a handshake plus a few message types), and owning it keeps the wire format under your control. The protocol "brain" is decoupled from the bytes on the wire, so the same server runs over stdio (what desktop clients expect), over HTTP (for out-of-process agents), or over an in-memory transport (for tests).
+
+## Installation
+
+The package is bundled in the meta-package, so `composer require univeros/framework` already includes it. Standalone:
+
+```bash
+composer require univeros/mcp
+```
+
+It depends on `univeros/cli` (the `mcp:serve` / `mcp:tools` commands), `univeros/container` (tools autowire their dependencies), and the packages whose capabilities the built-in tools wrap (`univeros/scaffold`, `univeros/introspection`, `univeros/doctor`, `univeros/events`, `univeros/agent-spec`). It also pulls in `opis/json-schema` — a pure-PHP JSON Schema validator used to validate every tool call. The database tools additionally use `univeros/persistence` when it is wired; without it they report that no database is configured rather than failing.
+
+## Quick start
+
+Add the server to your MCP client's config once. For Claude Desktop, that's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "altair": {
+      "command": "php",
+      "args": ["/path/to/project/bin/altair", "mcp", "serve"],
+      "env": { "APP_ENV": "dev" }
+    }
+  }
+}
+```
+
+From that point on the agent has the full tool palette. To see what it can call without wiring up a client, list the tools yourself:
+
+```bash
+bin/altair mcp:tools
+```
+
+That prints all 28 tools and their descriptions. For the machine-readable form (name + input/output JSON schema per tool, exactly what `tools/list` returns over the wire):
+
+```bash
+bin/altair mcp:tools --format=json
+```
+
+Start the server manually over stdio — one newline-delimited JSON-RPC message per line — to smoke-test a session by hand:
+
+```bash
+printf '%s\n' \
+  '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18"}}' \
+  '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"framework__list_packages","arguments":{}}}' \
+  | bin/altair mcp:serve
+```
+
+You'll get an `initialize` result (negotiated protocol version + server info) and a `tools/call` result whose `structuredContent` lists every installed package.
+
+## Concepts
+
+The server has a clean split between protocol, transport, and tools.
+
+- **Protocol** — `Server\Server` is the pure message brain: it turns one inbound JSON-RPC message into one outbound message (or null for a notification), with no knowledge of the transport. It handles `initialize` (with protocol-version negotiation in `Server\ServerInfo`), `ping`, `tools/list`, `tools/call`, and the `notifications/*` messages. Protocol-level problems (malformed JSON, unknown method, bad params, batch requests) come back as JSON-RPC errors; a tool that throws comes back as a *successful* `tools/call` result with `isError: true` — the MCP convention that a tool failure is data the model reacts to, not a transport error.
+- **Transport** — implementations of `Contracts\TransportInterface` carry the framed messages. `Transport\StdioTransport` is newline-delimited JSON over stdin/stdout (desktop clients); `Transport\HttpTransport` answers one JSON-RPC message per POST (out-of-process agents); `Transport\InMemoryTransport` queues messages for tests. `Server\ServerRunner` pumps a streaming transport: read a message, dispatch it, write the reply, repeat.
+- **Tools** — every tool is a class implementing `Contracts\McpToolInterface` (`call(array $input): array`) and carrying the `Attribute\McpTool` attribute for its name, description, and input/output JSON schema paths. `Tool\AttributeToolDiscoverer` reads the attribute into a `Tool\ToolDescriptor`; `Tool\ToolRegistry` holds the set (name-sorted for stable `tools/list` output); `Tool\ContainerToolResolver` instantiates a tool through the Container at call time, so a tool's constructor dependencies are autowired exactly like a CLI command's.
+- **Schemas** — `Schema\SchemaValidator` validates a tool's `arguments` against its input schema (via opis/json-schema) before the tool runs. Built-in schemas live in `src/Altair/Mcp/Schema/*.json` and are published verbatim through `tools/list`.
+
+The guardrails are what make it safe to point an agent at your filesystem:
+
+- `Guard\PathGuard` blocks writes to `vendor/`, `.git/`, `composer.json`, `composer.lock`, and any `.env*` file, and confines reads/spec-loads to the project root (lexical, traversal-safe).
+- `Guard\ServerMode` is the mutation policy set at startup: `--readonly` makes the whole server inspect-only; database writes additionally require `--allow-writes`.
+- `Database\SqlReadGuard` restricts `framework__db_query` to a single read-only `SELECT`/`WITH` and rejects writes, DDL, statement chaining, and `INTO OUTFILE`/`DUMPFILE`.
+
+## Usage
+
+### The built-in tools
+
+All 28 tools use the `framework__` prefix, take JSON arguments, and return JSON. They fall into five groups:
+
+**Discovery / inspection** — `list_packages`, `describe_package`, `list_specs`, `read_spec`, `list_endpoints`, `describe_endpoint`, `container_resolve`, `list_commands`.
+
+**Generation / mutation** — `write_spec` (validates before writing), `scaffold`, `rewind_spec`, `emit_openapi`, `emit_sdk`.
+
+**Verification** — `doctor`, `run_tests`, `check_drift`, `phpstan`.
+
+**Database** (read-only by default) — `db_query`, `db_schema`, `db_migrate`.
+
+**Introspection** — `container_inspect`, `config_dump` (secrets always masked), `routes_list`, `route_show`, `listeners_list`, `listener_show`, `middleware_list`, `manifest_diff`.
+
+Each one wraps the real framework API — `framework__scaffold` drives `univeros/scaffold`, `framework__doctor` drives `univeros/doctor`, the `framework__*_inspect`/`*_list` tools drive `univeros/introspection` — so the tool surface and the CLI surface stay in lock-step.
+
+### Running the server
+
+The stdio transport is the common case and the default:
+
+```bash
+bin/altair mcp:serve
+```
+
+For an out-of-process agent, switch to HTTP (one JSON-RPC message per POST):
+
+```bash
+bin/altair mcp:serve --transport=http --host=127.0.0.1 --port=3737
+```
+
+Lock the server down when you only want inspection, or opt into gated database writes:
+
+```bash
+bin/altair mcp:serve --readonly          # no writes at all
+bin/altair mcp:serve --allow-writes      # permit db:migrate via framework__db_migrate
+```
+
+### Writing a custom tool
+
+A tool is a plain service: implement `McpToolInterface` and decorate it with `#[McpTool]`. The input has already been validated against your schema before `call()` runs, and the Container autowires your constructor — so you can depend on any bound service.
+
+```php
+use Altair\Mcp\Attribute\McpTool;
+use Altair\Mcp\Contracts\McpToolInterface;
+use Override;
+
+#[McpTool(
+    name: 'app__greet',
+    description: 'Return a greeting for the given name.',
+    inputSchema: __DIR__ . '/Schema/greet-input.json',
+)]
+final readonly class GreetTool implements McpToolInterface
+{
+    #[Override]
+    public function call(array $input): array
+    {
+        return ['greeting' => 'Hello, ' . ($input['name'] ?? 'world')];
+    }
+}
+```
+
+`inputSchema` is an absolute path to a JSON Schema file (the attribute is evaluated at compile time, so use `__DIR__ . '/…'` rather than a function call). Point the server at the directory holding your tools with the `MCP_TOOL_PATHS` environment variable (`PATH_SEPARATOR`-delimited) and `AttributeToolDiscoverer` finds them at startup. Throw `Altair\Mcp\Exception\GuardrailException` from a tool when an operation should be refused — the server surfaces its message to the agent as a tool error rather than a crash.
+
+## Configuration
+
+`Configuration\McpConfiguration` wires everything into the Container: the tool registry (built-in tools from `Tool\BuiltinTools` plus any discovered user tools), the protocol services, the guardrails, and the read-only database gateway (`Database\CycleDatabaseGateway` when `univeros/persistence` is bound, otherwise `Database\NullDatabaseGateway`). It applies the prerequisite Configurations (events, scaffold journal, doctor) when they are absent, so tool dependencies resolve, and binds the Container to itself so tools resolve through the real instance.
+
+You rarely construct it by hand — `mcp:serve` and `mcp:tools` apply it for you, passing the `ServerMode` derived from the command flags. Construct it directly only when embedding the server in another process:
+
+```php
+use Altair\Container\Container;
+use Altair\Mcp\Configuration\McpConfiguration;
+use Altair\Mcp\Guard\ServerMode;
+use Altair\Mcp\Server\Server;
+
+$container = new Container();
+(new McpConfiguration(mode: new ServerMode(readonly: true)))->apply($container);
+
+/** @var Server $server */
+$server = $container->make(Server::class);
+$reply = $server->handle('{"jsonrpc":"2.0","id":1,"method":"tools/list"}');
+```
+
+See [container.md](./container.md) for the binding API.
+
+## Testing
+
+The tests under `tests/Mcp/` are the clearest description of the server's behaviour:
+
+- `tests/Mcp/Server/ServerTest.php` — the protocol surface: handshake, ping, tool listing, tool invocation, and every error path (parse error, unknown method, bad params, guardrail-as-tool-error).
+- `tests/Mcp/Tool/*ToolsTest.php` — each tool group, with golden input/output cases and the graceful-degradation paths (e.g. an introspection tool returning `{available: false}` when its host collaborator isn't bound).
+- `tests/Mcp/McpServerIntegrationTest.php` — a full agent-style session driven through `InMemoryTransport` against a Container-built `Server`: `initialize`, `tools/list`, then real `tools/call`s.
+
+When you add a tool, mirror that last pattern: build the registry, drive a session over the in-memory transport, and assert the structured result — it exercises validation, resolution, and the protocol envelope together.
+
+## Related packages
+
+- [cli.md](./cli.md) — `mcp:serve` and `mcp:tools` are attribute-driven commands discovered by the framework CLI.
+- [scaffold.md](./scaffold.md) — the `framework__write_spec` / `scaffold` / `rewind_spec` / `emit_openapi` / `emit_sdk` tools wrap it.
+- [introspection.md](./introspection.md) — the `framework__container_inspect` / `routes_*` / `listeners_*` / `middleware_list` / `config_dump` / `manifest_diff` tools wrap its inspectors.
+- [doctor.md](./doctor.md) — `framework__doctor` wraps the health-check runner.
+- [events.md](./events.md) — mutating tools record what they changed to the `.altair/events.jsonl` log.
+- [agent-spec.md](./agent-spec.md) — `framework__describe_package` surfaces package shape; AgentSpec is the agent-*readable* counterpart to this agent-*drivable* server.
+- [persistence.md](./persistence.md) — backs the `framework__db_*` tools when wired.
+
+## Limitations
+
+- This is a **local developer tool** that runs as your user with your filesystem permissions — that's the accepted trust model. The guardrails defend against an agent doing more than intended; they are not a sandbox against a hostile operator.
+- One instance per project. Hosting, multi-tenancy, and authentication on the HTTP transport are out of scope for v1 (the HTTP transport binds to `127.0.0.1` and assumes a same-trust-boundary caller).
+- The database tools require `univeros/persistence` to be wired; without it `db_query` / `db_schema` report that no database is configured, and `db_migrate` is gated behind `--allow-writes`.
+- `config_dump` masks secrets by **key name** (e.g. anything containing `PASSWORD`, `TOKEN`, `DSN`, …). A secret stored under a non-matching key — or inline in a URL value — can still surface; treat the output as sensitive.
+- The server implements MCP **tools** only; the protocol's "resources" and "prompts" primitives are not exposed in v1.

--- a/docs/packages/scaffold.md
+++ b/docs/packages/scaffold.md
@@ -1,0 +1,423 @@
+# Scaffold
+
+> The spec-driven core of the framework. One YAML endpoint spec goes in; an Action, an Input DTO, a Responder, a domain stub, a PHPUnit test, an OpenAPI 3.1 fragment, and a route entry come out — plus optional entity/repository/migration and message/handler trios. Every scaffold is journaled, so it is reversible. Drift between the spec and the generated code is a CI gate. And the merged OpenAPI document compiles to typed TypeScript and Python client SDKs.
+
+**Composer:** `univeros/scaffold`
+**Namespace:** `Altair\Scaffold`
+
+## Introduction
+
+Hand-writing the Action / Input / Responder triple for every HTTP endpoint is the kind of boilerplate that drifts the moment you touch it. You add a field to the Input but forget to add it to the OpenAPI fragment; you change a validation rule but the generated test still asserts the old behaviour; the route never gets registered because you were copy-pasting from the last endpoint and missed a line. Multiply that across a real API and the wire format, the validation, the docs, and the tests all quietly fall out of sync.
+
+This package makes the YAML spec the single source of truth. You describe an endpoint once — its method and path, its inputs and their validation rules, its responses, and the domain service it delegates to — and the scaffolder emits everything downstream from that one description. When you change the spec, you re-run the scaffolder. When someone hand-edits a generated file, `spec:lint` tells you (and CI) exactly where the file and the spec disagree.
+
+Three design choices make this safe to live with rather than a one-shot code dump you immediately abandon:
+
+1. **It is journaled.** Every successful scaffold writes a self-contained `.altair/journal/<id>.json` entry capturing the spec content, per-file SHAs, and the full `content_before` for any file it modified. A bad scaffold is no longer catastrophic — `journal:rewind` undoes it, and it refuses to clobber files you have hand-edited since unless you pass `--force`.
+2. **It detects drift.** The linter re-parses the generated PHP with `nikic/php-parser` and compares the AST back to the spec: input fields against constructor params, validation rules against `rules()`, response statuses against `statuses()`, and the action FQCN against the routes file. Drift is reported with an exit code, so it slots straight into CI.
+3. **It compiles clients.** The per-endpoint OpenAPI fragments merge into a single OpenAPI 3.1 document, and that document compiles to typed client SDKs — fetch-based TypeScript and `httpx`+`pydantic` Python — with deterministic output you can wire into a `--check` CI gate so the committed SDK can never drift from the spec.
+
+What this package deliberately does *not* do: it does not run your endpoints (that is [http.md](./http.md)), it does not invent a validation engine (rules map onto `Altair\Validation\Rule\*`), and it does not own the ORM or the queue — it only knows enough about [persistence.md](./persistence.md) and [messaging.md](./messaging.md) to emit their artifacts when you ask for them.
+
+## Installation
+
+Standalone:
+
+```bash
+composer require --dev univeros/scaffold
+```
+
+You almost always want this as a dev dependency: it generates code into your *checkout*, it is not part of your runtime. It pulls in `nikic/php-parser` (the drift linter re-parses emitted PHP), `symfony/yaml` (spec + OpenAPI parsing), and `univeros/cli` (the attribute-driven command runtime that hosts `spec:scaffold` and friends).
+
+If you install the full framework, `composer require univeros/framework` already bundles it.
+
+The journal and the event-log integration are optional. Bind `univeros/events` (the `suggest` in `composer.json`) when you want each scaffold to also append a mutation event to `.altair/events.jsonl` — see [Configuration](#configuration).
+
+## Quick start
+
+The smallest useful spec describes one endpoint and the domain service behind it:
+
+```yaml
+# api/users/create.yaml
+endpoint: { method: POST, path: /users, summary: Create a user, tags: [users] }
+input:
+  email: { type: string, rules: [email, required] }
+output:
+  201: { body: { user: App\User\User } }
+domain: { class: App\User\CreateUser }
+```
+
+Scaffold it. From the project root:
+
+```bash
+bin/altair spec:scaffold api/users/create.yaml
+```
+
+That prints one line per file written (or skipped) and emits:
+
+```
+written app/Http/Actions/CreateUserAction.php
+written app/Http/Inputs/CreateUserInput.php
+written app/Http/Responders/CreateUserResponder.php
+written app/User/CreateUser.php
+written tests/Http/Actions/CreateUserActionTest.php
+written docs/openapi/create-user.yaml
+modified config/routes.php
+Wrote 7 file(s); skipped 0 existing file(s).
+```
+
+Preview without touching disk — `--dry-run` prints every planned file's full contents to stdout so you can eyeball the output before committing to it:
+
+```bash
+bin/altair spec:scaffold api/users/create.yaml --dry-run
+```
+
+Re-runs are idempotent: existing files are *skipped*, not overwritten. When you have intentionally changed the spec and want the generated files regenerated, pass `--force`:
+
+```bash
+bin/altair spec:scaffold api/ --force          # batch every spec under api/, overwriting
+```
+
+Once you have a few endpoints, merge their OpenAPI fragments into one document and compile clients from it:
+
+```bash
+bin/altair spec:emit-openapi --out=docs/openapi.yaml   # merge fragments → one 3.1 doc
+bin/altair spec:emit-sdk typescript > sdk.ts           # fetch-based, zero-dep TS client
+bin/altair spec:emit-sdk python --out=clients/python   # httpx + pydantic, sync + async
+```
+
+And before you push, let the linter catch any place a generated file has drifted from its spec:
+
+```bash
+bin/altair spec:lint                                   # exit 1 on drift — CI gate
+```
+
+## Concepts
+
+### The spec AST
+
+A spec file is parsed into a small immutable AST under `Altair\Scaffold\Spec\Ast\*`. The root node is `Spec`, a `final readonly` value object:
+
+```php
+final readonly class Spec
+{
+    public function __construct(
+        public EndpointSpec $endpoint,
+        public array $inputs,            // list<InputFieldSpec>
+        public array $outputs,           // list<OutputResponseSpec>
+        public DomainSpec $domain,
+        public string $sourcePath = '',
+        public ?PersistenceSpec $persistence = null,
+        public array $queue = [],        // list<QueueDispatchSpec>
+    ) {}
+
+    public function artifactName(): string;   // domain short-name, e.g. "CreateUser"
+    public function hasPersistence(): bool;
+}
+```
+
+The pieces map directly onto the YAML blocks:
+
+- **`EndpointSpec`** carries `method`, `path`, `summary`, and `tags`. The method is upper-cased and validated against the supported set (`GET POST PUT PATCH DELETE OPTIONS HEAD`); the path must start with `/`.
+- **`InputFieldSpec`** is one field of the `input:` map — `name`, `type`, a list of `rules`, a `sensitive` flag (keeps secrets out of logs and journals), and `of` for enum targets. `isRequired()` is true when `required` is among the rules; `isEnum()` is true for `type: enum` with an `of` class.
+- **`OutputResponseSpec`** is one `output:` entry: an integer `status` and a `body` map of field name → type spec (e.g. `App\User\User` or `array<string, list<string>>`).
+- **`DomainSpec`** is the service the Action delegates to — its `class` FQCN and the method to call (`invocation`, default `__invoke`).
+- **`PersistenceSpec`** / **`QueueDispatchSpec`** are the optional blocks covered below.
+
+`Spec::artifactName()` is the convention engine: it takes the domain class short-name (`App\User\CreateUser` → `CreateUser`) and every emitted artifact is named off it — `CreateUserAction`, `CreateUserInput`, `CreateUserResponder`, `CreateUserActionTest`. That is why the `domain.class` is required even for endpoints that barely have a domain layer: it is what names everything.
+
+Loading goes through `SpecLoader`, which accepts either a single file or a directory:
+
+```php
+public function load(string $path, bool $validate = true): array   // list<Spec>
+```
+
+Point it at a directory and it walks recursively for `*.yaml` / `*.yml`, sorts the paths (so batch runs are deterministic), and returns one `Spec` per file. Validation is on by default; `Validator` collects every semantic error (unknown HTTP method, unknown validation rule, malformed FQCN, a persistence block with the wrong number of primary keys) and throws a single `SpecValidationException` carrying the full list — you fix all the errors at once rather than one round-trip per mistake.
+
+### The emission plan and the emitters
+
+`EmissionPlan::build()` is the pure heart of the package — it runs every emitter against a `Spec` and returns a `list<EmittedFile>` without touching disk:
+
+```php
+public function build(Spec $spec): array    // list<EmittedFile>
+```
+
+Each emitter returns an `EmittedFile` — a `relativePath`, the file `contents`, and an `EmittedFileKind` enum tag. The HTTP-side emitters always fire (`ActionEmitter`, `InputEmitter`, `ResponderEmitter`, `DomainStubEmitter`, `TestEmitter`, `OpenApiEmitter`, `RouteEmitter`). The persistence emitters (`EntityEmitter`, `RepositoryEmitter`, `MigrationEmitter`) fire only when the spec carries a `persistence:` block, and the repository emitter only when a repository FQCN is declared. The queue emitters (`MessageEmitter`, `HandlerEmitter`, `HandlerTestEmitter`) fire once per `queue:` entry. The full set of kinds:
+
+```
+Action  Input  Responder  DomainStub  Test  OpenApi  Route
+Entity  Repository  Migration
+Message  Handler  HandlerTest
+```
+
+Because `build()` is pure, the same `Spec` always yields byte-identical output — which is exactly what makes the snapshot tests, the drift linter, and the journal's replay-and-compare all possible.
+
+### File writing and write statuses
+
+`FileWriter` resolves each `EmittedFile`'s path against a project root and writes it, returning a `WriteOutcome` whose `WriteStatus` is one of three:
+
+- **`Written`** — a new file landed on disk (or `--force` overwrote an existing one).
+- **`Skipped`** — the file already existed and `--force` was not passed. This is the idempotent re-run case.
+- **`Modified`** — reserved for the routes file. Route entries are never overwritten wholesale; instead the new entry is *appended* to the existing `config/routes.php` (a fresh one is created if absent), and the writer first checks whether the entry is already present so re-runs do not duplicate routes.
+
+That three-way distinction is what lets `spec:scaffold` report "wrote N, skipped M" honestly, and what the journal records so a later `rewind` knows whether to delete a file (it was created) or restore its previous content (it was modified).
+
+### The journal — rewind / replay safety net
+
+The journal is what turns a one-shot generator into something you can run fearlessly. Every successful scaffold writes one `.altair/journal/<id>.json` entry per spec. The id is a sortable `<YYYYMMDDTHHMMSSZ>-<short-sha>` stem, and the entry is self-contained — it embeds the spec content (`spec.content_inline`), per-file SHAs, and the complete `content_before` for any file it modified — so it can be replayed or reversed even if the original spec file is later edited or deleted.
+
+`Journal` is the read/write/query facade over `FilesystemStorage`:
+
+```php
+public function record(JournalEntry $entry): string;       // returns the written path
+public function findById(string $idOrPrefix): JournalEntry; // full id or unambiguous prefix
+public function tail(?int $limit = null): Generator;        // newest-first
+public function history(): Generator;                       // oldest-first
+public function rewind(JournalEntry $entry, bool $force = false): array;
+public function replay(/* via ReplayCommand */);
+```
+
+`findById()` resolving a unique prefix matters for ergonomics — an agent (or you) can pass the first 8 characters of an id without juggling the full timestamp form. `rewind()` deletes created files (when their on-disk SHA still matches what was recorded) and restores modified files from `content_before`; the entry itself is not deleted, it gets a `reverted_at` stamp appended so the history stays auditable. If any file's SHA no longer matches — meaning you hand-edited it after scaffolding — `rewind()` throws `RewindRefusedException` listing the unsafe files unless `force: true` is given.
+
+`SnapshotCollector` is the glue inside `ScaffoldCommand`: `captureBefore()` reads the existing content *before* the write, `record()` classifies each `WriteOutcome` into created / modified / skipped snapshots afterwards, and those snapshots become the `JournalEntry` via `JournalEntry::scaffold(...)`. Journaling is best-effort — a storage failure never fails the scaffold itself.
+
+### Drift detection
+
+`DriftDetector` re-parses the generated PHP and compares its AST back to the spec across four axes (see `DriftKind`):
+
+- **`MissingInputField` / `UnknownInputField`** — the spec's input fields vs. the Input DTO's constructor params.
+- **`MissingValidationRule`** — each spec rule vs. what the Input DTO's static `rules()` returns.
+- **`ResponderMissingStatus`** — each spec response status vs. the Responder's static `statuses()`.
+- **`UnregisteredRoute`** — whether the action FQCN appears in the routes file at all.
+
+Each finding is a `DriftFinding` (`kind`, a human-readable `message`, a file `location`), collected into an immutable `DriftReport`. `DriftReport::hasDrift()` drives the `spec:lint` exit code. Drift is detected one direction at a time and reported precisely — the message tells you whether to fix the spec or fix the code.
+
+### SDK emitters from the merged OpenAPI document
+
+The SDK layer is independent of the spec AST — it works off the *merged OpenAPI 3.1 document*, so it can also compile a hand-authored OpenAPI file, not just framework-generated fragments. `OpenApiParser::parseYaml()` turns the document into a language-neutral model under `Altair\Scaffold\Sdk\Model` (operations, request/response schemas, `$ref` resolution, enum support, even synthesising an `operationId` when one is missing). Each emitter implements `EmitterInterface`:
+
+```php
+interface EmitterInterface
+{
+    public function language(): string;          // "typescript" | "python"
+    public function defaultFileName(): string;   // "sdk.ts" | "client.py"
+    public function emit(OpenApiDocument $document, bool $multiFile = false): EmittedSdk;
+}
+```
+
+`EmitterRegistry::default()` ships both built-ins; `available()`, `has()`, and `get()` are the lookup surface. Emitters are *pure* — same document in, byte-identical `EmittedSdk` out — which is what makes the `--check` drift gate reliable. The TypeScript emitter produces a fetch-based, zero-runtime-dependency client with status-discriminated response unions; the Python emitter produces an `httpx` + `pydantic v2` client with both sync and async classes, targeting `mypy --strict`.
+
+### Optional `persistence:` and `queue:` spec blocks
+
+The same spec file can carry two optional blocks that extend the emission plan into adjacent packages:
+
+- A **`persistence:`** block (a `PersistenceSpec`) emits a Cycle-annotated entity, a typed repository (when a repository FQCN is given), and a Cycle migration — kept in lockstep with the HTTP artifacts so the wire format and the storage shape never diverge. See [persistence.md](./persistence.md).
+- A **`queue:`** block (one or more `QueueDispatchSpec`) emits, per entry, a readonly message DTO, an `#[AsHandler]`-decorated handler stub, and a PHPUnit test. See [messaging.md](./messaging.md).
+
+Both are validated alongside the rest of the spec: persistence fields must use a known column type and declare exactly one primary key; queue field types must be a scalar or an FQCN.
+
+## Usage
+
+### Writing a spec
+
+Write the YAML first — the scaffolder is the only thing that should produce the Action/Input/Responder triple. A fuller spec:
+
+```yaml
+# api/users/create.yaml
+endpoint:
+  method: POST
+  path: /users
+  summary: Create a user
+  tags: [users]
+
+input:
+  email:    { type: string, rules: [email, required] }
+  password: { type: string, rules: [min:8, required], sensitive: true }
+
+output:
+  201: { body: { user: App\User\User } }
+  422: { body: { errors: 'array<string, list<string>>' } }
+  409: { body: { message: string } }
+
+domain:
+  class: App\User\CreateUser
+```
+
+The validator will reject the spec if `method` is not a real HTTP verb, if `path` does not start with `/`, if any rule is not one of the known `Altair\Validation\Rule\*` rules (`required alpha alphanum between boolean callback creditcard datetime email iban in integer ip isbn max min regex swiftbic url zipcode`), if a response status is outside `100..599`, or if `domain.class` is not a well-formed FQCN. Mark any secret-bearing field `sensitive: true` so it is kept out of generated logging and journal snapshots.
+
+### Scaffolding
+
+```bash
+bin/altair spec:scaffold api/users/create.yaml          # one spec
+bin/altair spec:scaffold api/                           # every spec under a directory
+bin/altair spec:scaffold api/users/create.yaml --dry-run
+bin/altair spec:scaffold api/ --force                   # regenerate, overwriting
+bin/altair spec:scaffold api/users/create.yaml --root=/abs/path/to/project
+```
+
+`--root` overrides the project root used as the base for emitted paths; without it, the command walks up from the current working directory to the nearest `composer.json`. The default behaviour skips files that already exist, so the safe loop is: edit the spec, `--dry-run` to preview, then `--force` to regenerate.
+
+### Regenerate vs. hand-edit, and the `spec:lint` drift gate
+
+Generated files are real files in your repo — you *can* hand-edit them, and sometimes you should (a bespoke query in a repository, a non-trivial responder). The contract is: when you change the *spec*, regenerate; when you hand-edit *generated code*, run the linter so the divergence is visible.
+
+```bash
+bin/altair spec:lint                 # defaults to scanning api/
+bin/altair spec:lint api/users/create.yaml
+bin/altair spec:lint --root=/abs/path/to/project
+```
+
+`spec:lint` exits `1` when it finds any drift, printing each finding as `[<kind>] <message>`, and `0` when clean. Wire it into CI next to `composer cs`, `composer stan`, and `composer test`:
+
+```yaml
+# .github/workflows/ci.yml
+- name: Ensure scaffolded code matches its specs
+  run: bin/altair spec:lint
+```
+
+### Undoing and re-applying with the journal
+
+> **Journal commands require host wiring.** The `journal:*` commands take a non-nullable `Journal` constructor dependency, and they live in `src/Altair/Scaffold/Journal/Cli` — a *sibling* of `src/Altair/Scaffold/Cli`, which is the only scaffold directory the framework's `bin/altair` adds to its command path. So out of the box the framework binary exposes `spec:*` but not `journal:*`. A host application enables the journal by (1) applying `ScaffoldJournalConfiguration` to its container, and (2) adding `…/src/Altair/Scaffold/Journal/Cli` to `ALTAIR_CLI_PATHS` (see [cli.md](./cli.md)). With both in place, `spec:scaffold` starts writing journal entries and the commands below light up.
+
+```bash
+bin/altair journal:list -n 50                  # newest 50 entries (or --format=json)
+bin/altair journal:show <id>                   # full detail (resolves unambiguous prefixes)
+bin/altair journal:diff <id>                   # per-file diffs embedded in the entry
+bin/altair journal:rewind                      # undo the most recent scaffold
+bin/altair journal:rewind --to=<id>            # undo back to (and including) an entry
+bin/altair journal:rewind --dry-run            # preview what would be undone
+bin/altair journal:rewind --force              # override the hand-edit safety check
+bin/altair journal:replay --id=<id>            # re-apply one entry from its embedded spec
+bin/altair journal:replay --from=<id>          # re-apply forward from a point
+bin/altair journal:replay --all                # replay the whole journal (confirms first)
+bin/altair journal:replay --force              # overwrite existing files while replaying
+```
+
+`journal:rewind` works newest-first and refuses to clobber files you have edited since the original scaffold (SHA mismatch) — re-run with `--force` to override, and it will tell you exactly which files were unsafe. `journal:replay` reads the spec out of the entry's embedded `content_inline`, never the original file, and reports drift (a `1` exit) when the regenerated content no longer matches what the journal recorded — which usually means the scaffolder itself changed between the original run and the replay.
+
+The `journal:*` commands are named to avoid colliding with the introspection sub-package's `spec:list` / `spec:show`, which view raw YAML specs rather than scaffold-time history.
+
+### Emitting OpenAPI and SDKs, with the `--check` CI drift gate
+
+`spec:scaffold` already drops a per-endpoint OpenAPI fragment under `docs/openapi/`. Merge them into one document:
+
+```bash
+bin/altair spec:emit-openapi                       # merged 3.1 doc → stdout
+bin/altair spec:emit-openapi --out=docs/openapi.yaml
+bin/altair spec:emit-openapi --pretty              # 4-space indent
+bin/altair spec:emit-openapi --fragments=docs/openapi --root=/abs/path
+```
+
+Then compile typed clients from that merged document:
+
+```bash
+bin/altair spec:emit-sdk --list                          # list available languages
+bin/altair spec:emit-sdk typescript > sdk.ts             # single-file, to stdout
+bin/altair spec:emit-sdk typescript --out=sdk.ts
+bin/altair spec:emit-sdk typescript --out=clients/ts --multi-file   # types.ts + client.ts
+bin/altair spec:emit-sdk python --out=clients/python
+bin/altair spec:emit-sdk typescript --openapi=docs/openapi.yaml     # compile a given doc
+bin/altair spec:emit-sdk typescript --out=sdk.ts --check            # exit 1 on drift
+```
+
+When `--openapi` is omitted the command merges `docs/openapi/*.yaml` on the fly, so the SDK always reflects the current specs. Because emission is deterministic, `--check` is a true CI gate — it regenerates in memory and diffs against the files on disk, exiting `1` (and listing the drifted files) when the committed SDK has fallen behind the spec. Do not hand-edit emitted SDKs; regenerate them.
+
+```yaml
+# .github/workflows/ci.yml
+- name: SDKs are current
+  run: |
+    bin/altair spec:emit-sdk typescript --out=clients/ts/sdk.ts --check
+    bin/altair spec:emit-sdk python --out=clients/python --multi-file --check
+```
+
+## Configuration
+
+There is nothing to configure for the core `spec:*` commands — they are plain `readonly` invokables with new-on-default dependencies, auto-discovered by `bin/altair` because it adds `src/Altair/Scaffold/Cli` to the command path at startup.
+
+The journal is the one part that needs wiring, and it is opt-in. `ScaffoldJournalConfiguration` binds `Journal`, `FilesystemStorage`, and `FileDiffer` into `Altair\Container`, reading three env vars:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ALTAIR_JOURNAL_ENABLED` | `true` | Set `false` to skip binding the journal. |
+| `ALTAIR_JOURNAL_DIR` | `.altair` | Base directory, relative to the project root. |
+| `ALTAIR_JOURNAL_SUBDIR` | `journal` | Journal subdirectory under the base. |
+
+```php
+use Altair\Configuration\Support\Env;
+use Altair\Container\Container;
+use Altair\Scaffold\Journal\Configuration\ScaffoldJournalConfiguration;
+
+$container = new Container();
+$container->share(new Env());
+
+(new ScaffoldJournalConfiguration(projectRoot: __DIR__))->apply($container);
+```
+
+`ScaffoldCommand` resolves `Journal` (and `RecorderInterface` from `univeros/events`) as *optional* constructor dependencies — both nullable — so a minimal host can scaffold without applying this configuration at all. Bind the journal and `spec:scaffold` starts recording; additionally bind the events recorder (via `EventsConfiguration`) and each scaffold also appends a `scaffold` mutation event to `.altair/events.jsonl` for cross-session agent memory. See [events.md](./events.md).
+
+Keep `.altair/` in your application's `.gitignore` — journal entries are local to a checkout, not shared history.
+
+## Testing
+
+The published tests under `tests/Scaffold/` are the most honest description of how each component behaves:
+
+- `tests/Scaffold/Spec/ParserTest.php`, `ValidatorTest.php`, `PersistenceParserTest.php`, `PersistenceValidatorTest.php` — YAML → AST parsing and the full semantic validation matrix.
+- `tests/Scaffold/Emitter/*EmitterTest.php` — one per emitter, each asserting the generated output against a golden snapshot under `tests/Scaffold/Snapshots/` (`CreateUserAction.php.txt`, `CreateUserInput.php.txt`, `User.php.txt`, `create-user.openapi.yaml`, and so on).
+- `tests/Scaffold/Cli/ScaffoldCommandIntegrationTest.php` — end-to-end: a spec run through the command into a temp project tree, asserting written / skipped / modified outcomes.
+- `tests/Scaffold/Journal/*` — entry serialisation (`JournalEntryTest`), the SHA-guarded rewind logic (`JournalRewindTest`), atomic storage (`Storage/FilesystemStorageTest`), the unified differ, and the `journal:*` commands.
+- `tests/Scaffold/Linter/DriftDetectorTest.php` — each `DriftKind` exercised against a deliberately-divergent fixture.
+- `tests/Scaffold/Sdk/*` — the OpenAPI parser, both emitters, the registry, the `spec:emit-sdk` command, and a compile-integration test driven by `tests/Scaffold/Sdk/Fixtures/users-api.yaml`.
+
+The pattern to mirror when you extend an emitter: a `SpecFixture` builder under `tests/Scaffold/Support/`, a golden snapshot under `tests/Scaffold/Snapshots/`, and a test that diffs the emitter output against the snapshot. Determinism is the whole value proposition — these snapshot tests are what defend it. After an intentional change to an emitter, regenerate and diff the snapshot before committing.
+
+## Extending
+
+### Add an SDK language
+
+The natural extension point is a new SDK target. Implement `EmitterInterface` — `language()` returns the CLI identifier, `defaultFileName()` the single-file output name, and `emit()` walks the `OpenApiDocument` model to produce an `EmittedSdk` (a map of relative path → contents):
+
+```php
+use Altair\Scaffold\Sdk\Contracts\EmitterInterface;
+use Altair\Scaffold\Sdk\EmittedSdk;
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+
+final readonly class GoEmitter implements EmitterInterface
+{
+    public function language(): string { return 'go'; }
+    public function defaultFileName(): string { return 'client.go'; }
+
+    public function emit(OpenApiDocument $document, bool $multiFile = false): EmittedSdk
+    {
+        // walk $document->operations / $document->namedSchemas …
+        return new EmittedSdk(['client.go' => $source]);
+    }
+}
+```
+
+Then register it by constructing `EmitterRegistry` with your emitter alongside the defaults — do **not** fork the TypeScript or Python emitters. Keep your `emit()` deterministic (no `microtime()`, no unordered iteration); the contract requires byte-identical output for identical input so the `--check` gate stays meaningful.
+
+### Add a new generated artifact
+
+To emit an extra file from a spec, write an emitter that returns an `EmittedFile` with a new `EmittedFileKind`, then add it to `EmissionPlan::build()` (guarding it behind a spec block if it should only fire conditionally, the way the persistence and queue emitters are). Add a snapshot test, and — if the artifact should participate in drift detection — extend `DriftDetector` with a new `DriftKind`.
+
+### Add a new spec scaffolder downstream
+
+When you build a new generator in a downstream package, do **not** bypass `ScaffoldCommand`. Write a YAML spec and call `spec:scaffold`. Routing through the command is what gets you the journal entry and the event-log dual-write for free, and what keeps `journal:rewind` and `journal:replay` working over your new artifacts.
+
+## Related packages
+
+- [persistence.md](./persistence.md) — the Cycle ORM bridge. A `persistence:` block makes the scaffolder emit an entity, a repository, and a migration.
+- [messaging.md](./messaging.md) — the Symfony Messenger bridge. A `queue:` block makes the scaffolder emit a message DTO, an `#[AsHandler]` handler stub, and a test.
+- [events.md](./events.md) — the append-only mutation log. When bound, each scaffold (and journal rewind/replay) records a `scaffold` / `rewind` / `replay` event to `.altair/events.jsonl`.
+- [cli.md](./cli.md) — the attribute-driven CLI runtime that hosts every `spec:*` and `journal:*` command, plus the `ALTAIR_CLI_PATHS` mechanism the journal commands rely on.
+- [mcp.md](./mcp.md) — the MCP server. Its `framework__scaffold` / `framework__emit_*` tools wrap these commands so an agent can scaffold, lint, and emit SDKs over the wire.
+- [http.md](./http.md) — the runtime the generated Action / Input / Responder triple plugs into. The scaffolder generates against its conventions; the HTTP package actually serves the request.
+
+## Limitations
+
+- **Conventions are fixed in `Naming`.** Output paths and namespaces (`app/Http/Actions`, the `App\` namespace, `config/routes.php`, `database/migrations`) are baked into the `Naming` helper. Different layouts require constructing `Naming` with overrides and threading it through the emitters — there is no per-spec or config-file override for the paths yet.
+- **Validation rules are an allow-list.** Only the rules that ship with `Altair\Validation\Rule\*` are recognised; a custom rule will be flagged as unknown by the validator. Add it to the validator's known-rule set or it will not pass `spec:scaffold`.
+- **Drift detection is structural, not behavioural.** The linter checks input fields, validation rules, response statuses, and route registration. It does *not* verify that a hand-edited Action still does the right thing — only that the spec and the generated surface agree on shape.
+- **The journal is per-checkout, not shared.** Entries live under `.altair/` and are gitignored. `journal:rewind` / `replay` operate on your local history; they do not coordinate across machines or branches.
+- **The SDK emitters cover the subset the framework produces.** The OpenAPI parser understands operations, JSON request/response bodies, `$ref`, enums, and OpenAPI 3.1's `type: [t, "null"]` nullable form — enough for framework-generated documents plus common hand-authored ones. Exotic OpenAPI features (callbacks, `oneOf`/`allOf` composition, security schemes) are not modelled and are silently ignored.
+- **`journal:*` commands need explicit host wiring.** They are not exposed by the framework's `bin/altair` by default — the host must apply `ScaffoldJournalConfiguration` and add the journal CLI directory to `ALTAIR_CLI_PATHS` (see the Usage note above).

--- a/docs/packages/test-reporter.md
+++ b/docs/packages/test-reporter.md
@@ -1,0 +1,279 @@
+# TestReporter
+
+> An AI-native PHPUnit 11 extension that emits a structured JSON report at the end of every run — every failure mapped back to the production source under test, with structured diffs and a one-word verdict you can branch on.
+
+**Composer:** `univeros/test-reporter`
+**Namespace:** `Altair\TestReporter`
+
+## Introduction
+
+When an agent runs your test suite, it does not want to read the suite's output the way you do. PHPUnit's default printer is built for a human scanning a terminal: dots, an `F` here and there, a textual dump of the first few failures, a `Tests: 312, Assertions: 980, Failures: 2` footer. To act on that, an agent has to scrape it — parse the dots, regex out the failure blocks, guess which file the assertion came from, and then go hunting through `src/` for the class that actually broke. Every one of those steps is a place to be wrong, and none of them survive a PHPUnit version bump that nudges the output format.
+
+TestReporter removes the scraping. You register one extension, run `phpunit` exactly the way you already do, and at the end of the run you get a single JSON document. The top of that document has a `result` field whose value is one of `pass`, `fail`, or `error` — so an agent decides what to do next by reading one string, not by counting failures. Each entry in `failures[]` already carries the answer to "where do I look?": a `source_under_test` array pointing at the production file, method, and line range the failing test most likely targets. And `assertSame` / `assertEquals` mismatches come pre-diffed into a small typed payload, so the agent reasons about *what changed* without re-parsing PHPUnit's textual diff.
+
+The whole report is deterministic for the same outcome — no timestamps wedged into the diff payloads, no random ordering — which means you can check a golden copy into your test suite and diff against it in CI. That determinism is the same property that makes the report safe to feed an agent: run the suite twice with the same code and you get the same bytes, so an agent that caches by content hash will not re-reason about an unchanged run.
+
+What this package deliberately is *not*: it is not a replacement for PHPUnit's human output (leave that on; this runs alongside it), it is not a coverage tool, and it does not try to *fix* anything. It reports — richly, machine-first — and gets out of the way.
+
+## Installation
+
+Install it as a dev dependency:
+
+```bash
+composer require --dev univeros/test-reporter
+```
+
+It belongs in `require-dev` because it only ever runs under PHPUnit — it has no place in your production autoloader. The only runtime requirement beyond PHP 8.3 is `phpunit/phpunit: ^11.4`; the extension hooks into PHPUnit 11's event system, so it will not load under PHPUnit 10 or earlier. If you installed the whole framework via `composer require univeros/framework`, this package is already bundled.
+
+## Quick start
+
+Register the extension as a `<bootstrap>` inside an `<extensions>` block in your `phpunit.xml.dist`. This is the entire wiring — PHPUnit constructs the extension, calls `bootstrap()`, and the extension registers every subscriber it needs:
+
+```xml
+<extensions>
+    <bootstrap class="Altair\TestReporter\AltairExtension">
+        <parameter name="output" value="json"/>
+        <parameter name="file" value="build/test-results.json"/>
+    </bootstrap>
+</extensions>
+```
+
+Now run the suite the way you always have — nothing about the command changes:
+
+```bash
+vendor/bin/phpunit
+```
+
+When the run finishes, `build/test-results.json` holds the report. A passing run looks like this (trimmed):
+
+```json
+{
+    "version": "1.0",
+    "started_at": "2026-05-28T09:14:22.481+00:00",
+    "duration_ms": 1840,
+    "php_version": "8.3.7",
+    "phpunit_version": "11.5.0",
+    "totals": {
+        "tests": 312,
+        "assertions": 980,
+        "passed": 312,
+        "failed": 0,
+        "errored": 0,
+        "skipped": 0,
+        "warnings": 0,
+        "risky": 0,
+        "incomplete": 0
+    },
+    "result": "pass",
+    "failures": [],
+    "errors": [],
+    "skipped": [],
+    "risky": [],
+    "incomplete": []
+}
+```
+
+When something breaks, `result` flips and the matching array fills in. Here is a single `assertSame` failure, mapped back to its source:
+
+```json
+{
+    "result": "fail",
+    "totals": { "tests": 312, "failed": 1, "passed": 311, "...": "..." },
+    "failures": [
+        {
+            "test": "Altair\\Tests\\Http\\Support\\HttpCacheTest::testIsCacheableReturnsTrueWithMaxAge",
+            "test_file": "tests/Http/Support/HttpCacheTest.php",
+            "test_line": 41,
+            "type": "ExpectationFailedException",
+            "message": "Failed asserting that false is true.",
+            "expected": "true",
+            "actual": "false",
+            "diff": { "kind": "scalar", "expected": true, "actual": false },
+            "source_under_test": [
+                { "file": "src/Altair/Http/Support/HttpCache.php", "method": "isCacheable", "lines": "58-71" }
+            ],
+            "stack_trace": [
+                { "file": "tests/Http/Support/HttpCacheTest.php", "line": 41, "function": "Altair\\Tests\\Http\\Support\\HttpCacheTest::testIsCacheableReturnsTrueWithMaxAge" }
+            ]
+        }
+    ]
+}
+```
+
+An agent reads `result: "fail"`, walks `failures[0].source_under_test[0]`, and opens `src/Altair/Http/Support/HttpCache.php` at `isCacheable` (lines 58–71) — without ever looking at the test runner's textual output.
+
+## Concepts
+
+### The report shape
+
+The root document is built by `Altair\TestReporter\Result\TestReport` and carries a stable `version` constant (`"1.0"`) so consumers can detect format changes. Its top-level keys are:
+
+- **`result`** — the one-word verdict, the value of the `Altair\TestReporter\Result\ReportStatus` enum (`pass` / `fail` / `error`). It is `error` when any test errored, `fail` when any test failed (but none errored), and `pass` otherwise. This is the field to branch on.
+- **`totals`** — the aggregate counts from `Result\Totals`: `tests`, `assertions`, `passed`, `failed`, `errored`, `skipped`, `warnings`, `risky`, `incomplete`.
+- **`failures[]` / `errors[]`** — lists of `Result\FailureRecord`, the actionable entries.
+- **`skipped[]` / `risky[]` / `incomplete[]`** — lists of `Result\SkippedRecord` (just `test` + `reason`), kept separate from failures so an agent can tell "you have work to do" from "this was intentionally not run."
+- **`started_at`, `duration_ms`, `php_version`, `phpunit_version`** — run metadata.
+
+Each `FailureRecord` serialises to this shape:
+
+```json
+{
+    "test": "Fully\\Qualified\\TestClass::testMethod",
+    "test_file": "tests/...",
+    "test_line": 41,
+    "type": "ExpectationFailedException",
+    "message": "Failed asserting that ...",
+    "expected": "true",
+    "actual": "false",
+    "diff": { "kind": "scalar", "...": "..." },
+    "source_under_test": [ { "file": "...", "method": "...", "lines": "58-71" } ],
+    "stack_trace": [ { "file": "...", "line": 41, "function": "..." } ]
+}
+```
+
+### The structured diff
+
+`Altair\TestReporter\Diff\ValueDiffer` turns an `assertSame` / `assertEquals` comparison failure into a typed payload, keyed by `kind` so an agent branches on the shape rather than re-parsing the values:
+
+- **`scalar`** — `{ "kind": "scalar", "expected": 42, "actual": 7 }`
+- **`array`** — `{ "kind": "array", "added": {...}, "removed": {...}, "changed": { "key": { "expected": ..., "actual": ... } } }`
+- **`string`** — `{ "kind": "string", "expected_preview": "...", "actual_preview": "...", "expected_length": 5, "actual_length": 5 }` (previews are truncated past `ValueDiffer::STRING_PREVIEW_LIMIT` = 200 chars with a `… (N more chars)` marker)
+- **`object`** — `{ "kind": "object", "expected_class": "X", "actual_class": "Y", "expected_preview": "...", "actual_preview": "..." }`
+
+When the failure carried no comparable pair — most non-comparison assertions, like `assertTrue` — `diff` is `null`. The array diff is the most useful of the four: an agent can see exactly which keys were added, removed, or changed instead of eyeballing two serialised arrays.
+
+### The three-tier source resolver
+
+The most valuable field is `source_under_test`, and it is produced by `Altair\TestReporter\Resolver\SourceUnderTestResolver` using three signals tried strictly in order:
+
+1. **`#[CoversClass(X::class)]` / `#[CoversFunction('x')]` attributes** on the test class or method — authoritative. This is the signal you should give the resolver when you can.
+2. **A legacy `@covers` annotation** in the doc comment — a fallback for older code that still uses annotations. Do not add these in new code.
+3. **A namespace heuristic** — `Altair\Tests\Http\Support\HttpCacheTest` → `Altair\Http\Support\HttpCache`. The resolver strips a `\Tests\` segment and the trailing `Test` suffix, confirms the class exists, then walks its methods to find the one whose name the test method extends (`testIsCacheableReturnsTrueWithMaxAge` → `isCacheable`, picking the longest matching prefix when several would match).
+
+The resolver's signature is:
+
+```php
+public function resolve(string $testClass, string $testMethod): array // list<SourceLocation>
+```
+
+When no signal matches — an unknown class, a test that covers nothing nameable — it returns an empty list, and `source_under_test` serialises to `[]`. That empty array is itself a signal: the agent knows the mapping is unavailable and that it is on its own for that failure, rather than chasing a wrong guess.
+
+### Determinism
+
+`Altair\TestReporter\Output\JsonWriter` is documented to be deterministic for the same `TestReport` instance: no random fields, ordering only where it carries meaning. That is what makes a checked-in golden copy a viable CI gate — see [Testing](#testing). The writer emits pretty-printed JSON with unescaped slashes and unicode, terminated by a newline.
+
+## Usage
+
+### Make the resolver find your source
+
+The resolver is only as good as the signal you give it. Two conventions cover almost everything.
+
+The first is naming. Put the test in a sibling `Tests\` namespace, name the class `<Class>Test`, and prefix each test method with the source method it exercises. With that layout the namespace heuristic resolves the source for free — no attributes required:
+
+```php
+namespace Altair\Tests\Http\Support;        // sibling Tests\ segment
+
+final class HttpCacheTest extends TestCase  // <Class>Test
+{
+    public function testIsCacheableReturnsTrueWithMaxAge(): void // prefix: isCacheable
+    {
+        // resolves to Altair\Http\Support\HttpCache::isCacheable
+    }
+}
+```
+
+The second is the explicit override. When the naming convention is awkward — one test class covering several production classes, or a test whose name cannot mirror the method — annotate with `#[CoversClass]` and the resolver takes that as authoritative, ahead of the heuristic:
+
+```php
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(HttpCache::class)]
+final class HttpCacheBehaviourTest extends TestCase
+{
+    // every failure here maps to HttpCache regardless of method names
+}
+```
+
+Do **not** reach for the legacy `@covers` doc-comment annotation in new code. The resolver still honours it as a second-tier fallback so existing suites keep working, but `#[CoversClass]` is the supported, native form — PHPDoc covers are deprecated in PHPUnit and Rector will strip them anyway.
+
+### Branch agent logic on `result`
+
+The point of the one-word verdict is that downstream automation does not need to interpret the totals. The control flow is a single read:
+
+```php
+$report = json_decode(file_get_contents('build/test-results.json'), true);
+
+match ($report['result']) {
+    'pass'  => /* nothing broke — move on */,
+    'fail'  => /* assertions failed — read failures[].source_under_test */,
+    'error' => /* tests threw — read errors[]; likely a setup or fixture problem */,
+};
+```
+
+`fail` versus `error` matters to an agent: a `fail` points at a logic bug the agent can usually fix from `source_under_test`, while an `error` often means the test could not even run (a missing dependency, a broken fixture, an uncaught exception) — a different remediation path.
+
+### Run with the report disabled
+
+When you want only PHPUnit's human output for a particular run, set the `output` parameter to `none`. The extension still loads, but the writer becomes a no-op — no JSON is produced:
+
+```xml
+<bootstrap class="Altair\TestReporter\AltairExtension">
+    <parameter name="output" value="none"/>
+</bootstrap>
+```
+
+## Configuration
+
+There is no `Configuration` class and nothing to bind in the container — the extension is configured entirely through the two `<parameter>` elements on the `<bootstrap>` tag, read in `AltairExtension::bootstrap()`:
+
+| Parameter | Default | Effect |
+|---|---|---|
+| `output` | `json` | `json` emits the report; `none` disables emission (extension loads, writer is a no-op). |
+| `file` | _(unset)_ | Path the JSON is written to. The writer creates parent directories as needed. **Omit it and the report is written to stdout** instead of a file. |
+
+The signature PHPUnit calls is:
+
+```php
+public function bootstrap(
+    Configuration $configuration,
+    Facade $facade,
+    ParameterCollection $parameters,
+): void
+```
+
+The extension resolves the project root from `getcwd()` to relativise the file paths it emits — for the framework itself, and for any project you run `phpunit` from at its root, that yields clean repository-relative paths like `src/Altair/Http/Support/HttpCache.php`.
+
+Two practical notes. First, point `file` at a build directory you gitignore (`build/test-results.json` is the convention) — the report is a per-run artifact, not source. Second, if you omit `file` to write to stdout, be aware PHPUnit's own output goes to stdout too; pipe to a file or use `file` when you need the JSON cleanly.
+
+## Testing
+
+The package's own tests under `tests/TestReporter/` are the clearest description of each component's contract:
+
+- `tests/TestReporter/Resolver/SourceUnderTestResolverTest.php` exercises all three resolver tiers in turn — the `#[CoversClass]` attribute, the legacy `@covers` annotation, and the namespace heuristic — plus the empty-list result for an unknown class.
+- `tests/TestReporter/Diff/ValueDifferTest.php` pins each diff `kind`: scalar, array (added/removed/changed), string (previews + lengths + truncation past the limit), and object (class names + previews).
+- `tests/TestReporter/Output/JsonWriterTest.php` checks stdout and file emission and asserts byte-for-byte determinism — the same report rendered twice must match exactly.
+- `tests/TestReporter/ResultCollectorTest.php` covers the totals arithmetic and the report's JSON shape without needing a real `PHPUnit\Event\Code\Test` instance.
+
+Note the resolver tests lean on **fixtures** under `tests/TestReporter/Fixtures/` — `ExampleHttpCacheTest` (the `#[CoversClass]` path), `LegacyCoversAnnotationTest` (the annotation path), and `ExampleNoCoversTest` (the heuristic path), each paired with a tiny production-shaped class. Those fixtures are deliberately **excluded** from the main suite in `phpunit.xml.dist` so they do not run as real tests — the resolver test instantiates them by reflection instead:
+
+```xml
+<exclude>./tests/TestReporter/Fixtures/ExampleHttpCacheTest.php</exclude>
+<exclude>./tests/TestReporter/Fixtures/ExampleNoCoversTest.php</exclude>
+<exclude>./tests/TestReporter/Fixtures/LegacyCoversAnnotationTest.php</exclude>
+```
+
+Because `JsonWriter` is deterministic, the natural way to defend the report format in your own CI is a **golden snapshot**: capture a known-good `build/test-results.json` for a fixed suite and diff every run against it. Any unintended change to the format surfaces as a diff in the PR rather than a silent shift in what your agents consume.
+
+## Related packages
+
+- [cli.md](./cli.md) — the `bin/altair` command substrate. Other framework commands shell out to PHPUnit and read this report rather than scraping text.
+- [doctor.md](./doctor.md) — the health-check runner. Its `TestsPassingCheck` reads the `result` field of this report to decide whether the suite is green, exactly as described in [Branch agent logic on `result`](#branch-agent-logic-on-result).
+- [mcp.md](./mcp.md) — the Model Context Protocol server. Its `framework__run_tests` tool runs the suite with this extension active and returns the structured JSON straight to the calling agent.
+- [scaffold.md](./scaffold.md) — the spec scaffolder. The PHPUnit test it emits for every generated Action already follows the `<Class>Test` + method-prefix convention the resolver keys on, so failures in generated tests map back to the generated source out of the box.
+
+## Limitations
+
+- **PHPUnit 11 only.** The extension implements `PHPUnit\Runner\Extension\Extension` and subscribes to PHPUnit 11's event system. It will not load under PHPUnit 10 or earlier; the package requires `phpunit/phpunit: ^11.4`.
+- **`build/test-results.json` is a build artifact.** Keep it gitignored — it is regenerated on every run and is not source to be committed.
+- **The resolver can return `[]`.** When none of the three signals match — an unconventional test name with no `#[CoversClass]`, a test covering something the heuristic can't reach — `source_under_test` is an empty array. That is correct behaviour, not a bug: it tells the agent the mapping is unavailable so it does not chase a wrong guess. The fix is to add a `#[CoversClass]` attribute.
+- **Path relativisation uses `getcwd()`.** Paths are relative to the directory you invoke `phpunit` from. Run from your project root (as you normally would) and they come out clean; run from a subdirectory and the emitted paths reflect that working directory.


### PR DESCRIPTION
## Summary

Backfills user-facing documentation for every framework package that had shipped without a guide, and links them from the docs index. Addresses the gap where recently-built packages (notably `mcp` and `doctor`) had zero docs. Advances #15 (its original "16 packages" scope, expanded to the current set).

New `docs/packages/*.md` (7):

| Doc | Package |
|---|---|
| `cli.md` | `univeros/cli` — attribute-driven CLI substrate |
| `scaffold.md` | `univeros/scaffold` — spec → API generator + journal + SDKs |
| `introspection.md` | `univeros/introspection` — read-only app X-ray |
| `doctor.md` | `univeros/doctor` — health-check runner |
| `events.md` | `univeros/events` — `.altair/events.jsonl` mutation log |
| `test-reporter.md` | `univeros/test-reporter` — AI-native PHPUnit JSON report |
| `mcp.md` | `univeros/mcp` — Model Context Protocol server (28 tools) |

`docs/README.md` gains a Tooling entry for each.

## Approach

- Every page matches the established house template (one-line `>` pitch, **Composer:** / **Namespace:**, then Introduction → Installation → Quick start → Concepts → Usage → Configuration → Testing → Related packages → Limitations), in **second-person** prose with a why-sentence before each code block, rendering cleanly on github.com and standing alone.
- **Source-accurate**: command names, class/method signatures, and flags were verified against the actual classes — not CLAUDE.md. Where they diverged, source won (e.g. `journal:replay --id`, the listing command `journal:list`, `config:dump --no-secrets`).
- All cited `bin/altair` commands exist in source; all `framework__*` tools exist; all 7 docs have balanced code fences and the required headers.

## Out of scope / follow-ups
- `bootstrap` docs are deferred with **#73** (the `univeros/skeleton` + `bin/altair new` work).
- While scoping #73 I found a scaffolder↔HTTP-runtime contract drift (scaffolded endpoints don't execute through `ActionMiddleware`); filed as **#118**.

## Test plan
- [x] Docs are Markdown only — no code changed; CS/PHPStan/Rector/tests unaffected.
- [x] Fence balance + required headers verified on all 7 files.
- [x] Every `bin/altair` command and `framework__` tool cited is confirmed to exist in source.
- [ ] CI green (validate composer.json unchanged; suite unaffected).