### PR TITLE
re #118 execute spec-scaffolded typed-DTO inputs through ActionMiddleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
         "univeros/mcp": "self.version",
         "univeros/messaging": "self.version",
         "univeros/middleware": "self.version",
+        "univeros/observatory": "self.version",
         "univeros/persistence": "self.version",
         "univeros/queue": "self.version",
         "univeros/sanitation": "self.version",

--- a/docs/packages/observatory.md
+++ b/docs/packages/observatory.md
@@ -1,0 +1,120 @@
+# Observatory
+
+> A dev-only web monitoring panel for Altair apps — health, activity, queues, routes, config and more — in the spirit of Laravel Telescope/Horizon/Pulse, but as a thin, gated layer over data the framework already produces.
+
+**Composer:** `univeros/observatory`
+**Namespace:** `Altair\Observatory`
+
+## Introduction
+
+Every framework eventually needs a window into the running app: is it healthy, what just happened, what's stuck in the queue, which routes exist. Observatory is that window. The key design choice is that it owns **no data of its own** — `doctor` (health), `events` (the append-only activity/error log), `messaging` (queues and failed jobs), `introspection` (routes, container, config, listeners, middleware) and `persistence` (migrations) already expose everything, and `univeros/mcp` already wraps those same sources for agents. Observatory is simply the *human* consumer of that data: an agent reads via MCP, a developer reads via the panel.
+
+That makes the package a presentation layer with near-zero coupling to the core. A **panel** is a pure data provider — it reads one source and projects a render-agnostic `PanelSnapshot` (a status, a headline, a flat metrics map, detail rows). The same snapshot backs the web UI and any JSON endpoint, so panels stay unit-testable and never bind to HTML.
+
+Because the panel surfaces configuration, queues and database state, **access is fail-closed**: it is denied unless explicitly enabled *and* running in a non-production environment, so a misconfigured production deploy never exposes it.
+
+> **Status:** this is the package scaffold — the data layer (panels, registry, facade, access guard) and one reference panel (`runtime`). The HTTP entrypoint, SSE live-tail and Tailwind/Alpine UI, plus the `doctor`/`events`/`messaging`/`introspection` panels, land in follow-up phases. See [Roadmap](#roadmap).
+
+## Installation
+
+Standalone:
+
+```bash
+composer require --dev univeros/observatory
+```
+
+In the monorepo it ships with the framework. Register the Configuration and gate it via env:
+
+```dotenv
+OBSERVATORY_ENABLED=true   # default: false (off)
+APP_ENV=local              # panel served only in local/development/dev/testing
+```
+
+## Quick start
+
+Resolve the facade from the container and project the dashboard as plain data:
+
+```php
+use Altair\Observatory\Observatory;
+
+$observatory = $container->get(Observatory::class);
+
+if ($observatory->isAccessible()) {
+    foreach ($observatory->dashboard() as $id => $card) {
+        // $card = ['label' => ..., 'icon' => ..., 'snapshot' => ['status' => 'ok', ...]]
+    }
+}
+```
+
+## Concepts
+
+**A panel is a data provider, not a view.** `PanelInterface` is `id()`, `label()`, `icon()` and `snapshot(): PanelSnapshot`. Rendering is the UI layer's job, so the same panel serves HTML and JSON.
+
+**Snapshots are render-agnostic read models.** `PanelSnapshot` carries a `PanelStatus` (`ok`/`warning`/`critical`/`unknown`), a one-line `headline`, a flat `metrics` map for the card header, and an ordered list of `items` (detail rows). `toArray()` is the wire/JSON shape.
+
+**The registry is id-keyed and overridable.** `PanelRegistry` keys panels by `id()`; registering an existing id replaces it, so a host can override a built-in panel by registering its own after configuration (`prepare()`-ing the shared `PanelRegistry`).
+
+**Access is a swappable contract.** `AccessGuardInterface::allows()` decides whether the panel may be served. The default `EnvironmentAccessGuard` is fail-closed (enabled flag AND allow-listed environment). Hosts rebind it for real auth — IP allow-list, signed cookie, RBAC — without touching panels.
+
+## Configuration
+
+`ObservatoryConfiguration` wires the access guard, the panel registry (with the built-in `runtime` panel) and the `Observatory` facade into the container. It reads:
+
+| Env | Default | Effect |
+|---|---|---|
+| `OBSERVATORY_ENABLED` | `false` | Master on/off switch. |
+| `APP_ENV` | `production` | Panel served only when in `local`/`development`/`dev`/`testing`. |
+
+## Security
+
+Observatory exposes sensitive surfaces (config, queues, database). The guard is **fail-closed**: an unset flag or an unrecognised/production environment denies access. When the UI layer lands it will additionally reuse the introspection `config_dump` secret masking, and hosts are expected to put a real auth guard in front in any shared environment.
+
+## Testing
+
+The data layer is plain PHP with no I/O, so panels and the facade test directly:
+
+```php
+$observatory = new Observatory(
+    new PanelRegistry([new RuntimePanel()]),
+    new EnvironmentAccessGuard(enabled: true, environment: 'local'),
+);
+
+self::assertTrue($observatory->isAccessible());
+self::assertSame('ok', $observatory->dashboard()['runtime']['snapshot']['status']);
+```
+
+## Extending
+
+Implement `PanelInterface`, returning a `PanelSnapshot` from `snapshot()`, and register it on the shared `PanelRegistry`:
+
+```php
+final class QueuesPanel implements PanelInterface
+{
+    public function __construct(private readonly MessageBusInterface $bus) {}
+    public function id(): string { return 'queues'; }
+    public function label(): string { return 'Queues'; }
+    public function icon(): string { return 'queue-list'; }
+    public function snapshot(): PanelSnapshot { /* read failed/transports, map to a snapshot */ }
+}
+```
+
+`RuntimePanel` is the worked reference implementation (it depends on nothing outside PHP).
+
+## Roadmap
+
+1. **Scaffold** (current): panel contracts, registry, facade, access guard, `runtime` panel, docs.
+2. **UI layer**: PSR-15 HTTP entrypoint, SSE live-tail endpoint, server-rendered Tailwind/Alpine dashboard (dark-first, card-based).
+3. **Data panels**: `health` (doctor), `events` (activity/errors), `queues` (messaging), `routes`/`container`/`config`/`listeners`/`middleware` (introspection), `migrations` (persistence).
+
+## Related packages
+
+- `univeros/doctor` — health checks (the `health` panel's source).
+- `univeros/events` — the append-only activity/error log (the `events` panel's source).
+- `univeros/messaging` — queues and failed jobs (the `queues` panel's source).
+- `univeros/introspection` — routes, container, config, listeners, middleware.
+- `univeros/mcp` — the agent-facing consumer of the same data sources.
+
+## Limitations
+
+- Scaffold only: no HTTP/UI yet (see [Roadmap](#roadmap)).
+- The default guard is environment-based, not auth-based — put real authentication in front before exposing it anywhere shared.

--- a/src/Altair/Http/Exception/InputValidationException.php
+++ b/src/Altair/Http/Exception/InputValidationException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Http\Exception;
+
+/**
+ * Thrown when request data cannot satisfy a typed input DTO — a required field
+ * is missing. The HTTP action layer maps it to a 422 response carrying the
+ * per-field errors.
+ */
+final class InputValidationException extends HttpException
+{
+    /**
+     * @param array<string, string> $errors per-field error messages
+     */
+    public function __construct(
+        public readonly array $errors,
+        string $message = 'Input validation failed.',
+    ) {
+        parent::__construct($message);
+    }
+}

--- a/src/Altair/Http/Input/DtoInputHydrator.php
+++ b/src/Altair/Http/Input/DtoInputHydrator.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Http\Input;
+
+use Altair\Http\Exception\InputValidationException;
+use BackedEnum;
+
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOL;
+
+use Psr\Http\Message\ServerRequestInterface;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionParameter;
+use TypeError;
+
+/**
+ * Builds a typed, readonly input DTO from a PSR-7 request.
+ *
+ * Request data is merged (query string, then parsed body, then route
+ * attributes win) and mapped onto the DTO constructor by parameter name. Scalar
+ * values are coerced to the declared builtin type and backed-enum parameters are
+ * resolved with `tryFrom()`. Anything that cannot satisfy the declared type — a
+ * missing required field, a non-numeric value for an `int`, an unknown enum case
+ * — is collected into an {@see InputValidationException} (mapped to HTTP 422)
+ * rather than being allowed to surface as a `TypeError` (HTTP 500).
+ *
+ * This is the bridge that lets `spec:scaffold`-generated DTO inputs execute
+ * through {@see \Altair\Http\Middleware\ActionMiddleware} without implementing
+ * the request-bag {@see \Altair\Http\Contracts\InputInterface}.
+ */
+final class DtoInputHydrator
+{
+    /**
+     * @param class-string $dtoClass
+     */
+    public function hydrate(string $dtoClass, ServerRequestInterface $request): object
+    {
+        $reflection = new ReflectionClass($dtoClass);
+        $constructor = $reflection->getConstructor();
+
+        if ($constructor === null || $constructor->getNumberOfParameters() === 0) {
+            return $reflection->newInstance();
+        }
+
+        $data = $this->collect($request);
+
+        $arguments = [];
+        $errors = [];
+        foreach ($constructor->getParameters() as $parameter) {
+            $name = $parameter->getName();
+
+            if (\array_key_exists($name, $data)) {
+                $arguments[] = $this->coerce($data[$name], $parameter, $errors);
+                continue;
+            }
+
+            if ($parameter->isDefaultValueAvailable()) {
+                $arguments[] = $parameter->getDefaultValue();
+                continue;
+            }
+
+            if ($parameter->allowsNull()) {
+                $arguments[] = null;
+                continue;
+            }
+
+            $errors[$name] = 'is required';
+        }
+
+        if ($errors !== []) {
+            throw new InputValidationException($errors);
+        }
+
+        // Safety net: a value passed through to a non-builtin, non-enum type
+        // (class / union / intersection) that does not satisfy it surfaces as a
+        // 422 rather than an uncaught TypeError (HTTP 500).
+        try {
+            return $reflection->newInstanceArgs($arguments);
+        } catch (TypeError $typeError) {
+            throw new InputValidationException(
+                ['input' => 'has one or more fields of the wrong type'],
+                $typeError->getMessage(),
+            );
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function collect(ServerRequestInterface $request): array
+    {
+        $body = $request->getParsedBody();
+
+        // Route attributes win over body, which wins over the query string.
+        // Framework-internal attributes are colon-namespaced (e.g.
+        // `altair:http:action`) so they can never match a DTO property name.
+        return array_replace(
+            $request->getQueryParams(),
+            \is_array($body) ? $body : [],
+            $request->getAttributes(),
+        );
+    }
+
+    /**
+     * @param array<string, string> $errors
+     */
+    private function coerce(mixed $value, ReflectionParameter $parameter, array &$errors): mixed
+    {
+        $type = $parameter->getType();
+        if (!$type instanceof ReflectionNamedType || $value === null) {
+            return $value;
+        }
+
+        $name = $type->getName();
+
+        if ($type->isBuiltin()) {
+            return $this->coerceBuiltin($value, $name, $parameter->getName(), $errors);
+        }
+
+        if (enum_exists($name) && is_a($name, BackedEnum::class, true)) {
+            $case = (\is_int($value) || \is_string($value)) ? $name::tryFrom($value) : null;
+            if ($case === null) {
+                $errors[$parameter->getName()] = 'is not a valid value';
+
+                return null;
+            }
+
+            return $case;
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, string> $errors
+     */
+    private function coerceBuiltin(mixed $value, string $type, string $field, array &$errors): mixed
+    {
+        switch ($type) {
+            case 'int':
+                if (\is_int($value)) {
+                    return $value;
+                }
+
+                if (\is_string($value) && preg_match('/^-?\d+$/', $value) === 1) {
+                    return (int) $value;
+                }
+
+                $errors[$field] = 'must be an integer';
+
+                return null;
+            case 'float':
+                if (\is_int($value) || \is_float($value)) {
+                    return (float) $value;
+                }
+
+                if (\is_string($value) && is_numeric($value)) {
+                    return (float) $value;
+                }
+
+                $errors[$field] = 'must be a number';
+
+                return null;
+            case 'bool':
+                if (\is_bool($value)) {
+                    return $value;
+                }
+
+                $bool = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+                if ($bool === null) {
+                    $errors[$field] = 'must be a boolean';
+
+                    return null;
+                }
+
+                return $bool;
+            case 'string':
+                if (\is_string($value)) {
+                    return $value;
+                }
+
+                if (\is_int($value) || \is_float($value) || \is_bool($value)) {
+                    return (string) $value;
+                }
+
+                $errors[$field] = 'must be a string';
+
+                return null;
+            case 'array':
+                if (\is_array($value)) {
+                    return $value;
+                }
+
+                $errors[$field] = 'must be an array';
+
+                return null;
+            default:
+                return $value;
+        }
+    }
+}

--- a/src/Altair/Http/Input/DtoInputHydrator.php
+++ b/src/Altair/Http/Input/DtoInputHydrator.php
@@ -15,7 +15,7 @@ use Altair\Http\Exception\InputValidationException;
 use BackedEnum;
 
 use const FILTER_NULL_ON_FAILURE;
-use const FILTER_VALIDATE_BOOL;
+use const FILTER_VALIDATE_BOOLEAN;
 
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionClass;
@@ -176,7 +176,7 @@ final class DtoInputHydrator
                     return $value;
                 }
 
-                $bool = filter_var($value, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+                $bool = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
                 if ($bool === null) {
                     $errors[$field] = 'must be a boolean';
 

--- a/src/Altair/Http/Middleware/ActionMiddleware.php
+++ b/src/Altair/Http/Middleware/ActionMiddleware.php
@@ -12,11 +12,14 @@ declare(strict_types=1);
 namespace Altair\Http\Middleware;
 
 use Altair\Http\Base\Action;
-use Altair\Http\Contracts\DomainInterface;
+use Altair\Http\Base\Payload;
 use Altair\Http\Contracts\InputInterface;
 use Altair\Http\Contracts\MiddlewareInterface;
 use Altair\Http\Contracts\PayloadInterface;
 use Altair\Http\Contracts\ResponderInterface;
+use Altair\Http\Exception\InputValidationException;
+use Altair\Http\Exception\InvalidArgumentException;
+use Altair\Http\Input\DtoInputHydrator;
 use Altair\Http\Traits\ResolverAwareTrait;
 use Override;
 use Psr\Http\Message\ResponseFactoryInterface;
@@ -36,6 +39,7 @@ class ActionMiddleware implements MiddlewareInterface
     public function __construct(
         callable $resolver,
         private readonly ResponseFactoryInterface $responseFactory,
+        private readonly DtoInputHydrator $hydrator = new DtoInputHydrator(),
     ) {
         $this->resolver = $resolver;
     }
@@ -55,23 +59,62 @@ class ActionMiddleware implements MiddlewareInterface
 
     private function handle(Action $action, ServerRequestInterface $request): ResponseInterface
     {
-        /** @var DomainInterface $domain */
-        $domain = $this->resolve($action->getDomainClassName());
-        /** @var InputInterface $input */
-        $input = $this->resolve($action->getInputClassName());
         /** @var ResponderInterface $responder */
         $responder = $this->resolve($action->getResponderClassName());
 
-        $payload = $this->payload($domain, $input, $request);
+        try {
+            $payload = $this->resolvePayload($action, $request);
+        } catch (InputValidationException $inputValidationException) {
+            $payload = (new Payload())
+                ->withStatus(422)
+                ->withOutput(['errors' => $inputValidationException->errors]);
+        }
 
         return $responder($request, $this->responseFactory->createResponse(), $payload);
     }
 
-    private function payload(
-        DomainInterface $domain,
-        InputInterface $input,
-        ServerRequestInterface $request,
-    ): PayloadInterface {
-        return $domain($input($request));
+    /**
+     * Two input shapes are supported. The legacy shape implements
+     * {@see InputInterface} (a request bag) and pairs with a
+     * {@see DomainInterface}. The spec-scaffolded shape is a typed DTO that is
+     * hydrated from the request and handed to an invokable domain as
+     * `$domain($dto, $payload)`.
+     */
+    private function resolvePayload(Action $action, ServerRequestInterface $request): PayloadInterface
+    {
+        $domain = $this->resolve($action->getDomainClassName());
+        if (!\is_callable($domain)) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s must be invokable to act as a domain.',
+                $action->getDomainClassName(),
+            ));
+        }
+
+        $inputClass = $action->getInputClassName();
+
+        if (is_a($inputClass, InputInterface::class, true)) {
+            // Legacy path: request-bag input handed to the domain as an InputCollection.
+            /** @var InputInterface $input */
+            $input = $this->resolve($inputClass);
+            $payload = $domain($input($request));
+        } else {
+            // Typed-DTO path: hydrate the DTO from the request and hand it to the
+            // domain alongside a fresh Payload to build on.
+            if (!class_exists($inputClass)) {
+                throw new InvalidArgumentException(\sprintf("Input class '%s' does not exist.", $inputClass));
+            }
+
+            $payload = $domain($this->hydrator->hydrate($inputClass, $request), new Payload());
+        }
+
+        if (!$payload instanceof PayloadInterface) {
+            throw new InvalidArgumentException(\sprintf(
+                '%s::__invoke() must return %s.',
+                $action->getDomainClassName(),
+                PayloadInterface::class,
+            ));
+        }
+
+        return $payload;
     }
 }

--- a/src/Altair/Observatory/Configuration/ObservatoryConfiguration.php
+++ b/src/Altair/Observatory/Configuration/ObservatoryConfiguration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Configuration;
+
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Configuration\Traits\EnvAwareTrait;
+use Altair\Container\Container;
+use Altair\Observatory\Observatory;
+use Altair\Observatory\Panel\RuntimePanel;
+use Altair\Observatory\PanelRegistry;
+use Altair\Observatory\Security\AccessGuardInterface;
+use Altair\Observatory\Security\EnvironmentAccessGuard;
+use Override;
+
+/**
+ * Wires the access guard, the panel registry (with the built-in panels) and the
+ * Observatory facade into the Container.
+ *
+ * Access is fail-closed: it reads OBSERVATORY_ENABLED (default off) and APP_ENV
+ * (default "production"), so an unconfigured or production deploy never serves
+ * the panel. Hosts add panels by `prepare()`-ing {@see PanelRegistry} after this
+ * Configuration runs, and can rebind {@see AccessGuardInterface} for real auth.
+ */
+class ObservatoryConfiguration implements ConfigurationInterface
+{
+    use EnvAwareTrait;
+
+    #[Override]
+    public function apply(Container $container): void
+    {
+        $enabled = filter_var($this->env->get('OBSERVATORY_ENABLED', false), FILTER_VALIDATE_BOOLEAN);
+        $environment = (string) $this->env->get('APP_ENV', 'production');
+
+        $guard = new EnvironmentAccessGuard($enabled, $environment);
+        $registry = new PanelRegistry([new RuntimePanel()]);
+
+        $container
+            ->delegate(AccessGuardInterface::class, static fn(): AccessGuardInterface => $guard)
+            ->share(AccessGuardInterface::class)
+
+            ->delegate(PanelRegistry::class, static fn(): PanelRegistry => $registry)
+            ->share(PanelRegistry::class)
+
+            ->delegate(Observatory::class, static fn(): Observatory => new Observatory($registry, $guard))
+            ->share(Observatory::class);
+    }
+}

--- a/src/Altair/Observatory/Contracts/PanelInterface.php
+++ b/src/Altair/Observatory/Contracts/PanelInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Contracts;
+
+use Altair\Observatory\Panel\PanelSnapshot;
+
+/**
+ * A monitored surface of the application (health, events, queues, routes, ...).
+ *
+ * A panel is a pure data provider: it reads from an existing framework data
+ * source and projects a {@see PanelSnapshot}. Rendering lives in the UI layer,
+ * so panels stay testable and reusable by non-HTML consumers.
+ */
+interface PanelInterface
+{
+    /**
+     * Stable machine identifier (e.g. "runtime", "events", "queues").
+     */
+    public function id(): string;
+
+    /**
+     * Human label for the card/navigation (e.g. "Runtime").
+     */
+    public function label(): string;
+
+    /**
+     * Icon key the UI maps to an SVG (e.g. "server").
+     */
+    public function icon(): string;
+
+    /**
+     * Capture the current state of this surface.
+     */
+    public function snapshot(): PanelSnapshot;
+}

--- a/src/Altair/Observatory/Exception/ObservatoryException.php
+++ b/src/Altair/Observatory/Exception/ObservatoryException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Exception;
+
+use RuntimeException;
+
+class ObservatoryException extends RuntimeException {}

--- a/src/Altair/Observatory/Observatory.php
+++ b/src/Altair/Observatory/Observatory.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory;
+
+use Altair\Observatory\Contracts\PanelInterface;
+use Altair\Observatory\Security\AccessGuardInterface;
+
+/**
+ * The Observatory facade: gate access, expose the registered panels, and
+ * project the whole dashboard as plain data.
+ *
+ * The {@see dashboard()} output is render-agnostic, so it backs both the
+ * server-rendered web UI and any JSON endpoint without duplication.
+ */
+final readonly class Observatory
+{
+    public function __construct(
+        private PanelRegistry $panels,
+        private AccessGuardInterface $guard,
+    ) {}
+
+    public function isAccessible(): bool
+    {
+        return $this->guard->allows();
+    }
+
+    /**
+     * @return list<PanelInterface>
+     */
+    public function panels(): array
+    {
+        return $this->panels->all();
+    }
+
+    /**
+     * @return array<string, array{label: string, icon: string, snapshot: array{status: string, headline: string, metrics: array<string, scalar|null>, items: list<array<string, scalar|null>>}}>
+     */
+    public function dashboard(): array
+    {
+        $dashboard = [];
+
+        foreach ($this->panels->all() as $panel) {
+            $dashboard[$panel->id()] = [
+                'label' => $panel->label(),
+                'icon' => $panel->icon(),
+                'snapshot' => $panel->snapshot()->toArray(),
+            ];
+        }
+
+        return $dashboard;
+    }
+}

--- a/src/Altair/Observatory/Panel/PanelSnapshot.php
+++ b/src/Altair/Observatory/Panel/PanelSnapshot.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+/**
+ * An immutable, render-agnostic read model produced by a panel.
+ *
+ * The same snapshot feeds the web UI and any JSON/agent consumer, so it carries
+ * only plain data: a health status, a one-line headline, a flat metrics map, and
+ * an ordered list of detail rows.
+ */
+final readonly class PanelSnapshot
+{
+    /**
+     * @param array<string, scalar|null> $metrics flat key/value metrics for the card header
+     * @param list<array<string, scalar|null>> $items ordered detail rows
+     */
+    public function __construct(
+        public PanelStatus $status,
+        public string $headline,
+        public array $metrics = [],
+        public array $items = [],
+    ) {}
+
+    /**
+     * @return array{status: string, headline: string, metrics: array<string, scalar|null>, items: list<array<string, scalar|null>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'status' => $this->status->value,
+            'headline' => $this->headline,
+            'metrics' => $this->metrics,
+            'items' => $this->items,
+        ];
+    }
+}

--- a/src/Altair/Observatory/Panel/PanelStatus.php
+++ b/src/Altair/Observatory/Panel/PanelStatus.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+/**
+ * The health classification of a panel snapshot, used to colour its card.
+ */
+enum PanelStatus: string
+{
+    case Ok = 'ok';
+    case Warning = 'warning';
+    case Critical = 'critical';
+    case Unknown = 'unknown';
+}

--- a/src/Altair/Observatory/Panel/RuntimePanel.php
+++ b/src/Altair/Observatory/Panel/RuntimePanel.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * A self-contained reference panel reporting the PHP runtime: version, memory
+ * use, OPcache availability and loaded extensions.
+ *
+ * It depends on nothing outside PHP itself, so it doubles as the worked example
+ * for implementing {@see PanelInterface}.
+ */
+final class RuntimePanel implements PanelInterface
+{
+    private const int BYTES_PER_MIB = 1048576;
+
+    #[Override]
+    public function id(): string
+    {
+        return 'runtime';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Runtime';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'server';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $extensions = get_loaded_extensions();
+        sort($extensions, SORT_STRING);
+
+        $items = [];
+        foreach ($extensions as $extension) {
+            $items[] = ['extension' => $extension];
+        }
+
+        return new PanelSnapshot(
+            PanelStatus::Ok,
+            \sprintf('PHP %s', PHP_VERSION),
+            [
+                'php_version' => PHP_VERSION,
+                'memory_mb' => round(memory_get_usage(true) / self::BYTES_PER_MIB, 1),
+                'peak_memory_mb' => round(memory_get_peak_usage(true) / self::BYTES_PER_MIB, 1),
+                'opcache' => \function_exists('opcache_get_status') ? 'available' : 'unavailable',
+                'extensions' => \count($extensions),
+            ],
+            $items,
+        );
+    }
+}

--- a/src/Altair/Observatory/PanelRegistry.php
+++ b/src/Altair/Observatory/PanelRegistry.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory;
+
+use Altair\Observatory\Contracts\PanelInterface;
+
+/**
+ * Collects the panels exposed by Observatory, keyed by their id.
+ *
+ * Registering a panel with an existing id replaces it, so hosts can override a
+ * built-in panel by registering their own with the same id after configuration.
+ */
+final class PanelRegistry
+{
+    /**
+     * @var array<string, PanelInterface>
+     */
+    private array $panels = [];
+
+    /**
+     * @param list<PanelInterface> $panels
+     */
+    public function __construct(array $panels = [])
+    {
+        foreach ($panels as $panel) {
+            $this->register($panel);
+        }
+    }
+
+    public function register(PanelInterface $panel): void
+    {
+        $this->panels[$panel->id()] = $panel;
+    }
+
+    /**
+     * @return list<PanelInterface>
+     */
+    public function all(): array
+    {
+        return array_values($this->panels);
+    }
+
+    public function get(string $id): ?PanelInterface
+    {
+        return $this->panels[$id] ?? null;
+    }
+
+    public function has(string $id): bool
+    {
+        return isset($this->panels[$id]);
+    }
+}

--- a/src/Altair/Observatory/Security/AccessGuardInterface.php
+++ b/src/Altair/Observatory/Security/AccessGuardInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Security;
+
+/**
+ * Decides whether the Observatory panel may be served.
+ *
+ * Observatory exposes health, configuration, queues and database state, so it
+ * must never be reachable in production by default. Hosts can swap this for an
+ * auth-aware guard (IP allow-list, signed cookie, RBAC) without touching the
+ * panels themselves.
+ */
+interface AccessGuardInterface
+{
+    public function allows(): bool;
+}

--- a/src/Altair/Observatory/Security/EnvironmentAccessGuard.php
+++ b/src/Altair/Observatory/Security/EnvironmentAccessGuard.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Security;
+
+use Override;
+
+/**
+ * The default guard: deny unless Observatory is explicitly enabled AND the app
+ * runs in a non-production environment.
+ *
+ * This is fail-closed — an unset flag or an unrecognised environment denies
+ * access, so a misconfigured production deploy never exposes the panel.
+ */
+final readonly class EnvironmentAccessGuard implements AccessGuardInterface
+{
+    /**
+     * @param list<string> $allowedEnvironments
+     */
+    public function __construct(
+        private bool $enabled,
+        private string $environment,
+        private array $allowedEnvironments = ['local', 'development', 'dev', 'testing'],
+    ) {}
+
+    #[Override]
+    public function allows(): bool
+    {
+        return $this->enabled && \in_array($this->environment, $this->allowedEnvironments, true);
+    }
+}

--- a/src/Altair/Observatory/composer.json
+++ b/src/Altair/Observatory/composer.json
@@ -1,0 +1,20 @@
+{
+    "name": "univeros/observatory",
+    "description": "Observatory — a dev-only web monitoring panel for Altair apps. A thin, gated presentation layer over the framework's introspection, doctor, events, messaging and persistence data sources.",
+    "license": "MIT",
+    "homepage": "https://univeros.io",
+    "support": {
+        "issues": "https://github.com/univeros/framework/issues",
+        "source": "https://github.com/univeros/framework"
+    },
+    "require": {
+        "php": ">=8.3",
+        "univeros/configuration": "^2.0",
+        "univeros/container": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Altair\\Observatory\\": ""
+        }
+    }
+}

--- a/tests/Http/Fixtures/Action/EmptyInput.php
+++ b/tests/Http/Fixtures/Action/EmptyInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+/**
+ * A no-argument input DTO (the shape scaffolded for an endpoint with no inputs,
+ * e.g. a health-check / ping).
+ */
+final readonly class EmptyInput
+{
+}

--- a/tests/Http/Fixtures/Action/GreetAction.php
+++ b/tests/Http/Fixtures/Action/GreetAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+use Altair\Http\Base\Action;
+
+final class GreetAction extends Action
+{
+    public function __construct()
+    {
+        parent::__construct(
+            domain: GreetDomain::class,
+            responder: JsonResponder::class,
+            input: GreetInput::class,
+        );
+    }
+}

--- a/tests/Http/Fixtures/Action/GreetDomain.php
+++ b/tests/Http/Fixtures/Action/GreetDomain.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+use Altair\Http\Contracts\PayloadInterface;
+
+/**
+ * A spec-scaffold-shaped domain: invokable with the typed DTO + a fresh Payload.
+ */
+final class GreetDomain
+{
+    public function __invoke(GreetInput $input, PayloadInterface $payload): PayloadInterface
+    {
+        return $payload
+            ->withStatus(200)
+            ->withOutput(['hello' => $input->name, 'times' => $input->times]);
+    }
+}

--- a/tests/Http/Fixtures/Action/GreetInput.php
+++ b/tests/Http/Fixtures/Action/GreetInput.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+/**
+ * A spec-scaffold-shaped typed input DTO: native-typed readonly props + a
+ * static rules() method. `name` is required (no default), `times` is optional.
+ */
+final readonly class GreetInput
+{
+    public function __construct(
+        public string $name,
+        public int $times = 1,
+    ) {}
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public static function rules(): array
+    {
+        return ['name' => ['required']];
+    }
+}

--- a/tests/Http/Fixtures/Action/JsonResponder.php
+++ b/tests/Http/Fixtures/Action/JsonResponder.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+use Altair\Http\Contracts\PayloadInterface;
+use Altair\Http\Contracts\ResponderInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Mirrors the scaffolded responder: marshal the payload output into a JSON
+ * response using the payload status.
+ */
+final class JsonResponder implements ResponderInterface
+{
+    #[Override]
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        PayloadInterface $payload,
+    ): ResponseInterface {
+        return new JsonResponse($payload->getOutput(), $payload->getStatus() ?? 200);
+    }
+}

--- a/tests/Http/Fixtures/Action/LegacyAction.php
+++ b/tests/Http/Fixtures/Action/LegacyAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+use Altair\Http\Base\Action;
+
+final class LegacyAction extends Action
+{
+    public function __construct()
+    {
+        parent::__construct(
+            domain: LegacyDomain::class,
+            responder: JsonResponder::class,
+            input: LegacyInput::class,
+        );
+    }
+}

--- a/tests/Http/Fixtures/Action/LegacyDomain.php
+++ b/tests/Http/Fixtures/Action/LegacyDomain.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+use Altair\Http\Base\Payload;
+use Altair\Http\Collection\InputCollection;
+use Altair\Http\Contracts\DomainInterface;
+use Altair\Http\Contracts\PayloadInterface;
+use Override;
+
+/**
+ * The legacy domain shape: implements DomainInterface and receives an
+ * InputCollection.
+ */
+final class LegacyDomain implements DomainInterface
+{
+    #[Override]
+    public function __invoke(InputCollection $input): PayloadInterface
+    {
+        return (new Payload())
+            ->withStatus(200)
+            ->withOutput(['echo' => $input->get('echo')]);
+    }
+}

--- a/tests/Http/Fixtures/Action/LegacyInput.php
+++ b/tests/Http/Fixtures/Action/LegacyInput.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+use Altair\Http\Collection\InputCollection;
+use Altair\Http\Contracts\InputInterface;
+use Override;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * The legacy request-bag input shape: implements InputInterface and returns an
+ * InputCollection. Proves the pre-existing execution path still works.
+ */
+final readonly class LegacyInput implements InputInterface
+{
+    public function __construct(private InputCollection $collection)
+    {
+    }
+
+    #[Override]
+    public function __invoke(ServerRequestInterface $request): InputCollection
+    {
+        $this->collection->put('echo', 'legacy');
+
+        return $this->collection;
+    }
+}

--- a/tests/Http/Fixtures/Action/ProfileInput.php
+++ b/tests/Http/Fixtures/Action/ProfileInput.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+/**
+ * Exercises the hydrator's coercion + default + nullable handling.
+ */
+final readonly class ProfileInput
+{
+    public function __construct(
+        public string $email,
+        public int $age = 0,
+        public bool $active = false,
+        public ?string $note = null,
+    ) {}
+}

--- a/tests/Http/Fixtures/Action/Status.php
+++ b/tests/Http/Fixtures/Action/Status.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+enum Status: string
+{
+    case Active = 'active';
+    case Inactive = 'inactive';
+}

--- a/tests/Http/Fixtures/Action/StatusInput.php
+++ b/tests/Http/Fixtures/Action/StatusInput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Fixtures\Action;
+
+/**
+ * A DTO with a backed-enum field — exercises the hydrator's enum resolution.
+ */
+final readonly class StatusInput
+{
+    public function __construct(
+        public Status $status,
+    ) {}
+}

--- a/tests/Http/Input/DtoInputHydratorTest.php
+++ b/tests/Http/Input/DtoInputHydratorTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Input;
+
+use Altair\Http\Exception\InputValidationException;
+use Altair\Http\Input\DtoInputHydrator;
+use Altair\Tests\Http\Fixtures\Action\EmptyInput;
+use Altair\Tests\Http\Fixtures\Action\GreetInput;
+use Altair\Tests\Http\Fixtures\Action\ProfileInput;
+use Altair\Tests\Http\Fixtures\Action\Status;
+use Altair\Tests\Http\Fixtures\Action\StatusInput;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DtoInputHydrator::class)]
+#[CoversClass(InputValidationException::class)]
+final class DtoInputHydratorTest extends TestCase
+{
+    private function request(array $query = [], ?array $body = null, array $attributes = []): ServerRequest
+    {
+        $request = (new ServerRequest(uri: '/', method: 'POST'))->withQueryParams($query);
+        if ($body !== null) {
+            $request = $request->withParsedBody($body);
+        }
+
+        foreach ($attributes as $key => $value) {
+            $request = $request->withAttribute($key, $value);
+        }
+
+        return $request;
+    }
+
+    public function testHydratesNoArgDto(): void
+    {
+        $dto = (new DtoInputHydrator())->hydrate(EmptyInput::class, $this->request());
+
+        self::assertInstanceOf(EmptyInput::class, $dto);
+    }
+
+    public function testHydratesRequiredAndDefaultedFieldsFromQuery(): void
+    {
+        $dto = (new DtoInputHydrator())->hydrate(GreetInput::class, $this->request(['name' => 'Ada', 'times' => '3']));
+
+        self::assertInstanceOf(GreetInput::class, $dto);
+        self::assertSame('Ada', $dto->name);
+        self::assertSame(3, $dto->times);
+    }
+
+    public function testUsesDefaultWhenFieldAbsent(): void
+    {
+        $dto = (new DtoInputHydrator())->hydrate(GreetInput::class, $this->request(['name' => 'Ada']));
+
+        self::assertSame(1, $dto->times);
+    }
+
+    public function testCoercesScalarsAndHonoursNullableDefault(): void
+    {
+        $dto = (new DtoInputHydrator())->hydrate(
+            ProfileInput::class,
+            $this->request(body: ['email' => 'a@b.c', 'age' => '30', 'active' => 'true']),
+        );
+
+        self::assertInstanceOf(ProfileInput::class, $dto);
+        self::assertSame(30, $dto->age);
+        self::assertTrue($dto->active);
+        self::assertNull($dto->note);
+    }
+
+    public function testRouteAttributesWinOverQuery(): void
+    {
+        $dto = (new DtoInputHydrator())->hydrate(
+            GreetInput::class,
+            $this->request(query: ['name' => 'fromquery'], attributes: ['name' => 'fromroute']),
+        );
+
+        self::assertSame('fromroute', $dto->name);
+    }
+
+    public function testMissingRequiredFieldThrowsWithPerFieldErrors(): void
+    {
+        try {
+            (new DtoInputHydrator())->hydrate(GreetInput::class, $this->request());
+            self::fail('Expected InputValidationException.');
+        } catch (InputValidationException $inputValidationException) {
+            self::assertArrayHasKey('name', $inputValidationException->errors);
+        }
+    }
+
+    public function testWrongTypedScalarBecomes422NotTypeError(): void
+    {
+        try {
+            (new DtoInputHydrator())->hydrate(GreetInput::class, $this->request(['name' => 'Ada', 'times' => 'lots']));
+            self::fail('Expected InputValidationException.');
+        } catch (InputValidationException $inputValidationException) {
+            self::assertSame('must be an integer', $inputValidationException->errors['times']);
+        }
+    }
+
+    public function testResolvesBackedEnumField(): void
+    {
+        $dto = (new DtoInputHydrator())->hydrate(StatusInput::class, $this->request(['status' => 'active']));
+
+        self::assertInstanceOf(StatusInput::class, $dto);
+        self::assertSame(Status::Active, $dto->status);
+    }
+
+    public function testUnknownEnumCaseBecomes422(): void
+    {
+        try {
+            (new DtoInputHydrator())->hydrate(StatusInput::class, $this->request(['status' => 'bogus']));
+            self::fail('Expected InputValidationException.');
+        } catch (InputValidationException $inputValidationException) {
+            self::assertArrayHasKey('status', $inputValidationException->errors);
+        }
+    }
+}

--- a/tests/Http/Middleware/ActionPipelineTest.php
+++ b/tests/Http/Middleware/ActionPipelineTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Middleware;
+
+use Altair\Http\Collection\InputCollection;
+use Altair\Http\Input\DtoInputHydrator;
+use Altair\Http\Middleware\ActionMiddleware;
+use Altair\Http\Middleware\DispatcherMiddleware;
+use Altair\Tests\Http\Fixtures\Action\GreetAction;
+use Altair\Tests\Http\Fixtures\Action\GreetDomain;
+use Altair\Tests\Http\Fixtures\Action\JsonResponder;
+use Altair\Tests\Http\Fixtures\Action\LegacyAction;
+use Altair\Tests\Http\Fixtures\Action\LegacyDomain;
+use Altair\Tests\Http\Fixtures\Action\LegacyInput;
+use FastRoute\RouteCollector;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Relay\Relay;
+
+use function FastRoute\simpleDispatcher;
+
+/**
+ * End-to-end: a request travels FastRoute → DispatcherMiddleware →
+ * ActionMiddleware → Responder and produces a real HTTP response. Proves the
+ * spec-scaffolded typed-DTO shape executes (the drift in #118) AND the legacy
+ * InputInterface shape still works. This locks the scaffolder/runtime contract
+ * so it cannot silently drift again.
+ */
+#[CoversClass(ActionMiddleware::class)]
+#[CoversClass(DispatcherMiddleware::class)]
+#[CoversClass(DtoInputHydrator::class)]
+final class ActionPipelineTest extends TestCase
+{
+    private function dispatch(ServerRequest $request): ResponseInterface
+    {
+        $dispatcher = simpleDispatcher(static function (RouteCollector $routes): void {
+            $routes->addRoute('GET', '/greet', new GreetAction());
+            $routes->addRoute('GET', '/legacy', new LegacyAction());
+        });
+
+        $resolver = static fn(string $class): object => match ($class) {
+            GreetDomain::class => new GreetDomain(),
+            LegacyDomain::class => new LegacyDomain(),
+            JsonResponder::class => new JsonResponder(),
+            LegacyInput::class => new LegacyInput(new InputCollection()),
+            default => new $class(),
+        };
+
+        $relay = new Relay([
+            new DispatcherMiddleware($dispatcher),
+            new ActionMiddleware($resolver, new ResponseFactory()),
+        ]);
+
+        return $relay->handle($request);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function json(ResponseInterface $response): array
+    {
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode((string) $response->getBody(), true);
+
+        return $decoded;
+    }
+
+    public function testTypedDtoEndpointExecutesAndReturns200(): void
+    {
+        $request = (new ServerRequest(uri: '/greet', method: 'GET'))
+            ->withQueryParams(['name' => 'Ada', 'times' => '3']);
+
+        $response = $this->dispatch($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['hello' => 'Ada', 'times' => 3], $this->json($response));
+    }
+
+    public function testMissingRequiredFieldReturns422(): void
+    {
+        $response = $this->dispatch(new ServerRequest(uri: '/greet', method: 'GET'));
+
+        self::assertSame(422, $response->getStatusCode());
+        self::assertArrayHasKey('name', $this->json($response)['errors']);
+    }
+
+    public function testLegacyInputInterfaceEndpointStillWorks(): void
+    {
+        $response = $this->dispatch(new ServerRequest(uri: '/legacy', method: 'GET'));
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['echo' => 'legacy'], $this->json($response));
+    }
+}

--- a/tests/Observatory/EnvironmentAccessGuardTest.php
+++ b/tests/Observatory/EnvironmentAccessGuardTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory;
+
+use Altair\Observatory\Security\EnvironmentAccessGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EnvironmentAccessGuard::class)]
+final class EnvironmentAccessGuardTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{bool, string, bool}>
+     */
+    public static function cases(): iterable
+    {
+        yield 'enabled + local => allowed' => [true, 'local', true];
+        yield 'enabled + testing => allowed' => [true, 'testing', true];
+        yield 'enabled + production => denied' => [true, 'production', false];
+        yield 'enabled + unknown env => denied' => [true, 'staging', false];
+        yield 'disabled + local => denied' => [false, 'local', false];
+        yield 'disabled + production => denied' => [false, 'production', false];
+    }
+
+    #[DataProvider('cases')]
+    public function testAllows(bool $enabled, string $environment, bool $expected): void
+    {
+        self::assertSame($expected, (new EnvironmentAccessGuard($enabled, $environment))->allows());
+    }
+
+    public function testFailsClosedForProductionEvenWhenEnabled(): void
+    {
+        // The critical security property: a production deploy is never exposed
+        // just because the flag was flipped on.
+        self::assertFalse((new EnvironmentAccessGuard(true, 'production'))->allows());
+    }
+}

--- a/tests/Observatory/ObservatoryTest.php
+++ b/tests/Observatory/ObservatoryTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory;
+
+use Altair\Observatory\Observatory;
+use Altair\Observatory\Panel\RuntimePanel;
+use Altair\Observatory\PanelRegistry;
+use Altair\Observatory\Security\EnvironmentAccessGuard;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Observatory::class)]
+final class ObservatoryTest extends TestCase
+{
+    public function testIsAccessibleDelegatesToGuard(): void
+    {
+        self::assertTrue($this->observatory(true)->isAccessible());
+        self::assertFalse($this->observatory(false)->isAccessible());
+    }
+
+    public function testDashboardProjectsEveryPanel(): void
+    {
+        $dashboard = $this->observatory(true)->dashboard();
+
+        self::assertArrayHasKey('runtime', $dashboard);
+        self::assertSame('Runtime', $dashboard['runtime']['label']);
+        self::assertSame('server', $dashboard['runtime']['icon']);
+        self::assertSame('ok', $dashboard['runtime']['snapshot']['status']);
+    }
+
+    public function testPanelsExposesRegisteredPanels(): void
+    {
+        $panels = $this->observatory(true)->panels();
+
+        self::assertCount(1, $panels);
+        self::assertSame('runtime', $panels[0]->id());
+    }
+
+    private function observatory(bool $enabled): Observatory
+    {
+        return new Observatory(
+            new PanelRegistry([new RuntimePanel()]),
+            new EnvironmentAccessGuard($enabled, 'local'),
+        );
+    }
+}

