### PR TITLE
re #120 Observatory: SSE live-tail + per-panel detail views

### DIFF
--- a/src/Altair/Observatory/Http/ActivityStreamHandler.php
+++ b/src/Altair/Observatory/Http/ActivityStreamHandler.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Observatory\Http;
+
+use Altair\Events\Event;
+use Altair\Events\Reader;
+use Altair\Observatory\Observatory;
+use JsonException;
+use Override;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Server-Sent Events endpoint for the live activity tail.
+ *
+ * Rather than holding a long-lived connection (which would pin a PHP worker),
+ * this emits the events newer than the client's `Last-Event-ID` and closes; the
+ * browser's EventSource reconnects after `retry` ms with the last id it saw, so
+ * the stream stays near-real-time with zero extra infrastructure. Events are
+ * emitted oldest-first so the client can prepend each row and keep the newest on
+ * top. Access is gated by the Observatory facade.
+ */
+final readonly class ActivityStreamHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private Observatory $observatory,
+        private Reader $reader,
+        private ResponseFactoryInterface $responseFactory,
+        private StreamFactoryInterface $streamFactory,
+        private int $retryMs = 2000,
+        private int $backlog = 50,
+    ) {}
+
+    #[Override]
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (!$this->observatory->isAccessible()) {
+            return $this->responseFactory->createResponse(403);
+        }
+
+        $lastId = $this->lastEventId($request);
+
+        $events = $lastId === ''
+            ? iterator_to_array($this->reader->tail($this->backlog), false)
+            : iterator_to_array($this->reader->sinceId($lastId), false);
+
+        $body = \sprintf("retry: %d\n\n", $this->retryMs);
+        // Readers yield newest-first; reverse to oldest-first for prepend ordering.
+        foreach (array_reverse($events) as $event) {
+            $body .= $this->formatEvent($event);
+        }
+
+        return $this->responseFactory->createResponse(200)
+            ->withHeader('Content-Type', 'text/event-stream')
+            ->withHeader('Cache-Control', 'no-cache')
+            ->withHeader('X-Accel-Buffering', 'no')
+            ->withBody($this->streamFactory->createStream($body));
+    }
+
+    private function lastEventId(ServerRequestInterface $request): string
+    {
+        $header = $request->getHeaderLine('Last-Event-ID');
+
+        if ($header !== '') {
+            return $header;
+        }
+
+        $lastId = $request->getQueryParams()['lastId'] ?? null;
+
+        return \is_string($lastId) ? $lastId : '';
+    }
+
+    private function formatEvent(Event $event): string
+    {
+        $array = $event->toArray();
+
+        try {
+            $data = json_encode($array, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+        } catch (JsonException) {
+            return '';
+        }
+
+        $id = isset($array['id']) && \is_scalar($array['id']) ? (string) $array['id'] : '';
+
+        return \sprintf("id: %s\nevent: activity\ndata: %s\n\n", $id, $data);
+    }
+}

--- a/src/Altair/Observatory/Http/DashboardHandler.php
+++ b/src/Altair/Observatory/Http/DashboardHandler.php
@@ -23,9 +23,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 /**
  * Serves the Observatory dashboard as server-rendered HTML.
  *
- * Access is gated by the Observatory facade: when the guard denies, a 403
- * "disabled" page is returned instead of any panel data. The host routes a path
+ * `GET ?` renders the card overview; `GET ?panel=<id>` renders that panel's
+ * detail view (a filterable table of its rows, 404 when the id is unknown).
+ * Access is gated by the Observatory facade — a denied guard returns the 403
+ * "disabled" page instead of any panel data. The host routes a path
  * (e.g. /_observatory) to this handler.
+ *
+ * $streamUrl, when set, is passed to the activity detail view to drive the SSE
+ * live-tail (it should point at the host's {@see ActivityStreamHandler} route).
  */
 final readonly class DashboardHandler implements RequestHandlerInterface
 {
@@ -34,6 +39,7 @@ final readonly class DashboardHandler implements RequestHandlerInterface
         private TemplateRenderer $renderer,
         private ResponseFactoryInterface $responseFactory,
         private StreamFactoryInterface $streamFactory,
+        private string $streamUrl = '',
     ) {}
 
     #[Override]
@@ -43,8 +49,21 @@ final readonly class DashboardHandler implements RequestHandlerInterface
             return $this->html(403, $this->renderer->render('denied'));
         }
 
