### PR TITLE
fix: resolve the container to itself for Container/ContainerInterface deps

### DIFF
--- a/docs/packages/container.md
+++ b/docs/packages/container.md
@@ -15,6 +15,8 @@ At its core the container is an auto-wiring injector. You hand it a class name a
 
 The container implements `Psr\Container\ContainerInterface` (`psr/container ^2`), so it is a drop-in wherever a PSR-11 container is expected. Its `get(string $id): mixed` method delegates to `make()`, and `has(string $id): bool` returns true if the identifier is known through an alias, a delegate, or a prior `share()` call. Note that auto-wirable concrete classes that have never been mentioned explicitly return `false` from `has()` — the container discovers them lazily through reflection when you call `make()`.
 
+The container also **registers itself**: a constructor dependency typed `Altair\Container\Container` or `Psr\Container\ContainerInterface` resolves to the active container instance, so service-locator-style classes receive the real container (with all its bindings) rather than a fresh, empty one. You do not need to `share($container)` yourself — that call is now a harmless no-op. Because self-resolution is a guarantee, `define()`, `delegate()`, and `prepare()` reject the container's own identifiers (they would otherwise be silently ignored); use `alias()` if you genuinely need to substitute the PSR-11 interface with a different implementation.
+
 The design deliberately differs from Symfony's compiled container and Laravel's IoC container in one key regard: there is no build or warmup step. Bindings are registered at runtime, reflection is cached in memory, and the container can be reconfigured between requests if your application needs that flexibility. The trade-off is that the container is more explicit about what it knows: `has()` only covers explicitly registered identifiers, not every auto-wirable class in the codebase.
 
 The framework's own configuration layer (`univeros/configuration`) standardises how packages register bindings: each package ships one or more classes that implement `Altair\Configuration\Contracts\ConfigurationInterface`, whose single method `apply(Container $container): void` adds aliases, delegates, and shares to a container instance passed from the application bootstrap. This convention lets you compose your container's wiring from independent units without a monolithic service-provider file.
@@ -561,7 +563,7 @@ If you are migrating from a very old revision of the framework (pre-2024), verif
 
 - **Cyclic dependencies throw immediately.** The `$making` guard detects direct and transitive cycles (A→B→A, A→B→C→A) and throws `InjectionException('Cyclic dependency detected')`. There is no lazy-proxy mechanism to break cycles; you must refactor the dependency graph.
 
-- **`has()` only covers explicitly registered identifiers.** A concrete class that has never been passed to `alias()`, `share()`, `delegate()`, or `define()` returns `false` from `has()`, even though `make()` will succeed for it via auto-wiring. Do not use `has()` as a general "can I make this?" probe.
+- **`has()` only covers aliases, shares, and delegates.** It is backed by `isset()`, which checks those three collections — *not* class definitions or parameter definitions. So a class given only construction directives via `define()`, or never registered at all, returns `false` from `has()` even though `make()` will succeed for it via auto-wiring. Do not use `has()` as a general "can I make this?" probe.
 
 - **One prepare per name.** Calling `prepare(Foo::class, $callable)` a second time silently replaces the first callable. There is no stacking of multiple prepares for the same class or interface name.
 

--- a/src/Altair/Bootstrap/resources/skeleton/config/container.php
+++ b/src/Altair/Bootstrap/resources/skeleton/config/container.php
@@ -6,11 +6,12 @@ use Altair\Configuration\Contracts\ConfigurationInterface;
 use Altair\Container\Container;
 
 /*
- * Boot factory: build the container, bind it to itself (so collaborators can
- * receive it), and apply the Configuration chain. Returns the ready container.
+ * Boot factory: build the container and apply the Configuration chain.
+ * The container resolves its own type to itself, so collaborators that depend
+ * on Container / ContainerInterface receive it without any explicit binding.
+ * Returns the ready container.
  */
 $container = new Container();
-$container->share($container);
 
 /** @var list<ConfigurationInterface> $configurations */
 $configurations = require __DIR__ . '/configurations.php';

--- a/src/Altair/Container/Container.php
+++ b/src/Altair/Container/Container.php
@@ -54,6 +54,13 @@ class Container implements ContainerInterface
      */
     protected $making = [];
 
+    /**
+     * Normalized identifiers that resolve to this container instance.
+     *
+     * @var array<string, true>
+     */
+    protected array $selfNames = [];
+
     protected ExecutableBuilder $executableBuilder;
 
     protected ArgumentsBuilder $argumentsBuilder;
