### PR TITLE
re #120 univeros/observatory — monitoring panel (8 panels + dashboard UI)

### DIFF
--- a/docs/packages/observatory.md
+++ b/docs/packages/observatory.md
@@ -13,7 +13,7 @@ That makes the package a presentation layer with near-zero coupling to the core.
 
 Because the panel surfaces configuration, queues and database state, **access is fail-closed**: it is denied unless explicitly enabled *and* running in a non-production environment, so a misconfigured production deploy never exposes it.
 
-> **Status:** this is the package scaffold — the data layer (panels, registry, facade, access guard) and one reference panel (`runtime`). The HTTP entrypoint, SSE live-tail and Tailwind/Alpine UI, plus the `doctor`/`events`/`messaging`/`introspection` panels, land in follow-up phases. See [Roadmap](#roadmap).
+> **Status:** the data-panel suite and the server-rendered dashboard UI are in. Panels: `runtime`, `health` (doctor), `events`/activity, `queues` (messaging), `routes`/`container`/`config` (introspection), `migrations` (persistence). `DashboardHandler` serves the gated, dark-first overview. The SSE live-tail and per-panel detail views are the remaining follow-up. See [Roadmap](#roadmap).
 
 ## Installation
 
@@ -100,11 +100,27 @@ final class QueuesPanel implements PanelInterface
 
 `RuntimePanel` is the worked reference implementation (it depends on nothing outside PHP).
 
+## Serving the dashboard
+
+`DashboardHandler` is a PSR-15 request handler. Route a path to it (it autowires
+`Observatory`, the renderer, and your PSR-17 response/stream factories):
+
+```php
+$response = $container->get(DashboardHandler::class)->handle($request);
+// 200 + HTML when accessible; 403 + "disabled" page otherwise.
+```
+
+The `queues` and `migrations` panels read through framework-owned seams —
+`FailedQueueReaderInterface` and `MigrationStatusReaderInterface`. Bind a host
+adapter (Messenger failure transport / Cycle migrator) for live data; absent a
+binding the panel simply isn't registered (the dashboard shows fewer cards).
+
 ## Roadmap
 
-1. **Scaffold** (current): panel contracts, registry, facade, access guard, `runtime` panel, docs.
-2. **UI layer**: PSR-15 HTTP entrypoint, SSE live-tail endpoint, server-rendered Tailwind/Alpine dashboard (dark-first, card-based).
-3. **Data panels**: `health` (doctor), `events` (activity/errors), `queues` (messaging), `routes`/`container`/`config`/`listeners`/`middleware` (introspection), `migrations` (persistence).
+1. **Scaffold** (done): panel contracts, registry, facade, access guard, `runtime` panel.
+2. **Data panels** (done): `health`, `events`, `queues`, `routes`, `container`, `config`, `migrations`.
+3. **UI** (done): gated `DashboardHandler` + dark-first card dashboard with the Altair-blue theme (zero-build CSS + inline icons).
+4. **Next**: SSE live-tail endpoint for the activity/queues streams, and per-panel detail views (filterable tables).
 
 ## Related packages
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,6 +3,9 @@ parameters:
     phpVersion: 80300
     paths:
         - src
+    excludePaths:
+        # Presentation-only view templates (HTML in PHP); not application logic.
+        - src/Altair/Observatory/resources/views/*
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false
     tmpDir: .phpstan-cache

--- a/src/Altair/Observatory/Configuration/ObservatoryConfiguration.php
+++ b/src/Altair/Observatory/Configuration/ObservatoryConfiguration.php
@@ -14,21 +14,41 @@ namespace Altair\Observatory\Configuration;
 use Altair\Configuration\Contracts\ConfigurationInterface;
 use Altair\Configuration\Traits\EnvAwareTrait;
 use Altair\Container\Container;
+use Altair\Doctor\Doctor;
+use Altair\Events\Reader;
+use Altair\Introspection\Inspector\ConfigInspector;
+use Altair\Introspection\Inspector\ContainerInspector;
+use Altair\Introspection\Inspector\RouteInspector;
+use Altair\Observatory\Contracts\FailedQueueReaderInterface;
+use Altair\Observatory\Contracts\MigrationStatusReaderInterface;
+use Altair\Observatory\Contracts\PanelInterface;
 use Altair\Observatory\Observatory;
+use Altair\Observatory\Panel\ConfigPanel;
+use Altair\Observatory\Panel\ContainerPanel;
+use Altair\Observatory\Panel\EventsPanel;
+use Altair\Observatory\Panel\HealthPanel;
+use Altair\Observatory\Panel\MigrationsPanel;
+use Altair\Observatory\Panel\QueuesPanel;
+use Altair\Observatory\Panel\RoutesPanel;
 use Altair\Observatory\Panel\RuntimePanel;
 use Altair\Observatory\PanelRegistry;
 use Altair\Observatory\Security\AccessGuardInterface;
 use Altair\Observatory\Security\EnvironmentAccessGuard;
+use Altair\Observatory\View\TemplateRenderer;
 use Override;
 
 /**
- * Wires the access guard, the panel registry (with the built-in panels) and the
- * Observatory facade into the Container.
+ * Wires the access guard, the panel registry and the Observatory facade.
  *
- * Access is fail-closed: it reads OBSERVATORY_ENABLED (default off) and APP_ENV
- * (default "production"), so an unconfigured or production deploy never serves
- * the panel. Hosts add panels by `prepare()`-ing {@see PanelRegistry} after this
- * Configuration runs, and can rebind {@see AccessGuardInterface} for real auth.
+ * Access is fail-closed (OBSERVATORY_ENABLED default off, APP_ENV default
+ * "production"). The registry is built lazily inside a delegate, so panels are
+ * only added when their data source is actually bound in the container — the
+ * dashboard degrades gracefully (fewer cards) rather than failing, and there is
+ * no ordering requirement between this Configuration and the source packages.
+ *
+ * QueuesPanel and MigrationsPanel read through the framework-owned
+ * {@see FailedQueueReaderInterface} / {@see MigrationStatusReaderInterface}
+ * seams; bind a host adapter for those to light up with live data.
  */
 class ObservatoryConfiguration implements ConfigurationInterface
 {
@@ -39,18 +59,56 @@ class ObservatoryConfiguration implements ConfigurationInterface
     {
         $enabled = filter_var($this->env->get('OBSERVATORY_ENABLED', false), FILTER_VALIDATE_BOOLEAN);
         $environment = (string) $this->env->get('APP_ENV', 'production');
-
         $guard = new EnvironmentAccessGuard($enabled, $environment);
-        $registry = new PanelRegistry([new RuntimePanel()]);
 
         $container
             ->delegate(AccessGuardInterface::class, static fn(): AccessGuardInterface => $guard)
             ->share(AccessGuardInterface::class)
 
-            ->delegate(PanelRegistry::class, static fn(): PanelRegistry => $registry)
+            ->delegate(TemplateRenderer::class, static fn(): TemplateRenderer => TemplateRenderer::default())
+            ->share(TemplateRenderer::class)
+
+            ->delegate(PanelRegistry::class, function () use ($container): PanelRegistry {
+                $registry = new PanelRegistry([new RuntimePanel()]);
+
+                $this->registerIfAvailable($registry, $container, HealthPanel::class, Doctor::class);
+                $this->registerIfAvailable($registry, $container, EventsPanel::class, Reader::class);
+                $this->registerIfAvailable($registry, $container, QueuesPanel::class, FailedQueueReaderInterface::class);
+                $this->registerIfAvailable($registry, $container, RoutesPanel::class, RouteInspector::class);
+                $this->registerIfAvailable($registry, $container, ContainerPanel::class, ContainerInspector::class);
+                $this->registerIfAvailable($registry, $container, ConfigPanel::class, ConfigInspector::class);
+                $this->registerIfAvailable($registry, $container, MigrationsPanel::class, MigrationStatusReaderInterface::class);
+
+                return $registry;
+            })
             ->share(PanelRegistry::class)
 
-            ->delegate(Observatory::class, static fn(): Observatory => new Observatory($registry, $guard))
+            ->delegate(Observatory::class, static function () use ($container, $guard): Observatory {
+                $registry = $container->get(PanelRegistry::class);
+
+                return new Observatory($registry instanceof PanelRegistry ? $registry : new PanelRegistry(), $guard);
+            })
             ->share(Observatory::class);
+    }
+
+    /**
+     * Register $panelClass only when its required data source is bound, autowiring
+     * the panel's constructor from the container.
+     */
+    private function registerIfAvailable(
+        PanelRegistry $registry,
+        Container $container,
+        string $panelClass,
+        string $requiredDependency,
+    ): void {
+        if (!$container->has($requiredDependency)) {
+            return;
+        }
+
+        $panel = $container->get($panelClass);
+
+        if ($panel instanceof PanelInterface) {
+            $registry->register($panel);
+        }
     }
 }

--- a/src/Altair/Observatory/Contracts/FailedQueueReaderInterface.php
+++ b/src/Altair/Observatory/Contracts/FailedQueueReaderInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Contracts;
+
+/**
+ * A narrow, render-agnostic view over a messaging failure transport.
+ *
+ * Observatory must read failed jobs without coupling to Symfony Messenger or
+ * requiring a live broker, so it depends on this framework-owned seam instead.
+ * The host adapts its real failure transport (a Symfony
+ * `ListableReceiverInterface`, a database table, ...) behind this interface;
+ * tests provide a trivial in-memory fake.
+ *
+ * Configured-but-empty (zero failures) and not-configured (no transports) are
+ * distinct states, so callers can render "all clear" differently from "no
+ * queues wired".
+ */
+interface FailedQueueReaderInterface
+{
+    /**
+     * Names of the configured transports (e.g. ["default", "high"]).
+     *
+     * Empty when messaging is not configured, which the panel surfaces as an
+     * Unknown status rather than a healthy one.
+     *
+     * @return list<string>
+     */
+    public function transportNames(): array;
+
+    /**
+     * Total number of envelopes currently held in the failure transport.
+     */
+    public function failedCount(): int;
+
+    /**
+     * The most recent failed envelopes, newest first, flattened to scalar rows.
+     *
+     * Every row is best-effort: any of the keys may be absent when the backing
+     * store can't supply them, so the panel must not assume their presence.
+     *
+     * @param  int                              $limit maximum rows to return
+     * @return list<array<string, scalar|null>> rows shaped like
+     *                                          {id?, message_class?, error?, transport?}
+     */
+    public function recentFailures(int $limit = 25): array;
+}

--- a/src/Altair/Observatory/Contracts/MigrationStatusReaderInterface.php
+++ b/src/Altair/Observatory/Contracts/MigrationStatusReaderInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Contracts;
+
+use Altair\Observatory\Panel\MigrationStatus;
+
+/**
+ * Narrow, fakeable seam yielding each known migration's applied/pending state.
+ *
+ * The framework's `db:migrate:status` reads this from a live Cycle
+ * {@see \Cycle\Migrations\Migrator}, which needs a database connection. This
+ * interface lets the Observatory project that state without coupling to Cycle
+ * or to a live connection: hosts bind a Cycle-backed implementation, while
+ * tests fake it. When the underlying state cannot be read (no database, an
+ * unconfigured migrator, a connection failure), implementations return `null`
+ * so the panel can degrade to an "unavailable" status rather than throw.
+ *
+ * @see \Altair\Observatory\Panel\MigrationsPanel
+ */
+interface MigrationStatusReaderInterface
+{
+    /**
+     * Every known migration with its applied/pending state, or `null` when the
+     * status cannot be read at all.
+     *
+     * An empty list is a valid, readable result (no migrations exist); `null`
+     * specifically signals that no status could be determined.
+     *
+     * @return list<MigrationStatus>|null
+     */
+    public function read(): ?array;
+}

--- a/src/Altair/Observatory/Http/DashboardHandler.php
+++ b/src/Altair/Observatory/Http/DashboardHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Http;
+
+use Altair\Observatory\Observatory;
+use Altair\Observatory\View\TemplateRenderer;
+use Override;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Serves the Observatory dashboard as server-rendered HTML.
+ *
+ * Access is gated by the Observatory facade: when the guard denies, a 403
+ * "disabled" page is returned instead of any panel data. The host routes a path
+ * (e.g. /_observatory) to this handler.
+ */
+final readonly class DashboardHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private Observatory $observatory,
+        private TemplateRenderer $renderer,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+    ) {}
+
+    #[Override]
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (!$this->observatory->isAccessible()) {
+            return $this->html(403, $this->renderer->render('denied'));
+        }
+
+        return $this->html(200, $this->renderer->render('dashboard', [
+            'panels' => $this->observatory->dashboard(),
+        ]));
+    }
+
+    private function html(int $status, string $body): ResponseInterface
+    {
+        return $this->responseFactory
+            ->createResponse($status)
+            ->withHeader('Content-Type', 'text/html; charset=utf-8')
+            ->withBody($this->streamFactory->createStream($body));
+    }
+}