+        $dashboard = $this->observatory->dashboard();
+        $panel = $request->getQueryParams()['panel'] ?? null;
+        $panelId = \is_string($panel) ? $panel : '';
+
+        if ($panelId !== '') {
+            return $this->html(isset($dashboard[$panelId]) ? 200 : 404, $this->renderer->render('panel', [
+                'panels' => $dashboard,
+                'active' => $panelId,
+                'streamUrl' => $this->streamUrl,
+            ]));
+        }
+
         return $this->html(200, $this->renderer->render('dashboard', [
-            'panels' => $this->observatory->dashboard(),
+            'panels' => $dashboard,
+            'active' => '',
         ]));
     }
 

--- a/src/Altair/Observatory/resources/assets/observatory.css
+++ b/src/Altair/Observatory/resources/assets/observatory.css
@@ -151,6 +151,10 @@ a:hover { color: var(--o-accent-hover); }
 @media (prefers-reduced-motion: reduce) { .o-stream-row { animation: none; } }
 .o-stream-time { color: var(--o-text-muted); }
 
+/* filter input (detail views) */
+.o-filter { width: 100%; max-width: 360px; margin-bottom: 12px; padding: 8px 12px; border-radius: var(--o-radius-sm); border: 1px solid var(--o-border); background: var(--o-surface); color: var(--o-text); font-size: 13px; font-family: var(--o-font); }
+.o-filter:focus { outline: none; border-color: var(--o-accent); box-shadow: 0 0 0 3px var(--o-accent-bg); }
+
 /* framework footer */
 .o-footer { margin-top: auto; padding: 16px 24px; border-top: 1px solid var(--o-border); color: var(--o-text-muted); font-size: 12px; display: flex; align-items: center; gap: 8px; }
 .o-footer a { color: var(--o-text-muted); }

--- a/src/Altair/Observatory/resources/views/dashboard.php
+++ b/src/Altair/Observatory/resources/views/dashboard.php
@@ -31,16 +31,7 @@ $icon = static fn(string $k, string $c = ''): string => IconSet::svg($k, $c);
 </head>
 <body>
 <div class="o-app">
-    <aside class="o-sidebar">
-        <div class="o-brand"><span class="o-brand-mark"><?= $icon('overview', 'o-brand-mark') ?></span> Observatory</div>
-        <div class="o-nav-group">Monitors</div>
-        <?php foreach ($panels as $id => $panel): ?>
-            <a class="o-nav-item" href="#panel-<?= $e((string) $id) ?>">
-                <?= $icon((string) ($panel['icon'] ?? '')) ?>
-                <span><?= $e((string) ($panel['label'] ?? $id)) ?></span>
-            </a>
-        <?php endforeach; ?>
-    </aside>
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
 
     <main class="o-main">
         <header class="o-topbar">
@@ -71,7 +62,7 @@ $icon = static fn(string $k, string $c = ''): string => IconSet::svg($k, $c);
                                 <?php endforeach; ?>
                             </div>
                         <?php endif; ?>
-                        <div class="o-card-foot"><a href="#panel-<?= $e((string) $id) ?>">view &rarr;</a></div>
+                        <div class="o-card-foot"><a href="?panel=<?= $e((string) $id) ?>">view &rarr;</a></div>
                     </section>
                 <?php endforeach; ?>
             </div>