@@ -81,6 +88,10 @@ class Container implements ContainerInterface
         $this->delegates = $delegatesCollection ?? new DelegatesCollection();
         $this->executableBuilder = $executableBuilder ?? new ExecutableBuilder($this);
         $this->argumentsBuilder = $argumentsBuilder ?? new ArgumentsBuilder($this);
+
+        foreach ([self::class, static::class, ContainerInterface::class] as $name) {
+            $this->selfNames[$this->normalizeName($name)] = true;
+        }
     }
 
     /**
@@ -116,6 +127,7 @@ class Container implements ContainerInterface
     public function define(string $name, Definition $definition): Container
     {
         [, $normalizedClass] = $this->aliases->resolve($name);
+        $this->guardNotSelfName($normalizedClass, $name);
         $this->classDefinitions->put($normalizedClass, $definition);
 
         return $this;
@@ -163,6 +175,14 @@ class Container implements ContainerInterface
      */
     public function share(mixed $nameOrInstance): Container
     {
+        // The container already resolves its own type to the active instance,
+        // so sharing it again is a harmless no-op (kept for backward
+        // compatibility) — and crucially it stays out of the shares collection
+        // so introspection never reports the container as a realised singleton.
+        if ($nameOrInstance === $this) {
+            return $this;
+        }
+
         if (\is_string($nameOrInstance)) {
             $this->shares->shareClass($nameOrInstance, $this->aliases);
         } elseif (\is_object($nameOrInstance)) {
@@ -198,6 +218,7 @@ class Container implements ContainerInterface
         }
 
         [, $normalizedClass] = $this->aliases->resolve($name);
+        $this->guardNotSelfName($normalizedClass, $name);
         $this->prepares[$normalizedClass] = $callableOrMethodStr;
 
         return $this;
@@ -235,6 +256,7 @@ class Container implements ContainerInterface
         }
 
         $normalizedName = $this->normalizeName($name);
+        $this->guardNotSelfName($normalizedName, $name);
         $this->delegates->put($normalizedName, $callableOrMethodStr);
 
         return $this;
@@ -249,6 +271,10 @@ class Container implements ContainerInterface
     public function make(string $name, ?Definition $definition = null)
     {
         [$className, $normalizedClass] = $this->aliases->resolve($name);
+
+        if (isset($this->selfNames[$normalizedClass])) {
+            return $this;
+        }
 
         if (isset($this->making[$normalizedClass])) {
             throw new InjectionException(
@@ -349,7 +375,8 @@ class Container implements ContainerInterface
     {
         $name = $this->normalizeName($name);
 
-        return isset($this->aliases[$name]) ||
+        return isset($this->selfNames[$name]) ||
+            isset($this->aliases[$name]) ||
             isset($this->delegates[$name]) ||
             isset($this->shares[$name]);
     }
@@ -455,5 +482,25 @@ class Container implements ContainerInterface
         }
 
         return new $className();
+    }
+
+    /**
+     * Reject custom bindings for the container's own identifiers — they would
+     * be silently ignored, since `make()` resolves those names to the active
+     * instance before consulting definitions, delegates, or prepares. Callers
+     * who need to substitute the PSR-11 interface should use `alias()` instead.
+     *
+     * @throws InvalidArgumentException
+     */
+    private function guardNotSelfName(string $normalizedName, string $originalName): void
+    {
+        if (isset($this->selfNames[$normalizedName])) {
+            throw new InvalidArgumentException(
+                \sprintf(
+                    "Cannot register a custom binding for '%s': the container always resolves its own type to the active instance. Use alias() to substitute the interface.",
+                    $originalName
+                )
+            );
+        }
     }
 }

--- a/src/Altair/Container/Reflection/CachedReflection.php
+++ b/src/Altair/Container/Reflection/CachedReflection.php
@@ -120,20 +120,6 @@ class CachedReflection implements ReflectionInterface
             }
         }
 
-        /*if (false !== $typeHint) {
-            return (string)$typeHint;
-        }
-
-        if ($reflectionClass = $parameter->getClass()) {
-            $typeHint = $reflectionClass->getName();
-            $classKey = ReflectionCacheInterface::CLASSES_KEY_PREFIX . strtolower($typeHint);
-            $this->cache->put($classKey, $reflectionClass);
-        } else {
-            $typeHint = null;
-        }
-
-        $this->cache->put($key, $typeHint);*/
-
         return $typeHint;
     }
 

--- a/tests/Container/ContainerTest.php
+++ b/tests/Container/ContainerTest.php
@@ -5,6 +5,7 @@ use Altair\Container\Exception\InjectionException;
 use Altair\Container\Exception\InvalidArgumentException;
 use Altair\Container\Container;
 use Altair\Container\Definition;