--- a/tests/Observatory/PanelRegistryTest.php
+++ b/tests/Observatory/PanelRegistryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory;
+
+use Altair\Observatory\Contracts\PanelInterface;
+use Altair\Observatory\Panel\PanelSnapshot;
+use Altair\Observatory\Panel\PanelStatus;
+use Altair\Observatory\PanelRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PanelRegistry::class)]
+final class PanelRegistryTest extends TestCase
+{
+    public function testRegistersFromConstructorAndExposesInOrder(): void
+    {
+        $registry = new PanelRegistry([$this->panel('a'), $this->panel('b')]);
+
+        self::assertCount(2, $registry->all());
+        self::assertSame(['a', 'b'], array_map(static fn(PanelInterface $p): string => $p->id(), $registry->all()));
+    }
+
+    public function testGetAndHasByIdentifier(): void
+    {
+        $registry = new PanelRegistry([$this->panel('runtime')]);
+
+        self::assertTrue($registry->has('runtime'));
+        self::assertFalse($registry->has('missing'));
+        self::assertInstanceOf(PanelInterface::class, $registry->get('runtime'));
+        self::assertNull($registry->get('missing'));
+    }
+
+    public function testRegisteringSameIdReplaces(): void
+    {
+        $registry = new PanelRegistry();
+        $registry->register($this->panel('runtime', 'First'));
+        $registry->register($this->panel('runtime', 'Second'));
+
+        self::assertCount(1, $registry->all());
+        self::assertSame('Second', $registry->get('runtime')?->label());
+    }
+
+    private function panel(string $id, string $label = 'Label'): PanelInterface
+    {
+        return new readonly class($id, $label) implements PanelInterface {
+            public function __construct(private string $id, private string $label) {}
+
+            public function id(): string
+            {
+                return $this->id;
+            }
+
+            public function label(): string
+            {
+                return $this->label;
+            }
+
+            public function icon(): string
+            {
+                return 'dot';
+            }
+
+            public function snapshot(): PanelSnapshot
+            {
+                return new PanelSnapshot(PanelStatus::Ok, 'ok');
+            }
+        };
+    }
+}