--- a/src/Altair/Observatory/resources/views/panel.php
+++ b/src/Altair/Observatory/resources/views/panel.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * Presentation template (excluded from static analysis). Receives $data:
+ *   $data['panels']  : full dashboard map (for the sidebar)
+ *   $data['active']  : the focused panel id
+ *   $data['streamUrl']: optional SSE URL for the activity live-tail ('' = off)
+ */
+
+use Altair\Observatory\View\TemplateRenderer;
+
+/** @var array<string, mixed> $data */
+$panels = \is_array($data['panels'] ?? null) ? $data['panels'] : [];
+$active = (string) ($data['active'] ?? '');
+$streamUrl = (string) ($data['streamUrl'] ?? '');
+$css = (string) @file_get_contents(__DIR__ . '/../assets/observatory.css');
+$e = static fn(int|float|string|bool|null $v): string => TemplateRenderer::e($v);
+
+$panel = \is_array($panels[$active] ?? null) ? $panels[$active] : null;
+$snapshot = \is_array($panel['snapshot'] ?? null) ? $panel['snapshot'] : [];
+$status = (string) ($snapshot['status'] ?? 'unknown');
+$metrics = \is_array($snapshot['metrics'] ?? null) ? $snapshot['metrics'] : [];
+$items = \is_array($snapshot['items'] ?? null) ? $snapshot['items'] : [];
+
+$columns = [];
+foreach ($items as $row) {
+    if (\is_array($row)) {
+        foreach (array_keys($row) as $key) {
+            $columns[(string) $key] = true;
+        }
+    }
+}
+$columns = array_keys($columns);
+$liveTail = $active === 'events' && $streamUrl !== '';
+?>
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Observatory — <?= $e((string) ($panel['label'] ?? $active)) ?></title>
+    <style><?= $css ?></style>
+</head>
+<body>
+<div class="o-app">
+    <?php include __DIR__ . '/partials/sidebar.php'; ?>
+
+    <main class="o-main">
+        <header class="o-topbar">
+            <a class="o-chip" href="?">&larr; Overview</a>
+            <h1><?= $e((string) ($panel['label'] ?? $active)) ?></h1>
+            <?php if ($panel !== null): ?>
+                <span class="o-badge" data-status="<?= $e($status) ?>"><span class="o-dot"></span> <?= $e(strtoupper($status)) ?></span>
+            <?php endif; ?>
+            <span class="o-spacer"></span>
+            <?php if ($liveTail): ?><span class="o-chip o-live"><span class="o-dot"></span> LIVE</span><?php endif; ?>
+        </header>
+
+        <div class="o-content">
+            <?php if ($panel === null): ?>
+                <div class="o-empty"><h2>Panel &ldquo;<?= $e($active) ?>&rdquo; not found</h2></div>
+            <?php else: ?>
+                <div class="o-headline o-tabular" style="margin-bottom:6px"><?= $e((string) ($snapshot['headline'] ?? '')) ?></div>
+                <?php if ($metrics !== []): ?>
+                    <div class="o-metrics" style="margin-bottom:18px">
+                        <?php foreach ($metrics as $key => $value): ?>
+                            <span class="o-metric"><?= $e((string) $key) ?> <b class="o-tabular"><?= $e(\is_scalar($value) ? $value : '') ?></b></span>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endif; ?>
+
+                <?php if ($columns !== []): ?>
+                    <input class="o-filter" type="search" placeholder="Filter rows&hellip;" aria-label="Filter rows"
+                           oninput="(function(q){document.querySelectorAll('#o-rows tr').forEach(function(r){r.style.display=r.textContent.toLowerCase().indexOf(q.toLowerCase())>-1?'':'none';});})(this.value)">
+                    <table class="o-table">
+                        <thead><tr><?php foreach ($columns as $column): ?><th><?= $e($column) ?></th><?php endforeach; ?></tr></thead>
+                        <tbody id="o-rows">
+                        <?php foreach ($items as $row): if (!\is_array($row)) {
+                            continue;
+                        } ?>
+                            <tr><?php foreach ($columns as $column):
+                                $value = $row[$column] ?? '';
+                                $numeric = \in_array($column, ['id', 'duration_ms', 'timestamp'], true);
+                                ?><td<?= $numeric ? ' class="o-num"' : '' ?>><?= $e(\is_scalar($value) ? $value : '') ?></td><?php endforeach; ?></tr>
+                        <?php endforeach; ?>
+                        </tbody>
+                    </table>
+                <?php else: ?>
+                    <div class="o-empty">No detail rows.</div>
+                <?php endif; ?>
+            <?php endif; ?>
+        </div>
+
+        <footer class="o-footer">
+            <span class="o-spacer"></span>
+            <span>Powered by the <a href="https://univeros.io" target="_blank" rel="noopener">Altair Framework</a></span>
+        </footer>
+    </main>
+</div>
+<?php if ($liveTail): ?>
+<script>
+(function () {
+    var columns = <?= json_encode($columns, JSON_THROW_ON_ERROR) ?>;
+    var tbody = document.getElementById('o-rows');
+    if (!tbody || !window.EventSource) { return; }
+    var source = new EventSource(<?= json_encode($streamUrl, JSON_THROW_ON_ERROR) ?>);
+    source.addEventListener('activity', function (event) {
+        var data;
+        try { data = JSON.parse(event.data); } catch (e) { return; }
+        var row = document.createElement('tr');
+        columns.forEach(function (column) {
+            var cell = document.createElement('td');
+            cell.textContent = data[column] != null ? String(data[column]) : '';
+            row.appendChild(cell);
+        });
+        tbody.insertBefore(row, tbody.firstChild);
+    });
+})();
+</script>
+<?php endif; ?>
+</body>
+</html>

