### PR TITLE
re #73 univeros/bootstrap — bin/altair new project bootstrap

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -11,7 +11,7 @@ EOF;
 
 $finder = (new PhpCsFixer\Finder())
     ->in(__DIR__)
-    ->exclude(['.github', 'build', 'tests', 'runtime', 'vendor']);
+    ->exclude(['.github', 'build', 'tests', 'runtime', 'vendor', 'skeleton']);
 
 return (new PhpCsFixer\Config())
     ->setRiskyAllowed(true)

--- a/bin/altair
+++ b/bin/altair
@@ -37,6 +37,7 @@ $paths = [];
 // Built-in framework commands ship with their own packages.
 $builtIn = [
     __DIR__ . '/../src/Altair/AgentSpec/Cli',
+    __DIR__ . '/../src/Altair/Bootstrap/Cli',
     __DIR__ . '/../src/Altair/Doctor/Cli',
     __DIR__ . '/../src/Altair/Mcp/Cli',
     __DIR__ . '/../src/Altair/Messaging/Cli',

--- a/composer.json
+++ b/composer.json
@@ -75,6 +75,7 @@
     },
     "replace": {
         "univeros/agent-spec": "self.version",
+        "univeros/bootstrap": "self.version",
         "univeros/cache": "self.version",
         "univeros/cli": "self.version",
         "univeros/common": "self.version",

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,7 @@ Developer experience and AI-agent ergonomics.
 - [Events](./packages/events.md) — the append-only `.altair/events.jsonl` mutation log, so agents and developers can answer "what just changed?" across sessions. (Not the PSR-14 dispatcher — that's Happen.)
 - [TestReporter](./packages/test-reporter.md) — an AI-native PHPUnit 11 extension that emits a structured JSON report, mapping each failure back to the production source under test with structured diffs.
 - [Mcp](./packages/mcp.md) — a first-party Model Context Protocol server exposing the framework as 28 agent-callable tools over stdio/HTTP, so any MCP client can build, inspect, test, and ship an Altair API through tool calls.
+- [Bootstrap](./packages/bootstrap.md) — zero-to-running project bootstrap: `bin/altair new` materialises a complete, runnable Altair API (a working `/ping`, a passing test, the spec-driven toolchain wired) from the skeleton template, with minimal/standard/full presets.
 
 ## How these docs are structured
 

--- a/docs/packages/bootstrap.md
+++ b/docs/packages/bootstrap.md
@@ -1,0 +1,156 @@
+# Bootstrap
+
+> Zero-to-running project bootstrap — the `bin/altair new` command that materialises a complete, runnable Altair API (one working endpoint, one passing test, the whole spec-driven toolchain wired) from a single command.
+
+**Composer:** `univeros/bootstrap`
+**Namespace:** `Altair\Bootstrap`
+
+## Introduction
+
+Every new project starts the same way: a directory layout, a `composer.json`, a PHPUnit config, a container boot file, route registration, env defaults. Hand-rolling those is busywork — and for an AI agent it is wasted tokens and a source of inconsistency before any real work begins. This package removes that step. You run `bin/altair new`, and you get a project that boots, tests cleanly, and serves `GET /ping` returning `200` — a known-good launchpad that every subsequent `spec:scaffold` extends.
+
+The package is small and deliberately so: a **skeleton template** (the files a new project needs), a **`SkeletonGenerator`** that copies and customises it, a handful of **presets** that answer the "which ORM / which queue" questions non-interactively, and the **`new` command** that ties them together. The generated `/ping` endpoint is real — it flows through the same `Action → Domain → Responder` pipeline ([http.md](./http.md)) and the same typed-DTO input handling every scaffolded endpoint uses, so it doubles as living proof that the framework is wired correctly.
+
+What this package does *not* do: it does not run `composer install`, apply migrations, or boot a server for you — those need the network and a chosen runtime, so the command prints them as next steps rather than performing them. It also does not generate frontend scaffolding or deployment manifests.
+
+## Installation
+
+The bootstrap command ships with the framework, so if you installed `univeros/framework` it is already on `bin/altair`. Standalone:
+
+```bash
+composer require univeros/bootstrap
+```
+
+It depends on [cli.md](./cli.md) (the command substrate), [container.md](./container.md), and [configuration.md](./configuration.md). No PHP extensions beyond core PHP 8.3.
+
+## Quick start
+
+Generate a project into `my-api` with the recommended preset:
+
+```bash
+bin/altair new --dir=my-api --preset=standard
+```
+
+That writes ~20 files and prints the next steps. Bring it to life:
+
+```bash
+cd my-api
+composer install
+composer serve            # php -S localhost:8080 -t public
+curl localhost:8080/ping  # {"message":"ok","timestamp":"..."}
+composer test             # the shipped PingActionTest + PingTest pass
+```
+
+Generate non-interactively (e.g. in a script or from an agent), choosing the smallest runnable shape:
+
+```bash
+bin/altair new --dir=/tmp/scratch --preset=minimal --no-interaction
+```
+
+## Concepts
+
+Four small pieces, each independently usable:
+
+- **Skeleton template** — the project files, shipped inside the package at `resources/skeleton`. It travels with `univeros/bootstrap` when the monorepo is split, so the generator always finds it via `SkeletonGenerator::defaultSkeletonPath()`. The template uses the `App\` namespace and a `vendor/app` package name as placeholders.
+- **`SkeletonGenerator`** — recursively copies the template into a target directory, rewriting the `App\` namespace and the composer package name on the way. It refuses to overwrite a non-empty directory unless you pass `force`.
+- **Presets** (`Profile\MinimalPreset`, `StandardPreset`, `FullPreset`, behind `Contracts\PresetInterface`) — a named bundle of the two choices the interactive command would otherwise prompt for: which ORM (`cycle` / `doctrine` / `pdo` / `none`) and which queue transport (`redis` / `doctrine` / `sync` / `none`). `PresetRegistry` resolves them by name and rejects unknown names.
+- **Steps** (`Step\GenerateEnvStep`) — the post-copy customisation. `GenerateEnvStep` writes `.env` from `.env.example`, setting the messenger DSN to match the preset; secrets stay as obvious placeholders (`APP_KEY=changeme`) rather than being auto-generated.
+
+The presets:
+
+| Preset | ORM | Queue | Use it when |
+|---|---|---|---|
+| `minimal` | none | sync | You want the smallest runnable project — no database, no broker. |
+| `standard` | cycle | redis | The recommended default for a real API. |
+| `full` | cycle | redis | Same as standard, with the agent-spec + MCP tooling expected to be pre-wired. |
+
+## What the generated project looks like
+
+```
+my-api/
+├── composer.json            # type: project, requires univeros/framework
+├── .env.example / .env      # non-secret defaults; APP_KEY=changeme placeholder
+├── phpunit.xml.dist
+├── phpstan.neon.dist
+├── .php-cs-fixer.dist.php
+├── public/index.php         # front controller: FastRoute + Relay + Action pipeline
+├── config/
+│   ├── container.php         # builds the container, applies the Configuration chain
+│   ├── configurations.php    # the Configuration chain (empty for minimal)
+│   └── routes.php            # [METHOD, PATH, Action::class] table
+├── app/                      # your code (App\ namespace)
+│   ├── Http/{Actions,Inputs,Responders}/Ping*.php
+│   └── Health/Ping.php       # the one fully-implemented domain
+├── api/ping.yaml             # the proof-of-life spec
+├── tests/{Http,Feature}/     # PingActionTest + an in-process PingTest
+├── docs/openapi/ping.yaml
+└── database/migrations/
+```
+
+The front controller wires the canonical pipeline — `DispatcherMiddleware` (FastRoute) then `ActionMiddleware` — through `Relay`, exactly as the framework's own integration tests do. Because `ActionMiddleware` hydrates typed DTO inputs (see [http.md](./http.md)), the scaffolded `Action → Domain → Responder` shape runs without further glue.
+
+## Usage
+
+### Choosing a name and namespace
+
+The defaults are the `App\` namespace and the `vendor/app` package name. Override both:
+
+```bash
+bin/altair new --dir=acme-api --name=acme/api --namespace=Acme --preset=standard
+```
+
+The generator rewrites `namespace App` → `namespace Acme`, the `App\` use-statements and FQNs in every `.php` file, and the `composer.json` `autoload.psr-4` key.
+
+### Regenerating into an existing directory
+
+By default the command refuses to write into a non-empty directory, so you can't clobber work by accident. Pass `--force` to overwrite:
+
+```bash
+bin/altair new --dir=my-api --force
+```
+
+### Driving generation from your own tooling
+
+The pieces are plain services. Generate a project from a script or test without the CLI:
+
+```php
+use Altair\Bootstrap\Profile\PresetRegistry;
+use Altair\Bootstrap\SkeletonGenerator;
+use Altair\Bootstrap\Step\GenerateEnvStep;
+
+$created = (new SkeletonGenerator())->generate('/path/to/target', namespace: 'Acme', projectName: 'acme/api');
+
+(new GenerateEnvStep())->run('/path/to/target', (new PresetRegistry())->get('standard'));
+```
+
+`generate()` returns the list of created paths (relative to the target), so you can report or assert on exactly what was written.
+
+### Building the next endpoint
+
+Once the project is installed, the toolchain is the spec-driven flow from [scaffold.md](./scaffold.md):
+
+```bash
+vendor/bin/altair spec:scaffold api/your-endpoint.yaml
+```
+
+Implement the generated domain's `__invoke()` — the one piece left as a TODO — and the endpoint is live, just like `app/Health/Ping.php`.
+
+## Configuration
+
+There is no `Configuration` class to wire: `NewCommand`, `SkeletonGenerator`, `PresetRegistry`, and `GenerateEnvStep` are plain `readonly` services with new-on-default constructor arguments, and `bin/altair` auto-discovers the command via the [cli.md](./cli.md) attribute scanner (it adds `src/Altair/Bootstrap/Cli` to the command path at startup). Pass a custom `PresetRegistry` to `NewCommand` if you want to register your own presets.
+
+## Testing
+
+The published tests under `tests/Bootstrap/` show each piece in isolation and end to end:
+
+- `SkeletonGeneratorTest` — generation completeness, name + namespace rewriting, and the overwrite guard.
+- `PresetRegistryTest` / `GenerateEnvStepTest` — preset resolution and the env transformation.
+- `NewCommandTest` — the command produces a runnable project and rejects an unknown preset.
+- `GeneratedPingTest` — the headline acceptance: it generates a project, autoloads its `App\` classes from the temp directory, and dispatches a real `GET /ping` through the pipeline, asserting `200` and the health payload.
+
+## Limitations
+
+- The command **generates**; it does not run `composer install`, migrations, or a server — those are printed as next steps (they need the network and a chosen runtime).
+- ORM / queue presets currently steer the generated `.env` and the printed guidance; wiring the chosen bridge package into `config/configurations.php` automatically is a follow-up. The generated project is runnable for every preset.
+- `composer create-project univeros/skeleton` (the one-liner alternative to `bin/altair new`) requires the skeleton to be published as a standalone package — that ships with the package split (see the publishing work tracked separately).
+- Namespace rewriting is a textual transform over the template's `App\` token; it is reliable for the shipped template but is not a general-purpose namespace refactorer.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,6 +6,9 @@ parameters:
     excludePaths:
         # Presentation-only view templates (HTML in PHP); not application logic.
         - src/Altair/Observatory/resources/views/*
+        # Skeleton template emitted by `bin/altair new`; App-namespaced project
+        # code, not framework source.
+        - src/Altair/Bootstrap/resources/skeleton/*
     treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false
     tmpDir: .phpstan-cache

--- a/rector.php
+++ b/rector.php
@@ -23,6 +23,9 @@ return RectorConfig::configure()
     ])
     ->withSkip([
         __DIR__ . '/tests/bootstrap.php',
+        // Skeleton template emitted by `bin/altair new` — App-namespaced project
+        // code, not framework source.
+        __DIR__ . '/src/Altair/Bootstrap/resources/skeleton',
         // Scope boundary for #93: making params explicitly `?Type` lets Rector
         // collapse `?? new X()` bodies into promoted `= new X()` defaults. That
         // narrows the constructor contract (an explicit `null` arg becomes a

--- a/src/Altair/Bootstrap/Cli/NewCommand.php
+++ b/src/Altair/Bootstrap/Cli/NewCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Cli;
+
+use Altair\Bootstrap\Exception\BootstrapException;
+use Altair\Bootstrap\Profile\PresetRegistry;
+use Altair\Bootstrap\SkeletonGenerator;
+use Altair\Bootstrap\Step\GenerateEnvStep;
+use Altair\Cli\Attribute\Command;
+use Altair\Cli\Attribute\Option;
+
+use const STDERR;
+
+/**
+ * `bin/altair new` — materialise a runnable Altair API from the skeleton.
+ *
+ * ```bash
+ * bin/altair new --dir=my-api --preset=standard
+ * bin/altair new --dir=my-api --preset=minimal --no-interaction
+ * bin/altair new --dir=my-api --name=acme/api --namespace=Acme --force
+ * ```
+ *
+ * The generated project boots, serves `GET /ping`, and has the spec-driven
+ * toolchain wired. Composer install / migrate / serve are printed as next
+ * steps (they need network and a chosen runtime, so they are not run here).
+ */
+#[Command(name: 'new', description: 'Bootstrap a runnable Altair project from the skeleton.')]
+final readonly class NewCommand
+{
+    public function __construct(
+        private SkeletonGenerator $generator = new SkeletonGenerator(),
+        private PresetRegistry $presets = new PresetRegistry(),
+        private GenerateEnvStep $env = new GenerateEnvStep(),
+    ) {}
+
+    public function __invoke(
+        #[Option(description: 'Target directory (default: current directory).')]
+        ?string $dir = null,
+        #[Option(description: 'Preset: minimal, standard or full.')]
+        string $preset = 'standard',
+        #[Option(description: 'Composer package name for the generated project.')]
+        string $name = 'vendor/app',
+        #[Option(description: 'Root namespace for the generated project.')]
+        string $namespace = 'App',
+        #[Option(description: 'Overwrite a non-empty target directory.')]
+        bool $force = false,
+    ): int {
+        if (!$this->presets->has($preset)) {
+            fwrite(STDERR, \sprintf(
+                "Unknown preset '%s'. Available: %s.\n",
+                $preset,
+                implode(', ', $this->presets->names()),
+            ));
+
+            return 2;
+        }
+
+        $profile = $this->presets->get($preset);
+        $target = $dir ?? (getcwd() ?: '.');
+
+        try {
+            $created = $this->generator->generate($target, null, $namespace, $name, $force);
+            $this->env->run($target, $profile);
+        } catch (BootstrapException $bootstrapException) {
+            fwrite(STDERR, $bootstrapException->getMessage() . "\n");
+
+            return 1;
+        }
+
+        echo \sprintf(
+            "Created %d files in %s (preset: %s, orm: %s, queue: %s).\n",
+            \count($created),
+            $target,
+            $profile->name(),
+            $profile->orm(),
+            $profile->queue(),
+        );
+
+        $this->printNextSteps($target);
+
+        return 0;
+    }
+
+    private function printNextSteps(string $target): void
+    {
+        echo "\nNext steps:\n";
+        echo \sprintf("  cd %s\n", $target);
+        echo "  composer install\n";
+        echo "  composer serve            # http://localhost:8080\n";
+        echo "  curl localhost:8080/ping  # {\"message\":\"ok\",...}\n";
+        echo "\nBuild an endpoint:\n";
+        echo "  vendor/bin/altair spec:scaffold api/your-endpoint.yaml\n";
+        echo "\nDrive it from an MCP client (Claude Desktop, Cursor):\n";
+        echo "  add an \"altair\" server running: php vendor/bin/altair mcp serve\n";
+    }
+}

--- a/src/Altair/Bootstrap/Contracts/PresetInterface.php
+++ b/src/Altair/Bootstrap/Contracts/PresetInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Contracts;
+
+/**
+ * A named bundle of bootstrap choices. A preset answers the two questions the
+ * interactive `new` command would otherwise ask — which ORM and which queue
+ * transport — so a project can be generated non-interactively.
+ */
+interface PresetInterface
+{
+    public function name(): string;
+
+    /**
+     * One of: cycle, doctrine, pdo, none.
+     */
+    public function orm(): string;
+
+    /**
+     * One of: redis, doctrine, sync, none.
+     */
+    public function queue(): string;
+}

--- a/src/Altair/Bootstrap/Exception/BootstrapException.php
+++ b/src/Altair/Bootstrap/Exception/BootstrapException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Exception;
+
+use RuntimeException;
+
+/**
+ * Raised when a project cannot be bootstrapped — an unknown preset, a target
+ * directory that already has files, or a missing skeleton template.
+ */
+final class BootstrapException extends RuntimeException {}

--- a/src/Altair/Bootstrap/Profile/FullPreset.php
+++ b/src/Altair/Bootstrap/Profile/FullPreset.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Profile;
+
+use Altair\Bootstrap\Contracts\PresetInterface;
+use Override;
+
+/**
+ * Cycle ORM + Redis queue with the agent-spec and MCP tooling pre-wired.
+ */
+final class FullPreset implements PresetInterface
+{
+    #[Override]
+    public function name(): string
+    {
+        return 'full';
+    }
+
+    #[Override]
+    public function orm(): string
+    {
+        return 'cycle';
+    }
+
+    #[Override]
+    public function queue(): string
+    {
+        return 'redis';
+    }
+}

--- a/src/Altair/Bootstrap/Profile/MinimalPreset.php
+++ b/src/Altair/Bootstrap/Profile/MinimalPreset.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Profile;
+
+use Altair\Bootstrap\Contracts\PresetInterface;
+use Override;
+
+/**
+ * No ORM, no queue, synchronous handling — the smallest runnable project.
+ */
+final class MinimalPreset implements PresetInterface
+{
+    #[Override]
+    public function name(): string
+    {
+        return 'minimal';
+    }
+
+    #[Override]
+    public function orm(): string
+    {
+        return 'none';
+    }
+
+    #[Override]
+    public function queue(): string
+    {
+        return 'sync';
+    }
+}

--- a/src/Altair/Bootstrap/Profile/PresetRegistry.php
+++ b/src/Altair/Bootstrap/Profile/PresetRegistry.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Profile;
+
+use Altair\Bootstrap\Contracts\PresetInterface;
+use Altair\Bootstrap\Exception\BootstrapException;
+
+/**
+ * Resolves a preset by name. The default set is minimal / standard / full.
+ */
+final class PresetRegistry
+{
+    /**
+     * @var array<string, PresetInterface>
+     */
+    private array $presets = [];
+
+    public function __construct(PresetInterface ...$presets)
+    {
+        $defaults = $presets === [] ? [new MinimalPreset(), new StandardPreset(), new FullPreset()] : $presets;
+        foreach ($defaults as $preset) {
+            $this->presets[$preset->name()] = $preset;
+        }
+    }
+
+    public function get(string $name): PresetInterface
+    {
+        return $this->presets[$name]
+            ?? throw new BootstrapException(\sprintf(
+                "Unknown preset '%s'. Available: %s.",
+                $name,
+                implode(', ', $this->names()),
+            ));
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->presets[$name]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function names(): array
+    {
+        return array_keys($this->presets);
+    }
+}

--- a/src/Altair/Bootstrap/Profile/StandardPreset.php
+++ b/src/Altair/Bootstrap/Profile/StandardPreset.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Profile;
+
+use Altair\Bootstrap\Contracts\PresetInterface;
+use Override;
+
+/**
+ * Cycle ORM + Redis queue — the recommended default for a real API.
+ */
+final class StandardPreset implements PresetInterface
+{
+    #[Override]
+    public function name(): string
+    {
+        return 'standard';
+    }
+
+    #[Override]
+    public function orm(): string
+    {
+        return 'cycle';
+    }
+
+    #[Override]
+    public function queue(): string
+    {
+        return 'redis';
+    }
+}

--- a/src/Altair/Bootstrap/SkeletonGenerator.php
+++ b/src/Altair/Bootstrap/SkeletonGenerator.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap;
+
+use Altair\Bootstrap\Exception\BootstrapException;
+
+use const DIRECTORY_SEPARATOR;
+
+use FilesystemIterator;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Copies the skeleton template into a target directory, rewriting the `App`
+ * namespace and the composer package name as it goes. This is the file-level
+ * heart of `bin/altair new`; the command layers env generation and optional
+ * install/verify steps on top.
+ */
+final class SkeletonGenerator
+{
+    public static function defaultSkeletonPath(): string
+    {
+        // Ships inside the package so it travels with univeros/bootstrap when split.
+        return __DIR__ . '/resources/skeleton';
+    }
+
+    /**
+     * @return list<string> the created paths, relative to the target directory
+     */
+    public function generate(
+        string $targetDir,
+        ?string $skeletonDir = null,
+        string $namespace = 'App',
+        string $projectName = 'vendor/app',
+        bool $force = false,
+    ): array {
+        $skeletonDir ??= self::defaultSkeletonPath();
+        if (!is_dir($skeletonDir)) {
+            throw new BootstrapException(\sprintf("Skeleton template not found at '%s'.", $skeletonDir));
+        }
+
+        $namespace = $this->normalizeNamespace($namespace);
+
+        if (is_dir($targetDir) && !$force && $this->isNonEmpty($targetDir)) {
+            throw new BootstrapException(\sprintf(
+                "Target directory '%s' already exists and is not empty (pass force to overwrite).",
+                $targetDir,
+            ));
+        }
+
+        $created = [];
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($skeletonDir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::SELF_FIRST,
+        );
+
+        /** @var SplFileInfo $item */
+        foreach ($iterator as $item) {
+            $relative = substr($item->getPathname(), \strlen($skeletonDir) + 1);
+            $target = $targetDir . DIRECTORY_SEPARATOR . $relative;
+
+            if ($item->isDir()) {
+                $this->ensureDir($target);
+                continue;
+            }
+
+            $this->ensureDir(\dirname($target));
+            $contents = $this->transform($relative, (string) file_get_contents($item->getPathname()), $namespace, $projectName);
+
+            if (file_put_contents($target, $contents) === false) {
+                throw new BootstrapException(\sprintf("Failed to write '%s'.", $target));
+            }
+
+            $created[] = $relative;
+        }
+
+        sort($created);
+
+        return $created;
+    }
+
+    private function transform(string $relative, string $contents, string $namespace, string $projectName): string
+    {
+        if ($relative === 'composer.json') {
+            return $this->transformComposer($contents, $namespace, $projectName);
+        }
+
+        if ($namespace === 'App') {
+            return $contents;
+        }
+
+        if (str_ends_with($relative, '.php')) {
+            $contents = preg_replace('/\bnamespace App\b/', 'namespace ' . $namespace, $contents) ?? $contents;
+
+            return preg_replace('/\bApp\\\\/', $namespace . '\\', $contents) ?? $contents;
+        }
+
+        // Non-PHP files (YAML specs, README) reference App\ FQNs as plain text —
+        // e.g. api/ping.yaml's `domain.class: App\Health\Ping`.
+        return str_replace('App\\', $namespace . '\\', $contents);
+    }
+
+    private function transformComposer(string $contents, string $namespace, string $projectName): string
+    {
+        $data = json_decode($contents, true);
+        if (!\is_array($data)) {
+            return $contents;
+        }
+
+        $data['name'] = $projectName;
+
+        if ($namespace !== 'App') {
+            $autoload = $data['autoload'] ?? null;
+            $psr4 = \is_array($autoload) ? ($autoload['psr-4'] ?? null) : null;
+            if (\is_array($psr4) && \array_key_exists('App\\', $psr4)) {
+                $path = $psr4['App\\'];
+                unset($psr4['App\\']);
+                $psr4[$namespace . '\\'] = $path;
+                $autoload['psr-4'] = $psr4;
+                $data['autoload'] = $autoload;
+            }
+        }
+
+        return (json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) ?: $contents) . "\n";
+    }
+
+    private function normalizeNamespace(string $namespace): string
+    {
+        $namespace = trim($namespace, '\\');
+        if ($namespace === '') {
+            return 'App';
+        }
+
+        foreach (explode('\\', $namespace) as $segment) {
+            if (preg_match('/^[a-zA-Z_\x80-\xff][a-zA-Z0-9_\x80-\xff]*$/', $segment) !== 1) {
+                throw new BootstrapException(\sprintf(
+                    "'%s' is not a valid PHP namespace; each segment must be a legal identifier.",
+                    $namespace,
+                ));
+            }
+        }
+
+        return $namespace;
+    }
+
+    private function isNonEmpty(string $dir): bool
+    {
+        return (new FilesystemIterator($dir))->valid();
+    }
+
+    private function ensureDir(string $dir): void
+    {
+        if (!is_dir($dir) && !@mkdir($dir, 0o775, true) && !is_dir($dir)) {
+            throw new BootstrapException(\sprintf("Cannot create directory '%s'.", $dir));
+        }
+    }
+}

--- a/src/Altair/Bootstrap/Step/GenerateEnvStep.php
+++ b/src/Altair/Bootstrap/Step/GenerateEnvStep.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Bootstrap\Step;
+
+use Altair\Bootstrap\Contracts\PresetInterface;
+use Altair\Bootstrap\Exception\BootstrapException;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Writes the project's `.env` from `.env.example`, setting the messenger
+ * transport DSN to match the preset's queue choice. Secrets stay as obvious
+ * placeholders (e.g. `APP_KEY=changeme`) — never auto-generated.
+ */
+final class GenerateEnvStep
+{
+    public function run(string $targetDir, PresetInterface $preset): void
+    {
+        $example = $targetDir . DIRECTORY_SEPARATOR . '.env.example';
+        $contents = is_file($example) ? (string) file_get_contents($example) : "APP_ENV=dev\nAPP_KEY=changeme\n";
+
+        $contents = $this->setVar($contents, 'MESSENGER_TRANSPORT_DSN', $this->queueDsn($preset->queue()));
+
+        $envPath = $targetDir . DIRECTORY_SEPARATOR . '.env';
+        if (file_put_contents($envPath, $contents) === false) {
+            throw new BootstrapException(\sprintf("Failed to write '%s'.", $envPath));
+        }
+    }
+
+    private function queueDsn(string $queue): string
+    {
+        return match ($queue) {
+            'redis' => 'redis://localhost:6379/messages',
+            'doctrine' => 'doctrine://default',
+            default => 'sync://',
+        };
+    }
+
+    private function setVar(string $contents, string $key, string $value): string
+    {
+        $pattern = '/^' . preg_quote($key, '/') . '=.*/m';
+        $line = $key . '=' . $value;
+
+        if (preg_match($pattern, $contents) === 1) {
+            // Callback form so `$` / `\` in the value aren't treated as backreferences.
+            return preg_replace_callback($pattern, static fn(): string => $line, $contents) ?? $contents;
+        }
+
+        return rtrim($contents) . "\n" . $line . "\n";
+    }
+}

--- a/src/Altair/Bootstrap/composer.json
+++ b/src/Altair/Bootstrap/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "univeros/bootstrap",
+    "description": "Zero-to-running project bootstrap: the bin/altair new command that materialises a runnable Altair API from the skeleton template.",
+    "license": "MIT",
+    "homepage": "https://univeros.io",
+    "support": {
+        "issues": "https://github.com/univeros/framework/issues",
+        "source": "https://github.com/univeros/framework"
+    },
+    "require": {
+        "php": ">=8.3",
+        "univeros/cli": "^2.0",
+        "univeros/configuration": "^2.0",
+        "univeros/container": "^2.0",
+        "univeros/doctor": "^2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Altair\\Bootstrap\\": ""
+        }
+    }
+}

--- a/src/Altair/Bootstrap/resources/skeleton/.env.example
+++ b/src/Altair/Bootstrap/resources/skeleton/.env.example
@@ -1,0 +1,10 @@
+APP_ENV=dev
+APP_DEBUG=true
+APP_KEY=changeme
+
+# Database (used when an ORM is configured)
+DB_DRIVER=sqlite
+DB_DATABASE=database/app.sqlite
+
+# Messenger transport (used when a queue is configured)
+MESSENGER_TRANSPORT_DSN=sync://

--- a/src/Altair/Bootstrap/resources/skeleton/.gitignore
+++ b/src/Altair/Bootstrap/resources/skeleton/.gitignore
@@ -1,0 +1,7 @@
+/vendor/
+/composer.lock
+/.env
+/.altair/
+/.agent/
+/build/
+/.phpunit.cache/

--- a/src/Altair/Bootstrap/resources/skeleton/.php-cs-fixer.dist.php
+++ b/src/Altair/Bootstrap/resources/skeleton/.php-cs-fixer.dist.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+$finder = (new PhpCsFixer\Finder())
+    ->in([__DIR__ . '/app', __DIR__ . '/config', __DIR__ . '/public', __DIR__ . '/tests']);
+
+return (new PhpCsFixer\Config())
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PER-CS2.0' => true,
+        '@PER-CS2.0:risky' => true,
+        '@PHP83Migration' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'declare_strict_types' => true,
+        'no_unused_imports' => true,
+        'ordered_imports' => true,
+    ])
+    ->setFinder($finder);

--- a/src/Altair/Bootstrap/resources/skeleton/README.md
+++ b/src/Altair/Bootstrap/resources/skeleton/README.md
@@ -1,0 +1,78 @@
+# Altair API
+
+A runnable Altair Framework API, generated from `univeros/skeleton`. It ships
+one working endpoint (`GET /ping`), one passing test, and the spec-driven
+toolchain wired and ready.
+
+## Requirements
+
+- PHP 8.3+
+- Composer
+
+## Getting started
+
+Install dependencies and serve:
+
+```bash
+composer install
+composer serve            # php -S localhost:8080 -t public
+curl localhost:8080/ping  # {"message":"ok","timestamp":"..."}
+```
+
+Run the tests:
+
+```bash
+composer test
+```
+
+## Building endpoints
+
+Endpoints are spec-driven. Write a YAML spec under `api/`, then scaffold the
+Action / Input / Domain / Responder / test / OpenAPI fragment / route entry:
+
+```bash
+vendor/bin/altair spec:scaffold api/your-endpoint.yaml
+```
+
+Implement the generated domain's `__invoke()` (the one piece left as a TODO),
+and your endpoint is live. See `api/ping.yaml` + `app/Health/Ping.php` for the
+shape.
+
+Useful commands (all via `vendor/bin/altair`):
+
+```bash
+vendor/bin/altair spec:scaffold api/         # scaffold every spec
+vendor/bin/altair spec:emit-openapi          # merge the OpenAPI document
+vendor/bin/altair spec:lint                  # spec-vs-code drift gate
+vendor/bin/altair doctor                     # project health checks
+vendor/bin/altair mcp:serve                  # drive this project from an MCP client
+```
+
+## Layout
+
+```
+app/         your application code (App\ namespace)
+api/         YAML endpoint specs
+config/      container, configuration chain, routes
+public/      front controller (index.php)
+tests/       PHPUnit tests
+docs/openapi/ emitted OpenAPI fragments
+database/migrations/ migrations (when using an ORM)
+```
+
+## Driving it from an AI agent
+
+Point your MCP client at this project and the framework exposes its tools
+(`framework__scaffold`, `framework__run_tests`, …):
+
+```json
+{
+  "mcpServers": {
+    "altair": {
+      "command": "php",
+      "args": ["vendor/bin/altair", "mcp", "serve"],
+      "env": { "APP_ENV": "dev" }
+    }
+  }
+}
+```

--- a/src/Altair/Bootstrap/resources/skeleton/api/ping.yaml
+++ b/src/Altair/Bootstrap/resources/skeleton/api/ping.yaml
@@ -1,0 +1,14 @@
+endpoint:
+  method: GET
+  path: /ping
+  summary: Health check
+  tags: [health]
+input: {}
+output:
+  200:
+    body:
+      message: string
+      timestamp: string
+domain:
+  class: App\Health\Ping
+  invocation: __invoke

--- a/src/Altair/Bootstrap/resources/skeleton/app/Health/Ping.php
+++ b/src/Altair/Bootstrap/resources/skeleton/app/Health/Ping.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Health;
+
+use Altair\Http\Contracts\PayloadInterface;
+use App\Http\Inputs\PingInput;
+
+/**
+ * The proof-of-life domain: returns a small health payload. This is the one
+ * endpoint the skeleton ships fully implemented — every endpoint you scaffold
+ * afterwards follows the same Input → Domain → Responder shape.
+ */
+final class Ping
+{
+    public function __invoke(PingInput $input, PayloadInterface $payload): PayloadInterface
+    {
+        return $payload
+            ->withStatus(200)
+            ->withOutput(['message' => 'ok', 'timestamp' => gmdate('c')]);
+    }
+}

--- a/src/Altair/Bootstrap/resources/skeleton/app/Http/Actions/PingAction.php
+++ b/src/Altair/Bootstrap/resources/skeleton/app/Http/Actions/PingAction.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Actions;
+
+use Altair\Http\Base\Action;
+use App\Health\Ping;
+use App\Http\Inputs\PingInput;
+use App\Http\Responders\PingResponder;
+
+/**
+ * Wires GET /ping to its domain, input DTO and responder.
+ */
+final class PingAction extends Action
+{
+    public function __construct()
+    {
+        parent::__construct(
+            domain: Ping::class,
+            responder: PingResponder::class,
+            input: PingInput::class,
+        );
+    }
+}

--- a/src/Altair/Bootstrap/resources/skeleton/app/Http/Inputs/PingInput.php
+++ b/src/Altair/Bootstrap/resources/skeleton/app/Http/Inputs/PingInput.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Inputs;
+
+/**
+ * Input DTO for GET /ping. The endpoint takes no input, so this is empty —
+ * scaffolded endpoints with input fields get typed, readonly properties here.
+ */
+final readonly class PingInput
+{
+    public function __construct() {}
+
+    /**
+     * @return array<string, list<string>>
+     */
+    public static function rules(): array
+    {
+        return [];
+    }
+}

--- a/src/Altair/Bootstrap/resources/skeleton/app/Http/Responders/PingResponder.php
+++ b/src/Altair/Bootstrap/resources/skeleton/app/Http/Responders/PingResponder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Responders;
+
+use Altair\Http\Contracts\PayloadInterface;
+use Altair\Http\Contracts\ResponderInterface;
+use Laminas\Diactoros\Response\JsonResponse;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+/**
+ * Marshals the ping payload into a JSON response.
+ */
+final class PingResponder implements ResponderInterface
+{
+    public function __invoke(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        PayloadInterface $payload,
+    ): ResponseInterface {
+        return new JsonResponse($payload->getOutput(), $payload->getStatus() ?? 200);
+    }
+
+    /**
+     * @return list<int>
+     */
+    public static function statuses(): array
+    {
+        return [200];
+    }
+}

--- a/src/Altair/Bootstrap/resources/skeleton/composer.json
+++ b/src/Altair/Bootstrap/resources/skeleton/composer.json
@@ -1,0 +1,29 @@
+{
+    "name": "vendor/app",
+    "description": "An Altair Framework API.",
+    "type": "project",
+    "license": "proprietary",
+    "require": {
+        "php": ">=8.3",
+        "univeros/framework": "^2.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.4"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit",
+        "serve": "php -S localhost:8080 -t public"
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
+}

--- a/src/Altair/Bootstrap/resources/skeleton/config/configurations.php
+++ b/src/Altair/Bootstrap/resources/skeleton/config/configurations.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * The Configuration chain applied to the container at boot. The minimal
+ * skeleton needs none — the container autowires your Actions, Domains and
+ * Responders. `bin/altair new` adds entries here when you choose an ORM
+ * (Cycle) or a queue (Messenger): return the relevant Configuration instances.
+ *
+ * Example:
+ *   return [
+ *       new Altair\Persistence\Configuration\CycleOrmConfiguration(),
+ *       new Altair\Messaging\Configuration\MessengerConfiguration(),
+ *   ];
+ *
+ * @return list<Altair\Configuration\Contracts\ConfigurationInterface>
+ */
+return [];

--- a/src/Altair/Bootstrap/resources/skeleton/config/container.php
+++ b/src/Altair/Bootstrap/resources/skeleton/config/container.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Container\Container;
+
+/*
+ * Boot factory: build the container, bind it to itself (so collaborators can
+ * receive it), and apply the Configuration chain. Returns the ready container.
+ */
+$container = new Container();
+$container->share($container);
+
+/** @var list<ConfigurationInterface> $configurations */
+$configurations = require __DIR__ . '/configurations.php';
+foreach ($configurations as $configuration) {
+    $configuration->apply($container);
+}
+
+return $container;

--- a/src/Altair/Bootstrap/resources/skeleton/config/routes.php
+++ b/src/Altair/Bootstrap/resources/skeleton/config/routes.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Actions\PingAction;
+
+/*
+ * Route table: [METHOD, PATH, Action::class]. `bin/altair spec:scaffold`
+ * appends an entry here for each endpoint you generate.
+ */
+return [
+    ['GET', '/ping', PingAction::class],
+];

--- a/src/Altair/Bootstrap/resources/skeleton/docs/openapi/ping.yaml
+++ b/src/Altair/Bootstrap/resources/skeleton/docs/openapi/ping.yaml
@@ -1,0 +1,16 @@
+openapi: 3.1.0
+info:
+  title: 'Health check'
+  version: 0.0.0
+paths:
+  /ping:
+    get:
+      summary: 'Health check'
+      tags:
+        - health
+      responses:
+        200:
+          description: 'Response 200'
+          content:
+            application/json:
+              schema: { type: object, properties: { message: { type: string }, timestamp: { type: string } } }

--- a/src/Altair/Bootstrap/resources/skeleton/phpstan.neon.dist
+++ b/src/Altair/Bootstrap/resources/skeleton/phpstan.neon.dist
@@ -1,0 +1,7 @@
+parameters:
+    level: 6
+    phpVersion: 80300
+    paths:
+        - app
+        - config
+        - public

--- a/src/Altair/Bootstrap/resources/skeleton/phpunit.xml.dist
+++ b/src/Altair/Bootstrap/resources/skeleton/phpunit.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnRisky="true"
+         failOnWarning="true">
+    <testsuites>
+        <testsuite name="App Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory suffix=".php">app</directory>
+        </include>
+    </source>
+    <php>
+        <ini name="date.timezone" value="UTC"/>
+    </php>
+</phpunit>

--- a/src/Altair/Bootstrap/resources/skeleton/public/index.php
+++ b/src/Altair/Bootstrap/resources/skeleton/public/index.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Altair\Container\Container;
+use Altair\Http\Middleware\ActionMiddleware;
+use Altair\Http\Middleware\DispatcherMiddleware;
+use FastRoute\RouteCollector;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequestFactory;
+use Psr\Http\Message\ResponseInterface;
+use Relay\Relay;
+
+use function FastRoute\simpleDispatcher;
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+/** @var Container $container */
+$container = require dirname(__DIR__) . '/config/container.php';
+
+/** @var list<array{0: string, 1: string, 2: class-string}> $routes */
+$routes = require dirname(__DIR__) . '/config/routes.php';
+
+$dispatcher = simpleDispatcher(static function (RouteCollector $collector) use ($routes, $container): void {
+    foreach ($routes as [$method, $path, $action]) {
+        $collector->addRoute($method, $path, $container->make($action));
+    }
+});
+
+$relay = new Relay([
+    new DispatcherMiddleware($dispatcher),
+    new ActionMiddleware(
+        static fn(string $class): object => $container->make($class),
+        new ResponseFactory(),
+    ),
+]);
+
+$response = $relay->handle(ServerRequestFactory::fromGlobals());
+
+emit($response);
+
+/**
+ * Minimal SAPI emitter — writes the PSR-7 response to the output buffer.
+ */
+function emit(ResponseInterface $response): void
+{
+    http_response_code($response->getStatusCode());
+
+    foreach ($response->getHeaders() as $name => $values) {
+        foreach ($values as $value) {
+            header(sprintf('%s: %s', $name, $value), false);
+        }
+    }
+
+    echo $response->getBody();
+}

--- a/src/Altair/Bootstrap/resources/skeleton/tests/Feature/PingTest.php
+++ b/src/Altair/Bootstrap/resources/skeleton/tests/Feature/PingTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature;
+
+use Altair\Container\Container;
+use Altair\Http\Middleware\ActionMiddleware;
+use Altair\Http\Middleware\DispatcherMiddleware;
+use FastRoute\RouteCollector;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Relay\Relay;
+
+use function FastRoute\simpleDispatcher;
+
+/**
+ * Proof-of-life: a real GET /ping request travels the same pipeline the front
+ * controller uses and returns 200 with the health payload.
+ */
+final class PingTest extends TestCase
+{
+    public function testPingReturns200WithHealthPayload(): void
+    {
+        $container = new Container();
+        $container->share($container);
+
+        /** @var list<array{0: string, 1: string, 2: class-string}> $routes */
+        $routes = require __DIR__ . '/../../config/routes.php';
+
+        $dispatcher = simpleDispatcher(static function (RouteCollector $collector) use ($routes, $container): void {
+            foreach ($routes as [$method, $path, $action]) {
+                $collector->addRoute($method, $path, $container->make($action));
+            }
+        });
+
+        $relay = new Relay([
+            new DispatcherMiddleware($dispatcher),
+            new ActionMiddleware(static fn(string $class): object => $container->make($class), new ResponseFactory()),
+        ]);
+
+        $response = $relay->handle(new ServerRequest(uri: '/ping', method: 'GET'));
+
+        self::assertSame(200, $response->getStatusCode());
+
+        /** @var array{message: string, timestamp: string} $body */
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertSame('ok', $body['message']);
+        self::assertNotEmpty($body['timestamp']);
+    }
+}

--- a/src/Altair/Bootstrap/resources/skeleton/tests/Http/Actions/PingActionTest.php
+++ b/src/Altair/Bootstrap/resources/skeleton/tests/Http/Actions/PingActionTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Http\Actions;
+
+use App\Http\Actions\PingAction;
+use App\Http\Inputs\PingInput;
+use App\Http\Responders\PingResponder;
+use PHPUnit\Framework\TestCase;
+
+final class PingActionTest extends TestCase
+{
+    public function testActionWiresInputResponderAndDomain(): void
+    {
+        $action = new PingAction();
+
+        self::assertSame(PingInput::class, $action->getInputClassName());
+        self::assertSame(PingResponder::class, $action->getResponderClassName());
+    }
+
+    public function testResponderDeclaresThe200Status(): void
+    {
+        self::assertContains(200, PingResponder::statuses());
+    }
+}

--- a/tests/Bootstrap/GenerateEnvStepTest.php
+++ b/tests/Bootstrap/GenerateEnvStepTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Bootstrap;
+
+use Altair\Bootstrap\Profile\MinimalPreset;
+use Altair\Bootstrap\Profile\StandardPreset;
+use Altair\Bootstrap\Step\GenerateEnvStep;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(GenerateEnvStep::class)]
+final class GenerateEnvStepTest extends TestCase
+{
+    private string $dir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/altair-env-' . bin2hex(random_bytes(4));
+        mkdir($this->dir, 0o755, true);
+        file_put_contents($this->dir . '/.env.example', "APP_ENV=dev\nAPP_KEY=changeme\nMESSENGER_TRANSPORT_DSN=sync://\n");
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        @unlink($this->dir . '/.env.example');
+        @unlink($this->dir . '/.env');
+        @rmdir($this->dir);
+    }
+
+    public function testStandardPresetWritesRedisTransport(): void
+    {
+        (new GenerateEnvStep())->run($this->dir, new StandardPreset());
+
+        $env = (string) file_get_contents($this->dir . '/.env');
+        self::assertStringContainsString('MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages', $env);
+        // Secrets stay placeholders, never auto-generated.
+        self::assertStringContainsString('APP_KEY=changeme', $env);
+    }
+
+    public function testMinimalPresetKeepsSyncTransport(): void
+    {
+        (new GenerateEnvStep())->run($this->dir, new MinimalPreset());
+
+        self::assertStringContainsString('MESSENGER_TRANSPORT_DSN=sync://', (string) file_get_contents($this->dir . '/.env'));
+    }
+}

--- a/tests/Bootstrap/GeneratedPingTest.php
+++ b/tests/Bootstrap/GeneratedPingTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Bootstrap;
+
+use Altair\Bootstrap\SkeletonGenerator;
+use Altair\Container\Container;
+use Altair\Http\Middleware\ActionMiddleware;
+use Altair\Http\Middleware\DispatcherMiddleware;
+use FastRoute\RouteCollector;
+use Laminas\Diactoros\ResponseFactory;
+use Laminas\Diactoros\ServerRequest;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Relay\Relay;
+
+use function FastRoute\simpleDispatcher;
+
+/**
+ * The headline acceptance for #73: a freshly generated project actually serves
+ * GET /ping → 200 through the same pipeline its front controller uses. This
+ * generates the skeleton, autoloads its App\ classes from the temp directory,
+ * and dispatches a real request — exercising the full Action/Input(DTO)/
+ * Domain/Responder chain end to end.
+ */
+#[CoversClass(SkeletonGenerator::class)]
+final class GeneratedPingTest extends TestCase
+{
+    private string $dir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/altair-ping-' . bin2hex(random_bytes(4));
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+    }
+
+    public function testGeneratedProjectServesPing(): void
+    {
+        (new SkeletonGenerator())->generate($this->dir);
+
+        $appDir = $this->dir . '/app';
+        $autoloader = static function (string $class) use ($appDir): void {
+            if (str_starts_with($class, 'App\\')) {
+                $path = $appDir . '/' . str_replace('\\', '/', substr($class, 4)) . '.php';
+                if (is_file($path)) {
+                    require $path;
+                }
+            }
+        };
+        spl_autoload_register($autoloader);
+
+        try {
+            $container = new Container();
+            $container->share($container);
+
+            /** @var list<array{0: string, 1: string, 2: class-string}> $routes */
+            $routes = require $this->dir . '/config/routes.php';
+
+            $dispatcher = simpleDispatcher(static function (RouteCollector $collector) use ($routes, $container): void {
+                foreach ($routes as [$method, $path, $action]) {
+                    $collector->addRoute($method, $path, $container->make($action));
+                }
+            });
+
+            $relay = new Relay([
+                new DispatcherMiddleware($dispatcher),
+                new ActionMiddleware(static fn(string $class): object => $container->make($class), new ResponseFactory()),
+            ]);
+
+            $response = $relay->handle(new ServerRequest(uri: '/ping', method: 'GET'));
+
+            self::assertSame(200, $response->getStatusCode());
+
+            /** @var array{message: string, timestamp: string} $body */
+            $body = json_decode((string) $response->getBody(), true);
+            self::assertSame('ok', $body['message']);
+            self::assertNotEmpty($body['timestamp']);
+        } finally {
+            spl_autoload_unregister($autoloader);
+        }
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Bootstrap/NewCommandTest.php
+++ b/tests/Bootstrap/NewCommandTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Bootstrap;
+
+use Altair\Bootstrap\Cli\NewCommand;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(NewCommand::class)]
+final class NewCommandTest extends TestCase
+{
+    private string $dir;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->dir = sys_get_temp_dir() . '/altair-new-' . bin2hex(random_bytes(4));
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->dir);
+    }
+
+    public function testGeneratesARunnableProject(): void
+    {
+        ob_start();
+        $exit = (new NewCommand())(dir: $this->dir, preset: 'minimal');
+        ob_end_clean();
+
+        self::assertSame(0, $exit);
+        self::assertFileExists($this->dir . '/composer.json');
+        self::assertFileExists($this->dir . '/.env');
+        self::assertFileExists($this->dir . '/public/index.php');
+        self::assertFileExists($this->dir . '/app/Http/Actions/PingAction.php');
+    }
+
+    public function testUnknownPresetReturnsExitCodeTwo(): void
+    {
+        $exit = (new NewCommand())(dir: $this->dir, preset: 'enterprise');
+
+        self::assertSame(2, $exit);
+        self::assertDirectoryDoesNotExist($this->dir);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Bootstrap/PresetRegistryTest.php
+++ b/tests/Bootstrap/PresetRegistryTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Bootstrap;
+
+use Altair\Bootstrap\Profile\MinimalPreset;
+use Altair\Bootstrap\Profile\StandardPreset;
+use Altair\Bootstrap\Profile\FullPreset;
+use Altair\Bootstrap\Exception\BootstrapException;
+use Altair\Bootstrap\Profile\PresetRegistry;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(PresetRegistry::class)]
+#[CoversClass(MinimalPreset::class)]
+#[CoversClass(StandardPreset::class)]
+#[CoversClass(FullPreset::class)]
+final class PresetRegistryTest extends TestCase
+{
+    public function testDefaultsExposeMinimalStandardFull(): void
+    {
+        self::assertSame(['minimal', 'standard', 'full'], (new PresetRegistry())->names());
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function presets(): iterable
+    {
+        yield 'minimal' => ['minimal', 'none', 'sync'];
+        yield 'standard' => ['standard', 'cycle', 'redis'];
+        yield 'full' => ['full', 'cycle', 'redis'];
+    }
+
+    #[DataProvider('presets')]
+    public function testResolvesPresetChoices(string $name, string $orm, string $queue): void
+    {
+        $preset = (new PresetRegistry())->get($name);
+
+        self::assertSame($name, $preset->name());
+        self::assertSame($orm, $preset->orm());
+        self::assertSame($queue, $preset->queue());
+    }
+
+    public function testUnknownPresetThrows(): void
+    {
+        $this->expectException(BootstrapException::class);
+        (new PresetRegistry())->get('enterprise');
+    }
+}

--- a/tests/Bootstrap/SkeletonGeneratorTest.php
+++ b/tests/Bootstrap/SkeletonGeneratorTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Bootstrap;
+
+use Altair\Bootstrap\Exception\BootstrapException;
+use Altair\Bootstrap\SkeletonGenerator;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SkeletonGenerator::class)]
+final class SkeletonGeneratorTest extends TestCase
+{
+    private string $target;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->target = sys_get_temp_dir() . '/altair-skel-' . bin2hex(random_bytes(4));
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->removeDir($this->target);
+    }
+
+    public function testDefaultSkeletonPathExists(): void
+    {
+        self::assertDirectoryExists(SkeletonGenerator::defaultSkeletonPath());
+    }
+
+    public function testGeneratesACompleteRunnableProject(): void
+    {
+        $created = (new SkeletonGenerator())->generate($this->target);
+
+        self::assertContains('composer.json', $created);
+        self::assertContains('public/index.php', $created);
+        self::assertContains('app/Http/Actions/PingAction.php', $created);
+        self::assertContains('app/Health/Ping.php', $created);
+        self::assertContains('config/routes.php', $created);
+        self::assertContains('api/ping.yaml', $created);
+
+        self::assertFileExists($this->target . '/.env.example');
+    }
+
+    public function testSetsTheProjectNameInComposer(): void
+    {
+        (new SkeletonGenerator())->generate($this->target, projectName: 'acme/api');
+
+        $composer = json_decode((string) file_get_contents($this->target . '/composer.json'), true);
+        self::assertIsArray($composer);
+        self::assertSame('acme/api', $composer['name']);
+    }
+
+    public function testRewritesNamespaceWhenCustomised(): void
+    {
+        (new SkeletonGenerator())->generate($this->target, namespace: 'Acme', projectName: 'acme/api');
+
+        $action = (string) file_get_contents($this->target . '/app/Http/Actions/PingAction.php');
+        self::assertStringContainsString('namespace Acme\\Http\\Actions;', $action);
+        self::assertStringNotContainsString('namespace App\\', $action);
+
+        $composer = json_decode((string) file_get_contents($this->target . '/composer.json'), true);
+        self::assertIsArray($composer);
+        self::assertArrayHasKey('Acme\\', $composer['autoload']['psr-4']);
+
+        // Non-PHP files that reference App\ FQNs are rewritten too, so spec:lint /
+        // spec:scaffold resolve the domain class in a custom-namespace project.
+        $spec = (string) file_get_contents($this->target . '/api/ping.yaml');
+        self::assertStringContainsString('Acme\\Health\\Ping', $spec);
+    }
+
+    public function testRejectsAnInvalidNamespace(): void
+    {
+        $this->expectException(BootstrapException::class);
+        (new SkeletonGenerator())->generate($this->target, namespace: 'Foo; bad');
+    }
+
+    public function testRefusesToOverwriteNonEmptyTargetWithoutForce(): void
+    {
+        mkdir($this->target, 0o755, true);
+        file_put_contents($this->target . '/keep.txt', 'mine');
+
+        $this->expectException(BootstrapException::class);
+        (new SkeletonGenerator())->generate($this->target);
+    }
+
+    public function testForceOverwritesExistingTarget(): void
+    {
+        mkdir($this->target, 0o755, true);
+        file_put_contents($this->target . '/keep.txt', 'mine');
+
+        $created = (new SkeletonGenerator())->generate($this->target, force: true);
+
+        self::assertContains('composer.json', $created);
+    }
+
+    private function removeDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        foreach (scandir($dir) ?: [] as $item) {
+            if ($item === '.') {
+                continue;
+            }
+
+            if ($item === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $item;
+            is_dir($path) ? $this->removeDir($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
## Summary

Ships **`univeros/bootstrap`** — `bin/altair new` materialises a complete, runnable Altair API from a skeleton template in one command. Unblocked by #118 (typed-DTO endpoints execute), the generated `GET /ping` returns **200** through the real pipeline. Closes #73.

```bash
bin/altair new --dir=my-api --preset=standard
cd my-api && composer install && composer serve
curl localhost:8080/ping   # {"message":"ok","timestamp":"..."}
```

## What's included

- **`NewCommand`** (`bin/altair new`) — `--dir`, `--preset`, `--name`, `--namespace`, `--force`.
- **`SkeletonGenerator`** — recursively copies the template, rewriting the `App\` namespace (PHP and YAML/README FQNs) and the composer name; refuses a non-empty target without `--force`; validates `--namespace` is a legal PHP identifier.
- **Presets** `minimal` / `standard` / `full` behind `PresetInterface` + `PresetRegistry`.
- **`GenerateEnvStep`** — writes `.env` from `.env.example`, messenger DSN per preset; secrets stay placeholders (`APP_KEY=changeme`).
- **Skeleton template** at `src/Altair/Bootstrap/resources/skeleton/` — ships inside the package so it travels on a splitsh split. A runnable project: `composer.json` (`type: project`), `public/index.php` (FastRoute + Relay + Dispatcher/Action middleware), `config/{container,configurations,routes}.php`, the fully-implemented ping Action/Input(DTO)/Domain/Responder, `api/ping.yaml`, phpunit/phpstan/cs configs, a `Feature/PingTest`. Excluded from the framework's phpstan/rector/cs (App-namespaced project code).

## Reviews applied

Security + code review run; findings fixed:
- HIGH — `api/ping.yaml`'s `App\Health\Ping` is rewritten for custom namespaces.
- MEDIUM — `GenerateEnvStep` uses `preg_replace_callback` (no `$`/`\` backreference injection).
- LOW — `--namespace` validated as a legal PHP identifier.

## Test plan

- [x] `GeneratedPingTest`: generates a project, autoloads its `App\` classes, dispatches a real `GET /ping` → 200 (headline acceptance).
- [x] SkeletonGenerator / PresetRegistry / GenerateEnvStep / NewCommand unit-tested (namespace rewrite, invalid-namespace, force, unknown-preset → exit 2).
- [x] `bin/altair new --preset=standard` generates a 20-file runnable project.
- [x] PHPStan 8, Rector, php-cs-fixer (cache-free), full suite green (only pre-existing ext-mongodb env failures).

## Follow-ups
- Auto-wire the chosen ORM/queue `Configuration` into the generated `config/configurations.php`.
- Publish the skeleton as `composer create-project univeros/skeleton` (ships with the splitsh split, #14).