--- a/tests/Observatory/PanelSnapshotTest.php
+++ b/tests/Observatory/PanelSnapshotTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory;
+
+use Altair\Observatory\Panel\PanelSnapshot;
+use Altair\Observatory\Panel\PanelStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PanelSnapshot::class)]
+#[CoversClass(PanelStatus::class)]
+final class PanelSnapshotTest extends TestCase
+{
+    public function testToArrayProjectsAllFields(): void
+    {
+        $snapshot = new PanelSnapshot(
+            PanelStatus::Warning,
+            '3 failures',
+            ['total' => 12, 'failed' => 3],
+            [['id' => 'a'], ['id' => 'b']],
+        );
+
+        self::assertSame([
+            'status' => 'warning',
+            'headline' => '3 failures',
+            'metrics' => ['total' => 12, 'failed' => 3],
+            'items' => [['id' => 'a'], ['id' => 'b']],
+        ], $snapshot->toArray());
+    }
+
+    public function testDefaultsToEmptyMetricsAndItems(): void
+    {
+        $snapshot = new PanelSnapshot(PanelStatus::Ok, 'All good');
+
+        self::assertSame('ok', $snapshot->toArray()['status']);
+        self::assertSame([], $snapshot->metrics);
+        self::assertSame([], $snapshot->items);
+    }
+}