--- a/src/Altair/Observatory/resources/views/partials/sidebar.php
+++ b/src/Altair/Observatory/resources/views/partials/sidebar.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ *
+ * Presentation partial (excluded from static analysis). Shares $data with its
+ * parent template: expects $data['panels'] and $data['active'] (active panel id,
+ * '' on the overview).
+ */
+
+use Altair\Observatory\View\IconSet;
+use Altair\Observatory\View\TemplateRenderer;
+
+/** @var array<string, mixed> $data */
+$navPanels = \is_array($data['panels'] ?? null) ? $data['panels'] : [];
+$active = (string) ($data['active'] ?? '');
+$esc = static fn(int|float|string|bool|null $v): string => TemplateRenderer::e($v);
+?>
+<aside class="o-sidebar">
+    <div class="o-brand"><span class="o-brand-mark"><?= IconSet::svg('overview', 'o-brand-mark') ?></span> Observatory</div>
+    <a class="o-nav-item<?= $active === '' ? ' is-active' : '' ?>" href="?"><?= IconSet::svg('overview') ?><span>Overview</span></a>
+    <div class="o-nav-group">Monitors</div>
+    <?php foreach ($navPanels as $id => $navItem): ?>
+        <a class="o-nav-item<?= (string) $id === $active ? ' is-active' : '' ?>" href="?panel=<?= $esc((string) $id) ?>">
+            <?= IconSet::svg((string) ($navItem['icon'] ?? '')) ?>
+            <span><?= $esc((string) ($navItem['label'] ?? $id)) ?></span>
+        </a>
+    <?php endforeach; ?>
+</aside>

--- a/tests/Observatory/Http/ActivityStreamHandlerTest.php
+++ b/tests/Observatory/Http/ActivityStreamHandlerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Observatory\Http;
+
+use Altair\Events\Actor;
+use Altair\Events\Contracts\EventStorageInterface;
+use Altair\Events\Event;
+use Altair\Events\EventKind;
+use Altair\Events\EventStatus;
+use Altair\Events\Reader;
+use Altair\Observatory\Http\ActivityStreamHandler;
+use Altair\Observatory\Observatory;
+use Altair\Observatory\Panel\RuntimePanel;
+use Altair\Observatory\PanelRegistry;
+use Altair\Observatory\Security\EnvironmentAccessGuard;
+use DateTimeImmutable;
+use Generator;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\StreamFactory;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ActivityStreamHandler::class)]
+final class ActivityStreamHandlerTest extends TestCase
+{
+    public function testStreamsRecentEventsOldestFirstWhenAccessible(): void
+    {
+        $response = $this->handler(enabled: true, events: [$this->event('A'), $this->event('B')])
+            ->handle(new ServerRequest());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('text/event-stream', $response->getHeaderLine('Content-Type'));
+
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('retry: 2000', $body);
+        self::assertStringContainsString('event: activity', $body);
+        self::assertStringContainsString('id: A', $body);
+        self::assertStringContainsString('id: B', $body);
+        // Emitted oldest-first so the client prepends and keeps newest on top.
+        self::assertLessThan(strpos($body, 'id: B'), strpos($body, 'id: A'));
+    }
+
+    public function testLastEventIdReturnsOnlyNewerEvents(): void
+    {
+        $request = (new ServerRequest())->withHeader('Last-Event-ID', 'A');
+        $body = (string) $this->handler(true, [$this->event('A'), $this->event('B')])->handle($request)->getBody();
+
+        self::assertStringContainsString('id: B', $body);
+        self::assertStringNotContainsString('id: A', $body);
+    }
+
+    public function testReturns403WhenDenied(): void
+    {
+        $response = $this->handler(enabled: false, events: [$this->event('A')])->handle(new ServerRequest());
+
+        self::assertSame(403, $response->getStatusCode());
+    }
+
+    /**
+     * @param list<Event> $events
+     */
+    private function handler(bool $enabled, array $events): ActivityStreamHandler
+    {
+        $observatory = new Observatory(
+            new PanelRegistry([new RuntimePanel()]),
+            new EnvironmentAccessGuard($enabled, 'local'),
+        );
+
+        return new ActivityStreamHandler(
+            $observatory,
+            new Reader($this->storage($events)),
+            new ResponseFactory(),
+            new StreamFactory(),
+        );
+    }
+
+    /**
+     * @param list<Event> $events oldest -> newest
+     */
+    private function storage(array $events): EventStorageInterface
+    {
+        return new class ($events) implements EventStorageInterface {
+            /** @param list<Event> $events */
+            public function __construct(private array $events) {}
+
+            #[Override]
+            public function append(Event $event): void
+            {
+                $this->events[] = $event;
+            }
+
+            #[Override]
+            public function readAll(): Generator
+            {
+                yield from $this->events;
+            }
+
+            #[Override]
+            public function readReverse(): Generator
+            {
+                yield from array_reverse($this->events);
+            }
+
+            #[Override]
+            public function count(): int
+            {
+                return \count($this->events);
+            }
+        };
+    }
+
+    private function event(string $id): Event
+    {
+        return new Event(
+            id: $id,
+            timestamp: new DateTimeImmutable('2026-05-27T10:00:00Z'),
+            actor: Actor::Cli,
+            command: 'bin/altair foo',
+            kind: EventKind::Scaffold,
+            status: EventStatus::Ok,
+            durationMs: 5,
+            error: null,
+        );
+    }
+}