+use Psr\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -414,5 +415,74 @@ class ContainerTest extends TestCase
         );
         $obj = $container->make(PreparesImplementationTest::class);
         $this->assertSame(42, $obj->testProp);
+    }
+
+    public function testMakeResolvesConcreteContainerToItself(): void
+    {
+        $container = new Container();
+
+        $this->assertSame($container, $container->make(Container::class));
+    }
+
+    public function testMakeResolvesPsrContainerInterfaceToItself(): void
+    {
+        $container = new Container();
+
+        $this->assertSame($container, $container->make(ContainerInterface::class));
+    }
+
+    public function testInjectsItselfIntoConcreteContainerDependency(): void
+    {
+        $container = new Container();
+
+        $dependent = $container->make(NeedsConcreteContainer::class);
+
+        $this->assertSame($container, $dependent->container);
+    }
+
+    public function testInjectsItselfIntoPsrContainerInterfaceDependency(): void
+    {
+        $container = new Container();
+        // A binding only the real container knows about: if a fresh, empty
+        // container were injected instead, this alias would be absent.
+        $container->alias(DepInterface::class, DepImplementation::class);
+
+        $dependent = $container->make(NeedsContainerInterface::class);
+
+        $this->assertSame($container, $dependent->container);
+        $this->assertInstanceOf(DepImplementation::class, $dependent->container->make(DepInterface::class));
+    }
+
+    public function testSharingTheContainerItselfIsANoOpAndDoesNotPolluteShares(): void
+    {
+        $container = new Container();
+
+        $this->assertSame($container, $container->share($container));
+        // The container must not appear as a realised singleton in its shares.
+        $this->assertCount(0, $container->getShares());
+    }
+
+    public function testDefineRejectsContainerSelfName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $container = new Container();
+        $container->define(ContainerInterface::class, new Definition([]));
+    }
+
+    public function testDelegateRejectsContainerSelfName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $container = new Container();
+        $container->delegate(Container::class, fn(): Container => new Container());
+    }
+
+    public function testPrepareRejectsContainerSelfName(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $container = new Container();
+        $container->prepare(ContainerInterface::class, function ($obj, $container): void {});
     }
 }

--- a/tests/Container/fixtures.php
+++ b/tests/Container/fixtures.php
@@ -740,3 +740,17 @@ class ParentWithConstructor
 class ChildWithoutConstructor extends ParentWithConstructor
 {
 }
+
+class NeedsContainerInterface
+{
+    public function __construct(public readonly \Psr\Container\ContainerInterface $container)
+    {
+    }
+}
+
+class NeedsConcreteContainer
+{
+    public function __construct(public readonly Container $container)
+    {
+    }
+}


### PR DESCRIPTION
## Summary
The DI container never registered itself. A constructor dependency typed `Altair\Container\Container` silently auto-wired a **fresh, empty** container, and one typed `Psr\Container\ContainerInterface` threw *"is not instantiable"*. The framework papered over this by calling `$container->share($container)` at bootstrap.

This makes the container resolve its own type to the active instance:

- A normalized `selfNames` set (covering `self::class`, the runtime class, and `ContainerInterface::class`) is checked in `make()` and `isset()` — so PSR-11 `has()`/`get()` are correct too.
- Resolution stays **out of the `shares` collection**, so introspection (`ContainerInspector` / Observatory `ContainerPanel` / Tinker `ContainerCaster`) never reports the container as a "realised singleton". `share($container)` is now a harmless no-op.
- `define()` / `delegate()` / `prepare()` now **reject** the container's own identifiers instead of silently ignoring them (they were unreachable after self-resolution). `alias()` remains the supported way to substitute the PSR-11 interface.

### Also in this PR
- Delete dead commented-out code in `CachedReflection::getParameterTypeHint`.
- Fix a doc inaccuracy in `docs/packages/container.md`: the `has()` bullet wrongly listed `define()` (which is **not** covered by `isset()`); document the new self-resolution + the define/delegate/prepare guard.
- Drop the now-redundant `$container->share($container)` from the skeleton bootstrap template (and fix its comment).

## Test plan
- [x] 8 new container tests: concrete + interface resolve to `$this`; injected into ctor deps; `share($this)` is a no-op and doesn't pollute shares; define/delegate/prepare reject self-names.
- [x] Full suite green except known env-only failures (ext-mongodb/redis/memcached, tsc/mypy); the 4 introspection/observatory/tinker "empty container" tests stay green.
- [x] phpstan L8 / php-cs-fixer / rector all clean cache-free.
- [x] Independently code-reviewed (the HIGH silent-swallow finding is addressed by the guard).