--- a/tests/Observatory/RuntimePanelTest.php
+++ b/tests/Observatory/RuntimePanelTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory;
+
+use Altair\Observatory\Panel\PanelStatus;
+use Altair\Observatory\Panel\RuntimePanel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RuntimePanel::class)]
+final class RuntimePanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new RuntimePanel();
+
+        self::assertSame('runtime', $panel->id());
+        self::assertSame('Runtime', $panel->label());
+        self::assertSame('server', $panel->icon());
+    }
+
+    public function testSnapshotReportsRuntime(): void
+    {
+        $snapshot = (new RuntimePanel())->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertStringStartsWith('PHP ', $snapshot->headline);
+        self::assertSame(PHP_VERSION, $snapshot->metrics['php_version']);
+        self::assertGreaterThan(0, $snapshot->metrics['extensions']);
+        self::assertNotSame([], $snapshot->items);
+        self::assertArrayHasKey('extension', $snapshot->items[0]);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the scaffolder↔HTTP-runtime contract drift that blocked scaffolded endpoints (and #73). `spec:scaffold` emits a **typed readonly DTO** input and a domain shaped as `__invoke(Dto, Payload)`, but `ActionMiddleware` only knew the legacy `$domain($input($request))` path — so dispatching a scaffolded endpoint threw. Per the chosen approach (additive: the runtime learns DTOs), this teaches the runtime the typed-DTO shape **without breaking** the legacy path. Closes #118.

## Changes

- **`ActionMiddleware`** now branches in `resolvePayload()`:
  - Input implements `InputInterface` → legacy `$domain($input($request))`.
  - Otherwise → `DtoInputHydrator` builds the DTO from the request, then `$domain($dto, new Payload())`.
  - Domain is guarded by `is_callable` (preserves the prior "any invokable domain" behaviour — no BC break); the result must be a `PayloadInterface`. New optional ctor arg `DtoInputHydrator $hydrator = new DtoInputHydrator()`.
- **`DtoInputHydrator`** (new): merges request data (query < body < route attributes) onto the DTO constructor by name, with scalar coercion and backed-enum `tryFrom()`. Only declared constructor params are populated (no mass-assignment).
- **`InputValidationException`** (new): a missing required field, an uncoercible scalar (e.g. `"age": "abc"`), or an unknown enum case becomes **HTTP 422** with per-field messages — never an uncaught `TypeError` → 500 (a `TypeError` safety net also covers class/union-typed params).

## Reviews applied

Security + code review run; both HIGH findings fixed:
- Wrong-typed / enum values now return **422 not 500** (validated coercion + enum `tryFrom`).
- Legacy domain guard relaxed to `is_callable` (was a silent breaking change requiring `DomainInterface`).

## Acceptance / test plan

- [x] End-to-end (`ActionPipelineTest`): real request through FastRoute → DispatcherMiddleware → ActionMiddleware → Relay — typed-DTO **200**, missing-required **422**, legacy `InputInterface` path **200**. Locks the contract against future drift.
- [x] `DtoInputHydratorTest`: required/defaults/nullable, scalar coercion, route-attr precedence, wrong-typed → 422, backed-enum valid + invalid → 422, no-arg DTO.
- [x] PHPStan level 8, Rector dry-run, php-cs-fixer (cache-free), full suite green (only pre-existing ext-mongodb env failures).

## Follow-ups (out of scope)

- Full `rules()` validation (email/min/etc. via `Altair\Validation`) needs a rule-DSL→rule-class resolver (the Validation subsystem consumes rule class-strings, not the scaffolder's short-string DSL).
- #73 (`univeros/skeleton` + `bin/altair new`) is now unblocked.