--- a/tests/Observatory/Http/DashboardHandlerTest.php
+++ b/tests/Observatory/Http/DashboardHandlerTest.php
@@ -51,6 +51,27 @@ final class DashboardHandlerTest extends TestCase
         self::assertStringNotContainsString('PHP ' . PHP_VERSION, $body);
     }
 
+    public function testRendersPanelDetailWhenPanelQuerySet(): void
+    {
+        $request = (new ServerRequest())->withQueryParams(['panel' => 'runtime']);
+        $response = $this->handler(enabled: true)->handle($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = (string) $response->getBody();
+        self::assertStringContainsString('Runtime', $body);
+        self::assertStringContainsString('o-filter', $body);
+        self::assertStringContainsString('o-table', $body);
+    }
+
+    public function testReturns404ForUnknownPanel(): void
+    {
+        $request = (new ServerRequest())->withQueryParams(['panel' => 'does-not-exist']);
+        $response = $this->handler(enabled: true)->handle($request);
+
+        self::assertSame(404, $response->getStatusCode());
+        self::assertStringContainsString('not found', (string) $response->getBody());
+    }
+
     private function handler(bool $enabled): DashboardHandler
     {
         $observatory = new Observatory(

--- a/tests/Observatory/PanelRegistryTest.php
+++ b/tests/Observatory/PanelRegistryTest.php
@@ -51,7 +51,7 @@ final class PanelRegistryTest extends TestCase
 
     private function panel(string $id, string $label = 'Label'): PanelInterface
     {
-        return new readonly class($id, $label) implements PanelInterface {
+        return new readonly class ($id, $label) implements PanelInterface {
             public function __construct(private string $id, private string $label) {}
 
             public function id(): string


### PR DESCRIPTION
## Summary

Completes the #120 follow-up — the remaining live-tail + detail surfaces on top of the merged panels/dashboard (#122).

- **`ActivityStreamHandler`** (PSR-15 SSE): emits events newer than the client's `Last-Event-ID` (or the recent backlog) as `text/event-stream`, oldest-first, then closes — the browser's `EventSource` reconnects with the last id, so the tail stays near-real-time **without pinning a PHP worker**. Gated by the Observatory facade (403 when denied).
- **Per-panel detail views**: `DashboardHandler` now routes `?panel=<id>` to a detail page (404 on unknown id); the overview is unchanged. `panel.php` renders the status header + metrics + a **client-side filterable table**; for the activity panel it wires an `EventSource` (when a stream URL is configured) that prepends incoming rows. Shared sidebar extracted to a partial; overview card "view →" links open the detail view.
- `DashboardHandler` gains an optional `$streamUrl` passed to the activity detail (points at the host's `ActivityStreamHandler` route).

## Test plan
- [x] `composer stan` (level 8) — `[OK] No errors`
- [x] `composer cs` (cache-free, scoped) — clean
- [x] `vendor/bin/rector process --dry-run` — clean
- [x] `composer test` — 56 Observatory tests; full suite green apart from the pre-existing local `MongoSessionHandlerTest` env errors (CI loads ext-mongodb)

Closes the remaining items on #120.