--- a/src/Altair/Observatory/Panel/ConfigPanel.php
+++ b/src/Altair/Observatory/Panel/ConfigPanel.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Introspection\Inspector\ConfigInspector;
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * Surfaces the merged environment + container-parameter configuration as a
+ * panel.
+ *
+ * Reuses the introspection {@see ConfigInspector} and always calls
+ * `dump()` with masking enabled, so secret-looking keys (PASSWORD, SECRET,
+ * TOKEN, KEY, ...) are redacted to `***` before they reach the snapshot. The
+ * panel never requests the raw dump, so it cannot leak secret values. An empty
+ * configuration degrades to {@see PanelStatus::Unknown}.
+ */
+final readonly class ConfigPanel implements PanelInterface
+{
+    public function __construct(
+        private ConfigInspector $inspector,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'config';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Config';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'adjustments';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        // Masking is always on: the panel never surfaces raw secret values.
+        $table = $this->inspector->dump(maskSecrets: true);
+
+        $items = [];
+        foreach ($table->rows as $row) {
+            $items[] = [
+                'key' => $this->scalarOrNull($row['key'] ?? null),
+                'value' => $this->scalarOrNull($row['value'] ?? null),
+            ];
+        }
+
+        $count = \count($items);
+
+        if ($count === 0) {
+            return new PanelSnapshot(
+                PanelStatus::Unknown,
+                'no configuration available (unavailable)',
+                ['keys' => 0],
+            );
+        }
+
+        return new PanelSnapshot(
+            PanelStatus::Ok,
+            \sprintf('%d key%s', $count, $count === 1 ? '' : 's'),
+            ['keys' => $count],
+            $items,
+        );
+    }
+
+    private function scalarOrNull(mixed $value): string|int|float|bool|null
+    {
+        if ($value === null || \is_scalar($value)) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Observatory/Panel/ContainerPanel.php
+++ b/src/Altair/Observatory/Panel/ContainerPanel.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Introspection\Inspector\ContainerInspector;
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * Surfaces the application container's binding inventory as a panel.
+ *
+ * Reuses the introspection {@see ContainerInspector}, which walks the
+ * container's binding collections without triggering instantiation, so the
+ * panel is safe to render even when downstream services (database, etc.) are
+ * unavailable. A container with no registered bindings degrades to
+ * {@see PanelStatus::Unknown}.
+ */
+final readonly class ContainerPanel implements PanelInterface
+{
+    public function __construct(
+        private ContainerInspector $inspector,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'container';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Container';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'cube';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $table = $this->inspector->inspectAll();
+
+        $items = [];
+        foreach ($table->rows as $row) {
+            $items[] = [
+                'id' => $this->scalarOrNull($row['id'] ?? null),
+                'kind' => $this->scalarOrNull($row['kind'] ?? null),
+                'shared' => $this->scalarOrNull($row['shared'] ?? null),
+            ];
+        }
+
+        $count = \count($items);
+
+        if ($count === 0) {
+            return new PanelSnapshot(
+                PanelStatus::Unknown,
+                'no bindings registered (unavailable)',
+                ['bindings' => 0],
+            );
+        }
+
+        return new PanelSnapshot(
+            PanelStatus::Ok,
+            \sprintf('%d binding%s', $count, $count === 1 ? '' : 's'),
+            ['bindings' => $count],
+            $items,
+        );
+    }
+
+    private function scalarOrNull(mixed $value): string|int|float|bool|null
+    {
+        if ($value === null || \is_scalar($value)) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Observatory/Panel/EventsPanel.php
+++ b/src/Altair/Observatory/Panel/EventsPanel.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Events\Reader;
+use Altair\Observatory\Contracts\PanelInterface;
+use DateTimeInterface;
+use Override;
+
+/**
+ * Surfaces the append-only mutation event log (`.altair/events.jsonl`) as a
+ * panel: total volume, a per-status breakdown, and the most recent activity.
+ *
+ * Reads through {@see Reader} only, so it stays content-blind about storage and
+ * is trivially testable against an in-memory backing store.
+ */
+final readonly class EventsPanel implements PanelInterface
+{
+    public function __construct(
+        private Reader $reader,
+        private int $tail = 25,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'events';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Activity';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'rss';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $stats = $this->reader->stats();
+
+        $total = $stats['total'];
+        $ok = $stats['by_status']['ok'] ?? 0;
+        $fail = $stats['by_status']['fail'] ?? 0;
+
+        $status = match (true) {
+            $total === 0 => PanelStatus::Unknown,
+            $fail > 0 => PanelStatus::Warning,
+            default => PanelStatus::Ok,
+        };
+
+        return new PanelSnapshot(
+            $status,
+            \sprintf('%s %s', number_format($total), $total === 1 ? 'event' : 'events'),
+            [
+                'total' => $total,
+                'ok' => $ok,
+                'fail' => $fail,
+                'total_duration_ms' => $stats['total_duration_ms'],
+            ],
+            $this->recentItems(),
+        );
+    }
+
+    /**
+     * Recent events flattened to scalar-only rows, newest first.
+     *
+     * @return list<array<string, scalar|null>>
+     */
+    private function recentItems(): array
+    {
+        $items = [];
+        foreach ($this->reader->tail($this->tail) as $event) {
+            $items[] = [
+                'id' => $event->id,
+                'kind' => $event->kind->value,
+                'status' => $event->status->value,
+                'timestamp' => $event->timestamp->format(DateTimeInterface::RFC3339_EXTENDED),
+                'duration_ms' => $event->durationMs,
+            ];
+        }
+
+        return $items;
+    }
+}

--- a/src/Altair/Observatory/Panel/HealthPanel.php
+++ b/src/Altair/Observatory/Panel/HealthPanel.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Doctor\Result\CheckStatus;
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * Surfaces the framework's {@see Doctor} health checks as a panel.
+ *
+ * Running the full doctor suite on every dashboard render would be far too
+ * slow (phpstan/tests probes shell out), so the panel runs a constrained
+ * `--only` subset. The host narrows or widens that list when wiring the panel;
+ * an empty list runs every registered check (use sparingly).
+ */
+final readonly class HealthPanel implements PanelInterface
+{
+    /**
+     * @param list<string> $only check names to run (empty = the full suite)
+     */
+    public function __construct(
+        private Doctor $doctor,
+        private array $only = [],
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'health';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Health';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'heart-pulse';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $report = $this->doctor->run($this->only);
+
+        $passing = 0;
+        $failed = 0;
+        $skipped = 0;
+        $items = [];
+
+        foreach ($report->checks as $check) {
+            $items[] = $this->row($check);
+
+            match ($check->status) {
+                CheckStatus::Ok => $passing++,
+                CheckStatus::Error, CheckStatus::Warn => $failed++,
+                CheckStatus::Skipped => $skipped++,
+            };
+        }
+
+        $total = \count($report->checks);
+
+        return new PanelSnapshot(
+            $this->status($total, $passing, $failed),
+            \sprintf('%d/%d passing', $passing, $total),
+            [
+                'total' => $total,
+                'passing' => $passing,
+                'failed' => $failed,
+                'skipped' => $skipped,
+                'duration_ms' => $report->durationMs,
+            ],
+            $items,
+        );
+    }
+
+    /**
+     * Worst observed outcome wins. Errors/warns count as failures (Critical),
+     * any skip without a clean pass is a Warning, an all-ok run is Ok, and an
+     * empty run (nothing matched the `--only` filter) is Unknown.
+     *
+     * Counts are used instead of the report's own worst-status because the
+     * doctor collapses Skipped to severity 0 (same as Ok), so a skipped-only
+     * run would be indistinguishable from a clean run at the report level.
+     */
+    private function status(int $total, int $passing, int $failed): PanelStatus
+    {
+        if ($total === 0) {
+            return PanelStatus::Unknown;
+        }
+
+        if ($failed > 0) {
+            return PanelStatus::Critical;
+        }
+
+        if ($passing < $total) {
+            return PanelStatus::Warning;
+        }
+
+        return PanelStatus::Ok;
+    }
+
+    /**
+     * @return array<string, scalar|null>
+     */
+    private function row(CheckResult $check): array
+    {
+        return [
+            'name' => $check->name,
+            'status' => $check->status->value,
+            'summary' => $check->detail,
+        ];
+    }
+}

--- a/src/Altair/Observatory/Panel/MigrationStatus.php
+++ b/src/Altair/Observatory/Panel/MigrationStatus.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+/**
+ * One migration's applied/pending state, read through a
+ * {@see \Altair\Observatory\Contracts\MigrationStatusReaderInterface}.
+ *
+ * Plain, render-agnostic value so the panel never touches Cycle's own
+ * migration/state types directly.
+ */
+final readonly class MigrationStatus
+{
+    public function __construct(
+        public string $name,
+        public bool $applied,
+    ) {}
+}

--- a/src/Altair/Observatory/Panel/MigrationsPanel.php
+++ b/src/Altair/Observatory/Panel/MigrationsPanel.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Observatory\Contracts\MigrationStatusReaderInterface;
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * Surfaces Cycle ORM migration state as a panel: how many migrations have been
+ * applied versus pending, with the pending ones listed first.
+ *
+ * Reads through {@see MigrationStatusReaderInterface} only, never touching Cycle
+ * or a live connection directly. When the reader cannot determine status (no
+ * database, unconfigured migrator) it yields `null` and the panel degrades to
+ * {@see PanelStatus::Unknown} with an "unavailable" headline rather than failing
+ * the whole dashboard.
+ */
+final readonly class MigrationsPanel implements PanelInterface
+{
+    private const int RECENT_LIMIT = 25;
+
+    public function __construct(
+        private MigrationStatusReaderInterface $reader,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'migrations';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Migrations';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'circle-stack';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $migrations = $this->reader->read();
+
+        if ($migrations === null) {
+            return new PanelSnapshot(
+                PanelStatus::Unknown,
+                'unavailable',
+                [
+                    'applied' => null,
+                    'pending' => null,
+                ],
+            );
+        }
+
+        $applied = 0;
+        $pending = [];
+        foreach ($migrations as $migration) {
+            if ($migration->applied) {
+                $applied++;
+
+                continue;
+            }
+
+            $pending[] = $migration;
+        }
+
+        $pendingCount = \count($pending);
+
+        return new PanelSnapshot(
+            $pendingCount > 0 ? PanelStatus::Warning : PanelStatus::Ok,
+            \sprintf('%d pending', $pendingCount),
+            [
+                'applied' => $applied,
+                'pending' => $pendingCount,
+            ],
+            $this->items($migrations, $pending),
+        );
+    }
+
+    /**
+     * Pending migrations first (the actionable rows); if none are pending the
+     * most recent applied migrations are shown instead, so the panel is never
+     * empty when migrations exist.
+     *
+     * @param list<MigrationStatus> $migrations
+     * @param list<MigrationStatus> $pending
+     *
+     * @return list<array<string, scalar|null>>
+     */
+    private function items(array $migrations, array $pending): array
+    {
+        $rows = $pending !== [] ? $pending : \array_slice($migrations, -self::RECENT_LIMIT);
+
+        $items = [];
+        foreach ($rows as $migration) {
+            $items[] = [
+                'name' => $migration->name,
+                'applied' => $migration->applied,
+            ];
+        }
+
+        return $items;
+    }
+}

--- a/src/Altair/Observatory/Panel/QueuesPanel.php
+++ b/src/Altair/Observatory/Panel/QueuesPanel.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Observatory\Contracts\FailedQueueReaderInterface;
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * Surfaces the messaging layer as a panel: how many transports are wired and
+ * how many jobs have landed in the failure transport, with the most recent
+ * failures listed.
+ *
+ * It reads through {@see FailedQueueReaderInterface} only — a narrow,
+ * framework-owned seam the host adapts to its real failure transport — so the
+ * panel never touches Symfony Messenger or a live broker and stays trivially
+ * testable against an in-memory fake.
+ */
+final readonly class QueuesPanel implements PanelInterface
+{
+    /**
+     * @param int $tail maximum number of recent failures to list
+     */
+    public function __construct(
+        private FailedQueueReaderInterface $reader,
+        private int $tail = 25,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'queues';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Queues';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'queue-list';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $transports = $this->reader->transportNames();
+        $failed = $this->reader->failedCount();
+
+        $status = match (true) {
+            $transports === [] => PanelStatus::Unknown,
+            $failed > 0 => PanelStatus::Warning,
+            default => PanelStatus::Ok,
+        };
+
+        return new PanelSnapshot(
+            $status,
+            $this->headline($transports, $failed),
+            [
+                'failed' => $failed,
+                'transports' => \count($transports),
+            ],
+            $failed > 0 ? $this->reader->recentFailures($this->tail) : [],
+        );
+    }
+
+    /**
+     * @param list<string> $transports
+     */
+    private function headline(array $transports, int $failed): string
+    {
+        if ($transports === []) {
+            return 'No transports configured';
+        }
+
+        return \sprintf('%s failed', number_format($failed));
+    }
+}

--- a/src/Altair/Observatory/Panel/RoutesPanel.php
+++ b/src/Altair/Observatory/Panel/RoutesPanel.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Panel;
+
+use Altair\Introspection\Inspector\RouteInspector;
+use Altair\Observatory\Contracts\PanelInterface;
+use Override;
+
+/**
+ * Surfaces the framework's registered HTTP routes as a panel.
+ *
+ * Reuses the introspection {@see RouteInspector}, which walks the
+ * RouteCollection without triggering dispatch or middleware resolution, so the
+ * panel is safe to render from any context. When no routes are registered the
+ * panel degrades to {@see PanelStatus::Unknown} rather than reporting a healthy
+ * empty surface.
+ */
+final readonly class RoutesPanel implements PanelInterface
+{
+    public function __construct(
+        private RouteInspector $inspector,
+    ) {}
+
+    #[Override]
+    public function id(): string
+    {
+        return 'routes';
+    }
+
+    #[Override]
+    public function label(): string
+    {
+        return 'Routes';
+    }
+
+    #[Override]
+    public function icon(): string
+    {
+        return 'map';
+    }
+
+    #[Override]
+    public function snapshot(): PanelSnapshot
+    {
+        $table = $this->inspector->inspectAll();
+
+        $items = [];
+        foreach ($table->rows as $row) {
+            $items[] = [
+                'method' => $this->scalarOrNull($row['method'] ?? null),
+                'path' => $this->scalarOrNull($row['path'] ?? null),
+                'handler' => $this->scalarOrNull($row['action'] ?? null),
+            ];
+        }
+
+        $count = \count($items);
+
+        if ($count === 0) {
+            return new PanelSnapshot(
+                PanelStatus::Unknown,
+                'no routes registered (unavailable)',
+                ['routes' => 0],
+            );
+        }
+
+        return new PanelSnapshot(
+            PanelStatus::Ok,
+            \sprintf('%d route%s', $count, $count === 1 ? '' : 's'),
+            ['routes' => $count],
+            $items,
+        );
+    }
+
+    private function scalarOrNull(mixed $value): string|int|float|bool|null
+    {
+        if ($value === null || \is_scalar($value)) {
+            return $value;
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Observatory/View/IconSet.php
+++ b/src/Altair/Observatory/View/IconSet.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\View;
+
+/**
+ * A tiny set of self-contained, consistent line icons (1.5 stroke, 24-grid).
+ *
+ * Authored inline rather than pulling an icon dependency so Observatory stays
+ * zero-build. Panels reference icons by key via {@see PanelInterface::icon()};
+ * unknown keys fall back to a neutral glyph.
+ */
+final class IconSet
+{
+    /**
+     * @var array<string, string> inner SVG markup (paths) per icon key
+     */
+    private const array ICONS = [
+        'overview' => '<line x1="3" y1="21" x2="21" y2="21"/><rect x="5" y="11" width="3" height="8" rx="0.5"/><rect x="11" y="6" width="3" height="13" rx="0.5"/><rect x="17" y="14" width="3" height="5" rx="0.5"/>',
+        'server' => '<rect x="3" y="4" width="18" height="7" rx="1.5"/><rect x="3" y="13" width="18" height="7" rx="1.5"/><circle cx="6.5" cy="7.5" r="0.9"/><circle cx="6.5" cy="16.5" r="0.9"/>',
+        'health' => '<polyline points="3,12 7.5,12 10,5 14,19 16.5,12 21,12"/>',
+        'events' => '<circle cx="5" cy="19" r="1.6"/><path d="M5 13a6 6 0 0 1 6 6"/><path d="M5 8a11 11 0 0 1 11 11"/>',
+        'queues' => '<circle cx="4" cy="6" r="1.1"/><circle cx="4" cy="12" r="1.1"/><circle cx="4" cy="18" r="1.1"/><line x1="9" y1="6" x2="20" y2="6"/><line x1="9" y1="12" x2="20" y2="12"/><line x1="9" y1="18" x2="20" y2="18"/>',
+        'routes' => '<path d="M12 2 21 7 21 17 12 22 3 17 3 7Z"/><path d="M3 7 12 12 21 7"/><line x1="12" y1="12" x2="12" y2="22"/>',
+        'container' => '<rect x="4" y="4" width="16" height="16" rx="2"/><line x1="4" y1="9" x2="20" y2="9"/><line x1="9" y1="9" x2="9" y2="20"/>',
+        'config' => '<line x1="4" y1="8" x2="20" y2="8"/><circle cx="9" cy="8" r="2.2"/><line x1="4" y1="16" x2="20" y2="16"/><circle cx="15" cy="16" r="2.2"/>',
+        'migrations' => '<ellipse cx="12" cy="6" rx="8" ry="3"/><path d="M4 6v12c0 1.7 3.6 3 8 3s8-1.3 8-3V6"/><path d="M4 12c0 1.7 3.6 3 8 3s8-1.3 8-3"/>',
+    ];
+
+    /**
+     * Panel icon keys mapped onto the canonical glyphs above.
+     *
+     * @var array<string, string>
+     */
+    private const array ALIASES = [
+        'heart-pulse' => 'health',
+        'shield-check' => 'health',
+        'rss' => 'events',
+        'signal' => 'events',
+        'queue-list' => 'queues',
+        'map' => 'routes',
+        'cube' => 'container',
+        'adjustments' => 'config',
+        'circle-stack' => 'migrations',
+        'chart-bar' => 'overview',
+    ];
+
+    public static function svg(string $key, string $class = ''): string
+    {
+        $key = self::ALIASES[$key] ?? $key;
+        $inner = self::ICONS[$key] ?? '<circle cx="12" cy="12" r="8"/>';
+        $classAttr = $class === '' ? '' : \sprintf(' class="%s"', htmlspecialchars($class, ENT_QUOTES));
+
+        return \sprintf(
+            '<svg%s viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">%s</svg>',
+            $classAttr,
+            $inner,
+        );
+    }
+}

--- a/src/Altair/Observatory/View/TemplateRenderer.php
+++ b/src/Altair/Observatory/View/TemplateRenderer.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\View;
+
+use Altair\Observatory\Exception\ObservatoryException;
+
+/**
+ * A minimal, dependency-free PHP template renderer.
+ *
+ * Templates are plain PHP files under resources/views that receive a single
+ * `$data` array (no symbol extraction), so they stay easy to reason about and
+ * the renderer carries no engine baggage. The view files themselves are
+ * presentation-only and excluded from static analysis.
+ */
+final readonly class TemplateRenderer
+{
+    public function __construct(private string $viewPath) {}
+
+    public static function default(): self
+    {
+        return new self(\dirname(__DIR__) . '/resources/views');
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     *
+     * @throws ObservatoryException when the template is missing
+     */
+    public function render(string $template, array $data = []): string
+    {
+        $file = $this->viewPath . '/' . $template . '.php';
+
+        if (!is_file($file)) {
+            throw new ObservatoryException(\sprintf('Observatory view "%s" not found.', $template));
+        }
+
+        $capture = static function (string $__file, array $data): string {
+            ob_start();
+            require $__file;
+
+            return (string) ob_get_clean();
+        };
+
+        return $capture($file, $data);
+    }
+
+    /**
+     * Escape a value for safe HTML output.
+     */
+    public static function e(int|float|string|bool|null $value): string
+    {
+        return htmlspecialchars((string) $value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/src/Altair/Observatory/composer.json
+++ b/src/Altair/Observatory/composer.json
@@ -9,8 +9,14 @@
     },
     "require": {
         "php": ">=8.3",
+        "psr/http-factory": "^1.0",
+        "psr/http-message": "^1.1 || ^2.0",
+        "psr/http-server-handler": "^1.0",
         "univeros/configuration": "^2.0",
-        "univeros/container": "^2.0"
+        "univeros/container": "^2.0",
+        "univeros/doctor": "^2.0",
+        "univeros/events": "^2.0",
+        "univeros/introspection": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Altair/Observatory/resources/assets/observatory.css
+++ b/src/Altair/Observatory/resources/assets/observatory.css
@@ -1,0 +1,160 @@
+/*
+ * Observatory — design tokens + components.
+ *
+ * Dark-first, zero-build (no Tailwind/Node step): plain CSS custom properties
+ * are the single source of truth for the palette approved in the design pass.
+ * Light mode is defined as a pair via [data-theme="light"].
+ */
+
+:root {
+    /* surfaces */
+    --o-bg: #0A0E1A;
+    --o-surface: #131826;
+    --o-surface-2: #1B2233;
+    --o-border: #232A3B;
+    /* text */
+    --o-text: #E6EAF2;
+    --o-text-muted: #94A0B8;
+    /* signature accent — "Altair" blue-white */
+    --o-accent: #5B9DFF;
+    --o-accent-hover: #7BB0FF;
+    /* status */
+    --o-ok: #34D399;
+    --o-warn: #FBBF24;
+    --o-crit: #FB7185;
+    --o-unknown: #64748B;
+    /* tints (10%) */
+    --o-ok-bg: rgba(52, 211, 153, 0.10);
+    --o-warn-bg: rgba(251, 191, 36, 0.10);
+    --o-crit-bg: rgba(251, 113, 133, 0.10);
+    --o-unknown-bg: rgba(100, 116, 139, 0.12);
+    --o-accent-bg: rgba(91, 157, 255, 0.12);
+
+    --o-radius: 12px;
+    --o-radius-sm: 8px;
+    --o-gap: 16px;
+    --o-font: "Inter", system-ui, -apple-system, "Segoe UI", sans-serif;
+    --o-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+[data-theme="light"] {
+    --o-bg: #F7F8FB;
+    --o-surface: #FFFFFF;
+    --o-surface-2: #F1F3F8;
+    --o-border: #E6E9F0;
+    --o-text: #1B2233;
+    --o-text-muted: #5A6478;
+    --o-accent: #2F6FE0;
+    --o-accent-hover: #2560C8;
+}
+
+* { box-sizing: border-box; }
+
+body {
+    margin: 0;
+    background: var(--o-bg);
+    color: var(--o-text);
+    font-family: var(--o-font);
+    font-size: 14px;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+}
+
+.o-tabular { font-variant-numeric: tabular-nums; }
+.o-mono { font-family: var(--o-mono); }
+a { color: var(--o-accent); text-decoration: none; }
+a:hover { color: var(--o-accent-hover); }
+
+/* layout: sidebar + content */
+.o-app { display: grid; grid-template-columns: 240px 1fr; min-height: 100dvh; }
+.o-sidebar {
+    background: var(--o-surface);
+    border-right: 1px solid var(--o-border);
+    padding: 20px 12px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+.o-brand { display: flex; align-items: center; gap: 10px; padding: 4px 12px 18px; font-weight: 700; letter-spacing: -0.01em; }
+.o-brand-mark { width: 22px; height: 22px; color: var(--o-accent); }
+.o-nav-group { margin-top: 14px; padding: 0 12px 6px; font-size: 11px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--o-text-muted); }
+.o-nav-item {
+    display: flex; align-items: center; gap: 10px;
+    padding: 8px 12px; border-radius: var(--o-radius-sm);
+    color: var(--o-text-muted); font-weight: 500;
+    border-left: 2px solid transparent;
+}
+.o-nav-item:hover { color: var(--o-text); background: var(--o-surface-2); }
+.o-nav-item.is-active { color: var(--o-accent); background: var(--o-accent-bg); border-left-color: var(--o-accent); }
+.o-nav-item svg { width: 18px; height: 18px; }
+
+.o-main { display: flex; flex-direction: column; min-width: 0; }
+.o-topbar {
+    display: flex; align-items: center; gap: 12px;
+    padding: 14px 24px; border-bottom: 1px solid var(--o-border);
+    position: sticky; top: 0; background: color-mix(in srgb, var(--o-bg) 88%, transparent); backdrop-filter: blur(8px); z-index: 10;
+}
+.o-topbar h1 { font-size: 16px; font-weight: 600; margin: 0; }
+.o-spacer { flex: 1; }
+.o-content { padding: 24px; }
+
+/* env badge + live indicator */
+.o-chip { display: inline-flex; align-items: center; gap: 6px; padding: 3px 10px; border-radius: 999px; font-size: 12px; font-weight: 500; background: var(--o-surface-2); color: var(--o-text-muted); border: 1px solid var(--o-border); }
+.o-live { color: var(--o-accent); }
+.o-live .o-dot { background: var(--o-accent); animation: o-pulse 1.6s ease-in-out infinite; }
+@keyframes o-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.35; } }
+@media (prefers-reduced-motion: reduce) { .o-live .o-dot { animation: none; } }
+
+/* dashboard grid */
+.o-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: var(--o-gap); }
+
+/* card */
+.o-card {
+    position: relative; background: var(--o-surface); border: 1px solid var(--o-border);
+    border-radius: var(--o-radius); padding: 20px; overflow: hidden;
+    transition: border-color 150ms ease;
+}
+.o-card:hover { border-color: color-mix(in srgb, var(--o-accent) 40%, var(--o-border)); }
+.o-card::before { content: ""; position: absolute; left: 0; top: 0; bottom: 0; width: 2px; background: var(--o-status, var(--o-unknown)); }
+.o-card[data-status="ok"] { --o-status: var(--o-ok); }
+.o-card[data-status="warning"] { --o-status: var(--o-warn); }
+.o-card[data-status="critical"] { --o-status: var(--o-crit); }
+.o-card[data-status="unknown"] { --o-status: var(--o-unknown); }
+.o-card-head { display: flex; align-items: center; gap: 8px; margin-bottom: 14px; }
+.o-card-title { display: flex; align-items: center; gap: 8px; font-weight: 600; }
+.o-card-title svg { width: 18px; height: 18px; color: var(--o-text-muted); }
+.o-headline { font-size: 24px; font-weight: 700; letter-spacing: -0.02em; }
+.o-metrics { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 10px; }
+.o-metric { font-size: 12px; color: var(--o-text-muted); background: var(--o-surface-2); border-radius: var(--o-radius-sm); padding: 3px 8px; }
+.o-metric b { color: var(--o-text); font-weight: 600; }
+.o-card-foot { margin-top: 16px; font-size: 13px; }
+
+/* status badge */
+.o-badge { display: inline-flex; align-items: center; gap: 6px; padding: 2px 9px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.o-dot { width: 7px; height: 7px; border-radius: 999px; background: currentColor; flex: none; }
+.o-badge[data-status="ok"], .o-status-ok { color: var(--o-ok); background: var(--o-ok-bg); }
+.o-badge[data-status="warning"], .o-status-warning { color: var(--o-warn); background: var(--o-warn-bg); }
+.o-badge[data-status="critical"], .o-status-critical { color: var(--o-crit); background: var(--o-crit-bg); }
+.o-badge[data-status="unknown"], .o-status-unknown { color: var(--o-unknown); background: var(--o-unknown-bg); }
+
+/* data table */
+.o-table { width: 100%; border-collapse: collapse; font-size: 13px; }
+.o-table thead th { text-align: left; font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--o-text-muted); font-weight: 600; padding: 10px 12px; border-bottom: 1px solid var(--o-border); }
+.o-table tbody td { padding: 10px 12px; border-bottom: 1px solid var(--o-border); }
+.o-table tbody tr:hover { background: var(--o-surface-2); }
+.o-table .o-num { text-align: right; font-variant-numeric: tabular-nums; font-family: var(--o-mono); }
+
+/* live-tail stream */
+.o-stream { font-family: var(--o-mono); font-size: 13px; }
+.o-stream-row { display: flex; gap: 12px; padding: 6px 12px; border-bottom: 1px solid var(--o-border); animation: o-fadein 200ms ease; }
+@keyframes o-fadein { from { opacity: 0; transform: translateY(-2px); } to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) { .o-stream-row { animation: none; } }
+.o-stream-time { color: var(--o-text-muted); }
+
+/* access-denied / empty */
+.o-empty { text-align: center; color: var(--o-text-muted); padding: 64px 24px; }
+
+@media (max-width: 820px) {
+    .o-app { grid-template-columns: 1fr; }
+    .o-sidebar { display: none; }
+}

--- a/src/Altair/Observatory/resources/assets/observatory.css
+++ b/src/Altair/Observatory/resources/assets/observatory.css
@@ -151,6 +151,12 @@ a:hover { color: var(--o-accent-hover); }
 @media (prefers-reduced-motion: reduce) { .o-stream-row { animation: none; } }
 .o-stream-time { color: var(--o-text-muted); }
 
+/* framework footer */
+.o-footer { margin-top: auto; padding: 16px 24px; border-top: 1px solid var(--o-border); color: var(--o-text-muted); font-size: 12px; display: flex; align-items: center; gap: 8px; }
+.o-footer a { color: var(--o-text-muted); }
+.o-footer a:hover { color: var(--o-accent); }
+.o-footer .o-spacer { flex: 1; }
+
 /* access-denied / empty */
 .o-empty { text-align: center; color: var(--o-text-muted); padding: 64px 24px; }
 

--- a/src/Altair/Observatory/resources/views/dashboard.php
+++ b/src/Altair/Observatory/resources/views/dashboard.php
@@ -76,6 +76,13 @@ $icon = static fn(string $k, string $c = ''): string => IconSet::svg($k, $c);
                 <?php endforeach; ?>
             </div>
         </div>
+
+        <footer class="o-footer">
+            <span><?= $icon('overview') ?></span>
+            <span>Observatory</span>
+            <span class="o-spacer"></span>
+            <span>Powered by the <a href="https://univeros.io" target="_blank" rel="noopener">Altair Framework</a></span>
+        </footer>
     </main>
 </div>
 </body>

--- a/src/Altair/Observatory/resources/views/dashboard.php
+++ b/src/Altair/Observatory/resources/views/dashboard.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * Presentation template (excluded from static analysis). Receives $data:
+ *   $data['panels']: array<string, array{label, icon, snapshot: array{status, headline, metrics, items}}>
+ */
+
+use Altair\Observatory\View\IconSet;
+use Altair\Observatory\View\TemplateRenderer;
+
+/** @var array<string, mixed> $data */
+$panels = \is_array($data['panels'] ?? null) ? $data['panels'] : [];
+$css = (string) @file_get_contents(__DIR__ . '/../assets/observatory.css');
+$e = static fn(int|float|string|bool|null $v): string => TemplateRenderer::e($v);
+$icon = static fn(string $k, string $c = ''): string => IconSet::svg($k, $c);
+?>
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Observatory</title>
+    <style><?= $css ?></style>
+</head>
+<body>
+<div class="o-app">
+    <aside class="o-sidebar">
+        <div class="o-brand"><span class="o-brand-mark"><?= $icon('overview', 'o-brand-mark') ?></span> Observatory</div>
+        <div class="o-nav-group">Monitors</div>
+        <?php foreach ($panels as $id => $panel): ?>
+            <a class="o-nav-item" href="#panel-<?= $e((string) $id) ?>">
+                <?= $icon((string) ($panel['icon'] ?? '')) ?>
+                <span><?= $e((string) ($panel['label'] ?? $id)) ?></span>
+            </a>
+        <?php endforeach; ?>
+    </aside>
+
+    <main class="o-main">
+        <header class="o-topbar">
+            <h1>Overview</h1>
+            <span class="o-spacer"></span>
+            <span class="o-chip o-live"><span class="o-dot"></span> LIVE</span>
+            <button class="o-chip" type="button" onclick="document.documentElement.dataset.theme = document.documentElement.dataset.theme === 'dark' ? 'light' : 'dark'">Theme</button>
+        </header>
+
+        <div class="o-content">
+            <div class="o-grid">
+                <?php foreach ($panels as $id => $panel):
+                    $snapshot = \is_array($panel['snapshot'] ?? null) ? $panel['snapshot'] : [];
+                    $status = (string) ($snapshot['status'] ?? 'unknown');
+                    $metrics = \is_array($snapshot['metrics'] ?? null) ? $snapshot['metrics'] : [];
+                    ?>
+                    <section class="o-card" data-status="<?= $e($status) ?>" id="panel-<?= $e((string) $id) ?>">
+                        <div class="o-card-head">
+                            <span class="o-card-title"><?= $icon((string) ($panel['icon'] ?? '')) ?> <?= $e((string) ($panel['label'] ?? $id)) ?></span>
+                            <span class="o-spacer"></span>
+                            <span class="o-badge" data-status="<?= $e($status) ?>"><span class="o-dot"></span> <?= $e(strtoupper($status)) ?></span>
+                        </div>
+                        <div class="o-headline o-tabular"><?= $e((string) ($snapshot['headline'] ?? '')) ?></div>
+                        <?php if ($metrics !== []): ?>
+                            <div class="o-metrics">
+                                <?php foreach ($metrics as $key => $value): ?>
+                                    <span class="o-metric"><?= $e((string) $key) ?> <b class="o-tabular"><?= $e(\is_scalar($value) ? $value : '') ?></b></span>
+                                <?php endforeach; ?>
+                            </div>
+                        <?php endif; ?>
+                        <div class="o-card-foot"><a href="#panel-<?= $e((string) $id) ?>">view &rarr;</a></div>
+                    </section>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/Altair/Observatory/resources/views/denied.php
+++ b/src/Altair/Observatory/resources/views/denied.php
@@ -26,5 +26,10 @@ $css = (string) @file_get_contents(__DIR__ . '/../assets/observatory.css');
     <h2>Observatory is disabled</h2>
     <p>Set <code class="o-mono">OBSERVATORY_ENABLED=true</code> in a non-production environment to enable the panel.</p>
 </div>
+<footer class="o-footer">
+    <span class="o-spacer"></span>
+    <span>Powered by the <a href="https://univeros.io" target="_blank" rel="noopener">Altair Framework</a></span>
+    <span class="o-spacer"></span>
+</footer>
 </body>
 </html>

--- a/src/Altair/Observatory/resources/views/denied.php
+++ b/src/Altair/Observatory/resources/views/denied.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * Presentation template (excluded from static analysis).
+ */
+
+$css = (string) @file_get_contents(__DIR__ . '/../assets/observatory.css');
+?>
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Observatory — disabled</title>
+    <style><?= $css ?></style>
+</head>
+<body>
+<div class="o-empty">
+    <h2>Observatory is disabled</h2>
+    <p>Set <code class="o-mono">OBSERVATORY_ENABLED=true</code> in a non-production environment to enable the panel.</p>
+</div>
+</body>
+</html>

--- a/tests/Observatory/Http/DashboardHandlerTest.php
+++ b/tests/Observatory/Http/DashboardHandlerTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Http;
+
+use Altair\Observatory\Http\DashboardHandler;
+use Altair\Observatory\Observatory;
+use Altair\Observatory\Panel\RuntimePanel;
+use Altair\Observatory\PanelRegistry;
+use Altair\Observatory\Security\EnvironmentAccessGuard;
+use Altair\Observatory\View\TemplateRenderer;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\StreamFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DashboardHandler::class)]
+final class DashboardHandlerTest extends TestCase
+{
+    public function testRendersDashboardWhenAccessible(): void
+    {
+        $response = $this->handler(enabled: true)->handle(new ServerRequest());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertStringContainsString('text/html', $response->getHeaderLine('Content-Type'));
+
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('Observatory', $body);
+        self::assertStringContainsString('Runtime', $body);
+        self::assertStringContainsString('data-status="ok"', $body);
+    }
+
+    public function testReturns403WhenDenied(): void
+    {
+        $response = $this->handler(enabled: false)->handle(new ServerRequest());
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('disabled', $body);
+        // No panel data (e.g. the Runtime panel's headline/label) is rendered on the denied page.
+        self::assertStringNotContainsString('Runtime', $body);
+        self::assertStringNotContainsString('PHP ' . PHP_VERSION, $body);
+    }
+
+    private function handler(bool $enabled): DashboardHandler
+    {
+        $observatory = new Observatory(
+            new PanelRegistry([new RuntimePanel()]),
+            new EnvironmentAccessGuard($enabled, 'local'),
+        );
+
+        return new DashboardHandler(
+            $observatory,
+            TemplateRenderer::default(),
+            new ResponseFactory(),
+            new StreamFactory(),
+        );
+    }
+}

--- a/tests/Observatory/Panel/ConfigPanelTest.php
+++ b/tests/Observatory/Panel/ConfigPanelTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Container\Container;
+use Altair\Introspection\Inspector\ConfigInspector;
+use Altair\Observatory\Panel\ConfigPanel;
+use Altair\Observatory\Panel\PanelStatus;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ConfigPanel::class)]
+final class ConfigPanelTest extends TestCase
+{
+    /** @var list<string> */
+    private array $appliedKeys = [];
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        foreach ($this->appliedKeys as $key) {
+            unset($_ENV[$key], $_SERVER[$key]);
+            putenv($key);
+        }
+
+        $this->appliedKeys = [];
+    }
+
+    public function testIdentity(): void
+    {
+        $panel = new ConfigPanel(new ConfigInspector(new Container()));
+
+        self::assertSame('config', $panel->id());
+        self::assertSame('Config', $panel->label());
+        self::assertSame('adjustments', $panel->icon());
+    }
+
+    public function testSnapshotMasksSecretsAndReportsKeyCount(): void
+    {
+        $this->setEnv([
+            'OBS_DB_PASSWORD' => 'hunter2',
+            'OBS_LOG_LEVEL' => 'info',
+        ]);
+
+        $snapshot = (new ConfigPanel(new ConfigInspector(new Container())))->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertGreaterThan(0, $snapshot->metrics['keys']);
+        self::assertStringContainsString('key', $snapshot->headline);
+
+        $byKey = [];
+        foreach ($snapshot->items as $item) {
+            self::assertArrayHasKey('key', $item);
+            self::assertArrayHasKey('value', $item);
+            $byKey[(string) $item['key']] = $item['value'];
+        }
+
+        // The secret-looking key must be redacted; the raw value must never leak.
+        self::assertSame('***', $byKey['OBS_DB_PASSWORD']);
+        self::assertNotContains('hunter2', array_values($byKey));
+        self::assertSame('info', $byKey['OBS_LOG_LEVEL']);
+    }
+
+    public function testContainerParametersAreMaskedWhenSecretLooking(): void
+    {
+        $container = new Container();
+        $container->defineParameter('apiToken', 'abc123');
+
+        $snapshot = (new ConfigPanel(new ConfigInspector($container)))->snapshot();
+
+        $masked = null;
+        foreach ($snapshot->items as $item) {
+            if ($item['key'] === '$apiToken') {
+                $masked = $item['value'];
+                break;
+            }
+        }
+
+        self::assertSame('***', $masked);
+    }
+
+    /**
+     * @param array<string, string> $values
+     */
+    private function setEnv(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+            putenv(\sprintf('%s=%s', $key, $value));
+            $this->appliedKeys[] = $key;
+        }
+    }
+}

--- a/tests/Observatory/Panel/ContainerPanelTest.php
+++ b/tests/Observatory/Panel/ContainerPanelTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Container\Container;
+use Altair\Introspection\Inspector\ContainerInspector;
+use Altair\Observatory\Panel\ContainerPanel;
+use Altair\Observatory\Panel\PanelStatus;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+
+#[CoversClass(ContainerPanel::class)]
+final class ContainerPanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new ContainerPanel(new ContainerInspector(new Container()));
+
+        self::assertSame('container', $panel->id());
+        self::assertSame('Container', $panel->label());
+        self::assertSame('cube', $panel->icon());
+    }
+
+    public function testSnapshotReportsBindings(): void
+    {
+        $container = new Container();
+        $container->alias(LoggerInterface::class, NullLogger::class);
+        $container->share(NullLogger::class);
+
+        $snapshot = (new ContainerPanel(new ContainerInspector($container)))->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertGreaterThan(0, $snapshot->metrics['bindings']);
+        self::assertStringContainsString('binding', $snapshot->headline);
+        self::assertNotSame([], $snapshot->items);
+
+        $first = $snapshot->items[0];
+        self::assertArrayHasKey('id', $first);
+        self::assertArrayHasKey('kind', $first);
+        self::assertArrayHasKey('shared', $first);
+    }
+
+    public function testEmptyContainerDegradesToUnknown(): void
+    {
+        $snapshot = (new ContainerPanel(new ContainerInspector(new Container())))->snapshot();
+
+        self::assertSame(PanelStatus::Unknown, $snapshot->status);
+        self::assertStringContainsString('unavailable', $snapshot->headline);
+        self::assertSame([], $snapshot->items);
+        self::assertSame(0, $snapshot->metrics['bindings']);
+    }
+}

--- a/tests/Observatory/Panel/EventsPanelTest.php
+++ b/tests/Observatory/Panel/EventsPanelTest.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Events\Actor;
+use Altair\Events\Contracts\EventStorageInterface;
+use Altair\Events\Event;
+use Altair\Events\EventKind;
+use Altair\Events\EventStatus;
+use Altair\Events\Reader;
+use Altair\Observatory\Panel\EventsPanel;
+use Altair\Observatory\Panel\PanelStatus;
+use DateTimeImmutable;
+use Generator;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(EventsPanel::class)]
+final class EventsPanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new EventsPanel(new Reader(new FakeEventStorage([])));
+
+        self::assertSame('events', $panel->id());
+        self::assertSame('Activity', $panel->label());
+        self::assertSame('rss', $panel->icon());
+    }
+
+    public function testSnapshotIsUnknownWhenLogIsEmpty(): void
+    {
+        $snapshot = (new EventsPanel(new Reader(new FakeEventStorage([]))))->snapshot();
+
+        self::assertSame(PanelStatus::Unknown, $snapshot->status);
+        self::assertSame('0 events', $snapshot->headline);
+        self::assertSame(0, $snapshot->metrics['total']);
+        self::assertSame(0, $snapshot->metrics['ok']);
+        self::assertSame(0, $snapshot->metrics['fail']);
+        self::assertSame([], $snapshot->items);
+    }
+
+    public function testSnapshotIsOkForAllSuccessfulEvents(): void
+    {
+        $reader = new Reader(new FakeEventStorage([
+            $this->event('01HAAA0000000000000000000A', kind: EventKind::Scaffold, durationMs: 10),
+            $this->event('01HAAA0000000000000000000B', kind: EventKind::Migration, durationMs: 20),
+        ]));
+
+        $snapshot = (new EventsPanel($reader))->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertSame('2 events', $snapshot->headline);
+        self::assertSame(2, $snapshot->metrics['total']);
+        self::assertSame(2, $snapshot->metrics['ok']);
+        self::assertSame(0, $snapshot->metrics['fail']);
+        self::assertSame(30, $snapshot->metrics['total_duration_ms']);
+
+        // Newest-first: B before A.
+        self::assertCount(2, $snapshot->items);
+        self::assertSame('01HAAA0000000000000000000B', $snapshot->items[0]['id']);
+        self::assertSame('migration', $snapshot->items[0]['kind']);
+        self::assertSame('ok', $snapshot->items[0]['status']);
+        self::assertSame(20, $snapshot->items[0]['duration_ms']);
+        self::assertSame('01HAAA0000000000000000000A', $snapshot->items[1]['id']);
+    }
+
+    public function testSnapshotIsWarningWhenAnyEventFailed(): void
+    {
+        $reader = new Reader(new FakeEventStorage([
+            $this->event('01HAAA0000000000000000000A', status: EventStatus::Ok, durationMs: 10),
+            $this->event('01HAAA0000000000000000000B', status: EventStatus::Fail, durationMs: 5, error: 'boom'),
+        ]));
+
+        $snapshot = (new EventsPanel($reader))->snapshot();
+
+        self::assertSame(PanelStatus::Warning, $snapshot->status);
+        self::assertSame('2 events', $snapshot->headline);
+        self::assertSame(1, $snapshot->metrics['ok']);
+        self::assertSame(1, $snapshot->metrics['fail']);
+        self::assertSame('fail', $snapshot->items[0]['status']);
+    }
+
+    public function testTailLimitsRecentItems(): void
+    {
+        $reader = new Reader(new FakeEventStorage([
+            $this->event('01HAAA0000000000000000000A'),
+            $this->event('01HAAA0000000000000000000B'),
+            $this->event('01HAAA0000000000000000000C'),
+        ]));
+
+        $snapshot = (new EventsPanel($reader, tail: 2))->snapshot();
+
+        self::assertSame(3, $snapshot->metrics['total']);
+        self::assertCount(2, $snapshot->items);
+        self::assertSame('01HAAA0000000000000000000C', $snapshot->items[0]['id']);
+        self::assertSame('01HAAA0000000000000000000B', $snapshot->items[1]['id']);
+    }
+
+    private function event(
+        string $id,
+        EventKind $kind = EventKind::Scaffold,
+        EventStatus $status = EventStatus::Ok,
+        int $durationMs = 5,
+        ?string $error = null,
+    ): Event {
+        return new Event(
+            id: $id,
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+            actor: Actor::Cli,
+            command: 'bin/altair foo',
+            kind: $kind,
+            status: $status,
+            durationMs: $durationMs,
+            error: $error,
+        );
+    }
+}
+
+/**
+ * In-memory storage so the panel test never touches the filesystem.
+ */
+final class FakeEventStorage implements EventStorageInterface
+{
+    /**
+     * @param list<Event> $events oldest -> newest
+     */
+    public function __construct(
+        private array $events = [],
+    ) {}
+
+    #[Override]
+    public function append(Event $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    #[Override]
+    public function readAll(): Generator
+    {
+        yield from $this->events;
+    }
+
+    #[Override]
+    public function readReverse(): Generator
+    {
+        yield from array_reverse($this->events);
+    }
+
+    #[Override]
+    public function count(): int
+    {
+        return \count($this->events);
+    }
+}

--- a/tests/Observatory/Panel/HealthPanelTest.php
+++ b/tests/Observatory/Panel/HealthPanelTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Doctor\CheckRegistry;
+use Altair\Doctor\Doctor;
+use Altair\Doctor\Result\CheckResult;
+use Altair\Observatory\Panel\HealthPanel;
+use Altair\Observatory\Panel\PanelStatus;
+use Altair\Tests\Doctor\Support\FakeCheck;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(HealthPanel::class)]
+final class HealthPanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new HealthPanel(new Doctor(new CheckRegistry()));
+
+        self::assertSame('health', $panel->id());
+        self::assertSame('Health', $panel->label());
+        self::assertSame('heart-pulse', $panel->icon());
+    }
+
+    public function testFailingCheckMakesPanelCritical(): void
+    {
+        $panel = new HealthPanel($this->doctor([
+            new FakeCheck('a', CheckResult::ok('a', 'all good')),
+            new FakeCheck('b', CheckResult::ok('b', 'all good')),
+            new FakeCheck('c', CheckResult::error('c', 'boom')),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Critical, $snapshot->status);
+        self::assertSame('2/3 passing', $snapshot->headline);
+        self::assertSame(3, $snapshot->metrics['total']);
+        self::assertSame(2, $snapshot->metrics['passing']);
+        self::assertSame(1, $snapshot->metrics['failed']);
+        self::assertSame(0, $snapshot->metrics['skipped']);
+    }
+
+    public function testWarnCheckCountsAsFailedAndCritical(): void
+    {
+        $panel = new HealthPanel($this->doctor([
+            new FakeCheck('a', CheckResult::ok('a', 'ok')),
+            new FakeCheck('b', CheckResult::warn('b', 'careful')),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Critical, $snapshot->status);
+        self::assertSame('1/2 passing', $snapshot->headline);
+        self::assertSame(1, $snapshot->metrics['failed']);
+    }
+
+    public function testAllOkIsOk(): void
+    {
+        $panel = new HealthPanel($this->doctor([
+            new FakeCheck('a', CheckResult::ok('a', 'ok')),
+            new FakeCheck('b', CheckResult::ok('b', 'ok')),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertSame('2/2 passing', $snapshot->headline);
+    }
+
+    public function testSkippedOnlyRunIsWarning(): void
+    {
+        $panel = new HealthPanel($this->doctor([
+            new FakeCheck('a', CheckResult::ok('a', 'ok')),
+            new FakeCheck('b', CheckResult::skipped('b', 'not applicable')),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Warning, $snapshot->status);
+        self::assertSame('1/2 passing', $snapshot->headline);
+        self::assertSame(1, $snapshot->metrics['skipped']);
+    }
+
+    public function testEmptyRunIsUnknown(): void
+    {
+        $panel = new HealthPanel($this->doctor([]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Unknown, $snapshot->status);
+        self::assertSame('0/0 passing', $snapshot->headline);
+        self::assertSame([], $snapshot->items);
+    }
+
+    public function testItemsAreOneRowPerCheckWithStatusAndSummary(): void
+    {
+        $panel = new HealthPanel($this->doctor([
+            new FakeCheck('php_version', CheckResult::ok('php_version', 'PHP 8.3 detected')),
+            new FakeCheck('composer_deps', CheckResult::error('composer_deps', 'lockfile stale')),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame([
+            ['name' => 'php_version', 'status' => 'ok', 'summary' => 'PHP 8.3 detected'],
+            ['name' => 'composer_deps', 'status' => 'error', 'summary' => 'lockfile stale'],
+        ], $snapshot->items);
+    }
+
+    public function testOnlyFilterRunsTheNamedSubset(): void
+    {
+        $cheap = new FakeCheck('cheap', CheckResult::ok('cheap', 'fast'));
+        $slow = new FakeCheck('phpstan', CheckResult::ok('phpstan', 'slow'));
+        $panel = new HealthPanel($this->doctor([$cheap, $slow]), ['cheap']);
+
+        $snapshot = $panel->snapshot();
+
+        self::assertTrue($cheap->ran);
+        self::assertFalse($slow->ran, 'the slow check must be excluded by the only-filter');
+        self::assertSame('1/1 passing', $snapshot->headline);
+    }
+
+    /**
+     * @param list<FakeCheck> $checks
+     */
+    private function doctor(array $checks): Doctor
+    {
+        return new Doctor(new CheckRegistry($checks));
+    }
+}

--- a/tests/Observatory/Panel/MigrationsPanelTest.php
+++ b/tests/Observatory/Panel/MigrationsPanelTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Observatory\Contracts\MigrationStatusReaderInterface;
+use Altair\Observatory\Panel\MigrationsPanel;
+use Altair\Observatory\Panel\MigrationStatus;
+use Altair\Observatory\Panel\PanelStatus;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MigrationsPanel::class)]
+#[CoversClass(MigrationStatus::class)]
+final class MigrationsPanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new MigrationsPanel($this->reader(null));
+
+        self::assertSame('migrations', $panel->id());
+        self::assertSame('Migrations', $panel->label());
+        self::assertSame('circle-stack', $panel->icon());
+    }
+
+    public function testOkWhenNothingPending(): void
+    {
+        $panel = new MigrationsPanel($this->reader([
+            new MigrationStatus('20260101_create_users', true),
+            new MigrationStatus('20260102_create_orders', true),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertSame('0 pending', $snapshot->headline);
+        self::assertSame(2, $snapshot->metrics['applied']);
+        self::assertSame(0, $snapshot->metrics['pending']);
+        // No pending rows, so the recent applied migrations fill the list.
+        self::assertCount(2, $snapshot->items);
+        self::assertSame('20260101_create_users', $snapshot->items[0]['name']);
+        self::assertTrue($snapshot->items[0]['applied']);
+    }
+
+    public function testWarningWhenPending(): void
+    {
+        $panel = new MigrationsPanel($this->reader([
+            new MigrationStatus('20260101_create_users', true),
+            new MigrationStatus('20260102_create_orders', false),
+            new MigrationStatus('20260103_add_index', false),
+        ]));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Warning, $snapshot->status);
+        self::assertSame('2 pending', $snapshot->headline);
+        self::assertSame(1, $snapshot->metrics['applied']);
+        self::assertSame(2, $snapshot->metrics['pending']);
+        // Only the pending migrations are listed, in order.
+        self::assertCount(2, $snapshot->items);
+        self::assertSame('20260102_create_orders', $snapshot->items[0]['name']);
+        self::assertFalse($snapshot->items[0]['applied']);
+        self::assertSame('20260103_add_index', $snapshot->items[1]['name']);
+    }
+
+    public function testUnknownWhenUnreadable(): void
+    {
+        $panel = new MigrationsPanel($this->reader(null));
+
+        $snapshot = $panel->snapshot();
+
+        self::assertSame(PanelStatus::Unknown, $snapshot->status);
+        self::assertSame('unavailable', $snapshot->headline);
+        self::assertNull($snapshot->metrics['applied']);
+        self::assertNull($snapshot->metrics['pending']);
+        self::assertSame([], $snapshot->items);
+    }
+
+    /**
+     * @param list<MigrationStatus>|null $migrations
+     */
+    private function reader(?array $migrations): MigrationStatusReaderInterface
+    {
+        return new readonly class ($migrations) implements MigrationStatusReaderInterface {
+            /**
+             * @param list<MigrationStatus>|null $migrations
+             */
+            public function __construct(private ?array $migrations) {}
+
+            #[Override]
+            public function read(): ?array
+            {
+                return $this->migrations;
+            }
+        };
+    }
+}

--- a/tests/Observatory/Panel/QueuesPanelTest.php
+++ b/tests/Observatory/Panel/QueuesPanelTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Observatory\Contracts\FailedQueueReaderInterface;
+use Altair\Observatory\Panel\PanelStatus;
+use Altair\Observatory\Panel\QueuesPanel;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(QueuesPanel::class)]
+final class QueuesPanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new QueuesPanel($this->reader([], 0));
+
+        self::assertSame('queues', $panel->id());
+        self::assertSame('Queues', $panel->label());
+        self::assertSame('queue-list', $panel->icon());
+    }
+
+    public function testStatusIsUnknownWhenNoTransportsConfigured(): void
+    {
+        $snapshot = (new QueuesPanel($this->reader([], 0)))->snapshot();
+
+        self::assertSame(PanelStatus::Unknown, $snapshot->status);
+        self::assertSame('No transports configured', $snapshot->headline);
+        self::assertSame(0, $snapshot->metrics['transports']);
+        self::assertSame(0, $snapshot->metrics['failed']);
+        self::assertSame([], $snapshot->items);
+    }
+
+    public function testStatusIsOkWhenTransportsConfiguredAndNoFailures(): void
+    {
+        $snapshot = (new QueuesPanel($this->reader(['default', 'high'], 0)))->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertSame('0 failed', $snapshot->headline);
+        self::assertSame(2, $snapshot->metrics['transports']);
+        self::assertSame(0, $snapshot->metrics['failed']);
+        self::assertSame([], $snapshot->items, 'No failures should be listed when there are none.');
+    }
+
+    public function testStatusIsWarningWhenFailuresPresent(): void
+    {
+        $failures = [
+            ['id' => 'env-1', 'message_class' => 'App\\Messages\\SendWelcomeEmail', 'error' => 'SMTP timeout', 'transport' => 'failed'],
+            ['id' => 'env-2', 'message_class' => 'App\\Messages\\GenerateReport', 'error' => 'OOM', 'transport' => 'failed'],
+            ['id' => 'env-3', 'message_class' => 'App\\Messages\\Resize', 'error' => 'bad image', 'transport' => 'failed'],
+        ];
+
+        $snapshot = (new QueuesPanel($this->reader(['default'], 3, $failures)))->snapshot();
+
+        self::assertSame(PanelStatus::Warning, $snapshot->status);
+        self::assertSame('3 failed', $snapshot->headline);
+        self::assertSame(1, $snapshot->metrics['transports']);
+        self::assertSame(3, $snapshot->metrics['failed']);
+        self::assertCount(3, $snapshot->items);
+        self::assertSame('env-1', $snapshot->items[0]['id']);
+        self::assertSame('App\\Messages\\SendWelcomeEmail', $snapshot->items[0]['message_class']);
+    }
+
+    public function testHeadlineFormatsLargeCountsWithThousandsSeparator(): void
+    {
+        $snapshot = (new QueuesPanel($this->reader(['default'], 1234)))->snapshot();
+
+        self::assertSame('1,234 failed', $snapshot->headline);
+        self::assertSame(1234, $snapshot->metrics['failed']);
+    }
+
+    public function testTailLimitIsForwardedToReader(): void
+    {
+        $reader = new class implements FailedQueueReaderInterface {
+            public ?int $requestedLimit = null;
+
+            #[Override]
+            public function transportNames(): array
+            {
+                return ['default'];
+            }
+
+            #[Override]
+            public function failedCount(): int
+            {
+                return 5;
+            }
+
+            #[Override]
+            public function recentFailures(int $limit = 25): array
+            {
+                $this->requestedLimit = $limit;
+
+                return [];
+            }
+        };
+
+        (new QueuesPanel($reader, 10))->snapshot();
+
+        self::assertSame(10, $reader->requestedLimit);
+    }
+
+    /**
+     * @param list<string>                     $transports
+     * @param list<array<string, scalar|null>> $failures
+     */
+    private function reader(array $transports, int $failedCount, array $failures = []): FailedQueueReaderInterface
+    {
+        return new readonly class ($transports, $failedCount, $failures) implements FailedQueueReaderInterface {
+            /**
+             * @param list<string>                     $transports
+             * @param list<array<string, scalar|null>> $failures
+             */
+            public function __construct(
+                private array $transports,
+                private int $failedCount,
+                private array $failures,
+            ) {}
+
+            #[Override]
+            public function transportNames(): array
+            {
+                return $this->transports;
+            }
+
+            #[Override]
+            public function failedCount(): int
+            {
+                return $this->failedCount;
+            }
+
+            #[Override]
+            public function recentFailures(int $limit = 25): array
+            {
+                return \array_slice($this->failures, 0, $limit);
+            }
+        };
+    }
+}

--- a/tests/Observatory/Panel/RoutesPanelTest.php
+++ b/tests/Observatory/Panel/RoutesPanelTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Panel;
+
+use Altair\Http\Collection\RouteCollection;
+use Altair\Introspection\Inspector\RouteInspector;
+use Altair\Observatory\Panel\PanelStatus;
+use Altair\Observatory\Panel\RoutesPanel;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(RoutesPanel::class)]
+final class RoutesPanelTest extends TestCase
+{
+    public function testIdentity(): void
+    {
+        $panel = new RoutesPanel(new RouteInspector(new RouteCollection()));
+
+        self::assertSame('routes', $panel->id());
+        self::assertSame('Routes', $panel->label());
+        self::assertSame('map', $panel->icon());
+    }
+
+    public function testSnapshotReportsRoutes(): void
+    {
+        $routes = new RouteCollection();
+        $routes->put('GET /users', 'App\\Action\\ListUsers');
+        $routes->put('POST /users', 'App\\Action\\CreateUser');
+
+        $snapshot = (new RoutesPanel(new RouteInspector($routes)))->snapshot();
+
+        self::assertSame(PanelStatus::Ok, $snapshot->status);
+        self::assertSame('2 routes', $snapshot->headline);
+        self::assertSame(2, $snapshot->metrics['routes']);
+        self::assertCount(2, $snapshot->items);
+
+        $first = $snapshot->items[0];
+        self::assertArrayHasKey('method', $first);
+        self::assertArrayHasKey('path', $first);
+        self::assertArrayHasKey('handler', $first);
+        self::assertSame('/users', $first['path']);
+    }
+
+    public function testEmptyRoutesDegradeToUnknown(): void
+    {
+        $snapshot = (new RoutesPanel(new RouteInspector(new RouteCollection())))->snapshot();
+
+        self::assertSame(PanelStatus::Unknown, $snapshot->status);
+        self::assertStringContainsString('unavailable', $snapshot->headline);
+        self::assertSame([], $snapshot->items);
+        self::assertSame(0, $snapshot->metrics['routes']);
+    }
+}


### PR DESCRIPTION
## Summary

Builds **Observatory** — Altair's Telescope/Horizon/Pulse-style dev panel — from scaffold into a real, gated monitoring dashboard. It owns no data of its own: each panel is a thin, tested wrapper over a source the framework already exposes (the same sources `univeros/mcp` wraps for agents), so coupling to the core stays minimal.

### Panels (8)
Registered lazily and only when their data source is bound, so the dashboard degrades gracefully (fewer cards) rather than failing:
- **Runtime** (PHP/memory/opcache) · **Health** (doctor) · **Activity** (events log) · **Queues** (messaging, via a new `FailedQueueReaderInterface` seam) · **Routes / Container / Config** (introspection — **config secrets masked**) · **Migrations** (persistence, via a new `MigrationStatusReaderInterface` seam + `MigrationStatus` DTO).

### UI (approved design: dark-first, Altair-blue)
- `observatory.css` — zero-build design tokens + components (cards, status pills, tables, sidebar, live-tail, footer), light pair via `[data-theme]`.
- Self-authored `IconSet` (no icon dependency), `TemplateRenderer` (no-`extract` PHP views), card-grid `dashboard` + `denied` views with the **Altair Framework footer**.
- `DashboardHandler` (PSR-15): gated, server-rendered overview; **403 "disabled" page** when the guard denies.

### Security
Fail-closed `EnvironmentAccessGuard` (denied unless `OBSERVATORY_ENABLED` **and** a non-production `APP_ENV`); config panel reuses introspection's secret masking.

## Follow-up (tracked in #120)
SSE live-tail endpoint (activity/queues streams) + per-panel detail views (filterable tables).

## Test plan
- [x] `composer stan` (level 8) — `[OK] No errors` (view templates excluded as presentation)
- [x] `composer cs` (cache-free) — clean
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] `composer test` — 51 Observatory tests; full suite green apart from the pre-existing local `MongoSessionHandlerTest` env errors (CI loads ext-mongodb)