### PR TITLE
feat: Persistence read models (DataObjectHydrator + EntityManager::readModel)

### DIFF
--- a/.agent/packages/persistence.md
+++ b/.agent/packages/persistence.md
@@ -6,9 +6,15 @@
 
 | Interface | Method | Returns | Notes |
 |---|---|---|---|
-| `EntityManagerInterface` | `repository(string)` | `RepositoryInterface` |  |
+| `EntityManagerInterface` | `readModel(string, string)` | `ReadModelRepositoryInterface` |  |
+|  | `repository(string)` | `RepositoryInterface` |  |
 |  | `unitOfWork()` | `UnitOfWorkInterface` |  |
 | `HydratorInterface` | `hydrate(string, array)` | `DataObjectInterface` |  |
+|  | `hydrateMany(string, iterable)` | `array` |  |
+| `ReadModelRepositoryInterface` | `find(string\|int)` | `DataObjectInterface\|null` |  |
+|  | `findAll()` | `array` |  |
+|  | `findBy(array)` | `array` |  |
+|  | `findOneBy(array)` | `DataObjectInterface\|null` |  |
 | `RepositoryInterface` | `delete(object)` | `void` |  |
 |  | `find(string\|int)` | `object\|null` |  |
 |  | `findAll()` | `iterable` |  |
@@ -26,6 +32,7 @@
 - `AttributeSchemaProvider` _(final)_ — implements `SchemaProviderInterface`
 - `CycleEntityManager` _(final)_ — implements `EntityManagerInterface`
 - `CycleOrmConfiguration` _(final)_ — implements `ConfigurationInterface`
+- `CycleReadModelRepository` _(final)_ — implements `ReadModelRepositoryInterface`
 - `CycleRepository` — implements `RepositoryInterface`
 - `CycleUnitOfWork` _(final)_ — implements `UnitOfWorkInterface`
 - `DataObjectHydrator` _(final)_ — implements `HydratorInterface`
@@ -44,6 +51,7 @@
 - `tests/Persistence/Configuration/DatabaseConnectionFactoryTest.php`
 - `tests/Persistence/Configuration/DatabaseSettingsTest.php`
 - `tests/Persistence/Cycle/CycleEntityManagerTest.php`
+- `tests/Persistence/Cycle/CycleReadModelRepositoryTest.php`
 - `tests/Persistence/Cycle/CycleRepositoryTest.php`
 - `tests/Persistence/Dto/DataObjectHydratorTest.php`
 

--- a/.agent/packages/persistence.md
+++ b/.agent/packages/persistence.md
@@ -8,6 +8,7 @@
 |---|---|---|---|
 | `EntityManagerInterface` | `repository(string)` | `RepositoryInterface` |  |
 |  | `unitOfWork()` | `UnitOfWorkInterface` |  |
+| `HydratorInterface` | `hydrate(string, array)` | `DataObjectInterface` |  |
 | `RepositoryInterface` | `delete(object)` | `void` |  |
 |  | `find(string\|int)` | `object\|null` |  |
 |  | `findAll()` | `iterable` |  |
@@ -27,6 +28,7 @@
 - `CycleOrmConfiguration` _(final)_ — implements `ConfigurationInterface`
 - `CycleRepository` — implements `RepositoryInterface`
 - `CycleUnitOfWork` _(final)_ — implements `UnitOfWorkInterface`
+- `DataObjectHydrator` _(final)_ — implements `HydratorInterface`
 - `DatabaseConnectionFactory` _(final)_
 - `DatabaseSettings` _(final)_
 - `MigrateCommand` _(final)_
@@ -43,6 +45,7 @@
 - `tests/Persistence/Configuration/DatabaseSettingsTest.php`
 - `tests/Persistence/Cycle/CycleEntityManagerTest.php`
 - `tests/Persistence/Cycle/CycleRepositoryTest.php`
+- `tests/Persistence/Dto/DataObjectHydratorTest.php`
 
 ## Related packages
 
@@ -55,3 +58,4 @@
 - `univeros/cli`
 - `univeros/configuration`
 - `univeros/container`
+- `univeros/data`

--- a/docs/packages/persistence.md
+++ b/docs/packages/persistence.md
@@ -196,6 +196,34 @@ $container->delegate(
 
 In tests and during local development, bind `AttributeSchemaProvider` directly and let it recompile on each construction — convenient, slow, but the slowness rarely matters under `phpunit`.
 
+### Read models (DTO hydration)
+
+Cycle entities are mutable, managed objects. When you want to hand a caller an immutable read model instead — an `Altair\Data\DataObjectInterface` carrying just the fields a view or API response needs — use `DataObjectHydrator`. This is the bridge the Data package deliberately does not provide: `Data` assigns values as-is (its typed-property writes reject a mismatched type), so **type coercion lives here, in the persistence layer**, never in `Data`. The dependency arrow is one-way — `univeros/persistence` depends on `univeros/data`, never the reverse.
+
+`hydrate()` reflects the target Data object's declared property types and coerces each matching value before construction:
+
+```php
+use Altair\Persistence\Dto\DataObjectHydrator;
+
+$hydrator = new DataObjectHydrator();
+
+// $row is a storage row — everything stringy, as a driver returns it.
+$row = ['id' => '42', 'name' => 'Vega', 'active' => '1', 'created_at' => '2026-01-15 09:00:00'];
+
+$profile = $hydrator->hydrate(ProfileDto::class, $row);
+// $profile->id === 42 (int), $profile->active === true (bool),
+// $profile->created_at instanceof DateTimeImmutable
+```
+
+Coercion rules: numeric strings to `int`/`float`; `0`/`1`/`"true"`/`"false"` to `bool` (via `FILTER_VALIDATE_BOOLEAN`); scalars and `Stringable` to `string`; date strings/timestamps to `DateTimeImmutable`/`DateTime`. A property typed as another `DataObjectInterface` is hydrated recursively from a nested array — this is how composed read-models (the read-side of a relation) are expressed:
+
+```php
+$row = ['id' => 1, 'address' => ['city' => 'New York', 'zip' => '10001']];
+$profile = $hydrator->hydrate(ProfileDto::class, $row); // $profile->address instanceof AddressDto
+```
+
+`null` passes through untouched, keys with no matching property are dropped, and a value that cannot satisfy its declared type throws `HydrationException` (a `PersistenceExceptionInterface`) naming the offending field — rather than letting a raw `TypeError` escape from the constructor. Type against `HydratorInterface` so the hydrator stays swappable.
+
 ## CLI
 
 The package ships four `bin/altair db:*` commands. They auto-load when the framework's CLI binary picks up `src/Altair/Persistence/Cli` (already wired in `bin/altair`).
@@ -317,3 +345,4 @@ What you should **not** extend: `CycleEntityManager` is `final`. Replace it via 
 - **Doctrine bridge.** Not in this package. A separate `univeros/doctrine` could implement the same contracts; the wrap is already shaped for it.
 - **`--dry-run` SQL preview.** `db:migrate --dry-run` currently lists pending migration names. A per-migration SQL dump is a follow-up — Cycle's `Migrator` does not expose a non-destructive SQL preview out of the box.
 - **Postgres / MySQL CI matrix.** Tests today exercise in-memory SQLite. Real-driver integration tests are tracked as a follow-up on the original issue.
+- **DTO hydration scope.** `DataObjectHydrator` coerces against a single declared property type; union and intersection types are passed through for PHP to enforce. It does not auto-project a Cycle entity into a Data object — feed it a row array (`select()->fetchData()`, a query result, or `$entity` mapped to an array). A repository-level read-model layer that returns Data objects directly is a follow-up.

--- a/docs/packages/persistence.md
+++ b/docs/packages/persistence.md
@@ -196,33 +196,50 @@ $container->delegate(
 
 In tests and during local development, bind `AttributeSchemaProvider` directly and let it recompile on each construction — convenient, slow, but the slowness rarely matters under `phpunit`.
 
-### Read models (DTO hydration)
+### Read models
 
-Cycle entities are mutable, managed objects. When you want to hand a caller an immutable read model instead — an `Altair\Data\DataObjectInterface` carrying just the fields a view or API response needs — use `DataObjectHydrator`. This is the bridge the Data package deliberately does not provide: `Data` assigns values as-is (its typed-property writes reject a mismatched type), so **type coercion lives here, in the persistence layer**, never in `Data`. The dependency arrow is one-way — `univeros/persistence` depends on `univeros/data`, never the reverse.
+Cycle entities are mutable, managed objects. When a caller only needs to *read* — a view, an API response — hand it an immutable `Altair\Data\DataObjectInterface` instead. The entity manager is the entry point for the read side just as it is for writes:
 
-`hydrate()` reflects the target Data object's declared property types and coerces each matching value before construction:
+```php
+// $em is the EntityManagerInterface.
+$users = $em->readModel(User::class, UserProfileDto::class);
+
+$one  = $users->find(42);                       // ?UserProfileDto
+$some = $users->findBy(['role' => 'admin']);    // list<UserProfileDto>
+$all  = $users->findAll();                      // list<UserProfileDto>
+```
+
+`readModel()` returns a `ReadModelRepositoryInterface` — `find` / `findOneBy` / `findBy` / `findAll`, no writes. Writes stay on the entity `RepositoryInterface` and the unit of work; reads come back as Data objects. The Cycle implementation selects **raw rows** (`Select::fetchData()`) rather than managed entities, so reads skip the identity map — the right trade for the read side.
+
+#### Coercion (the hydrator underneath)
+
+Each row is projected through a `HydratorInterface` (`DataObjectHydrator` by default, bound in `CycleOrmConfiguration` and swappable). This is the bridge the Data package deliberately does not provide: `Data` assigns values as-is (its typed-property writes reject a mismatched type), so **type coercion lives here, in the persistence layer**, never in `Data`. The dependency arrow is one-way — `univeros/persistence` depends on `univeros/data`, never the reverse.
+
+You can also use the hydrator directly on any array — a custom query result, a cache payload:
 
 ```php
 use Altair\Persistence\Dto\DataObjectHydrator;
 
 $hydrator = new DataObjectHydrator();
 
-// $row is a storage row — everything stringy, as a driver returns it.
-$row = ['id' => '42', 'name' => 'Vega', 'active' => '1', 'created_at' => '2026-01-15 09:00:00'];
-
-$profile = $hydrator->hydrate(ProfileDto::class, $row);
+// A storage row — everything stringy, as a driver returns it.
+$profile = $hydrator->hydrate(ProfileDto::class, [
+    'id' => '42', 'name' => 'Vega', 'active' => '1', 'created_at' => '2026-01-15 09:00:00',
+]);
 // $profile->id === 42 (int), $profile->active === true (bool),
 // $profile->created_at instanceof DateTimeImmutable
+
+$many = $hydrator->hydrateMany(ProfileDto::class, $rows); // list<ProfileDto>
 ```
 
-Coercion rules: numeric strings to `int`/`float`; `0`/`1`/`"true"`/`"false"` to `bool` (via `FILTER_VALIDATE_BOOLEAN`); scalars and `Stringable` to `string`; date strings/timestamps to `DateTimeImmutable`/`DateTime`. A property typed as another `DataObjectInterface` is hydrated recursively from a nested array — this is how composed read-models (the read-side of a relation) are expressed:
+Coercion rules: numeric strings to `int`/`float`; `0`/`1`/`"true"`/`"false"` to `bool` (via `FILTER_VALIDATE_BOOLEAN`); scalars and `Stringable` to `string`; date strings/timestamps to `DateTimeImmutable`/`DateTime`. A property typed as another `DataObjectInterface` is hydrated recursively from a nested array — this is how composed read-models (the read side of a relation) are expressed:
 
 ```php
 $row = ['id' => 1, 'address' => ['city' => 'New York', 'zip' => '10001']];
 $profile = $hydrator->hydrate(ProfileDto::class, $row); // $profile->address instanceof AddressDto
 ```
 
-`null` passes through untouched, keys with no matching property are dropped, and a value that cannot satisfy its declared type throws `HydrationException` (a `PersistenceExceptionInterface`) naming the offending field — rather than letting a raw `TypeError` escape from the constructor. Type against `HydratorInterface` so the hydrator stays swappable.
+`null` passes through untouched, keys with no matching property are dropped, and a value that cannot satisfy its declared type throws `HydrationException` (a `PersistenceExceptionInterface`) naming the offending field — rather than letting a raw `TypeError` escape from the constructor.
 
 ## CLI
 
@@ -345,4 +362,4 @@ What you should **not** extend: `CycleEntityManager` is `final`. Replace it via 
 - **Doctrine bridge.** Not in this package. A separate `univeros/doctrine` could implement the same contracts; the wrap is already shaped for it.
 - **`--dry-run` SQL preview.** `db:migrate --dry-run` currently lists pending migration names. A per-migration SQL dump is a follow-up — Cycle's `Migrator` does not expose a non-destructive SQL preview out of the box.
 - **Postgres / MySQL CI matrix.** Tests today exercise in-memory SQLite. Real-driver integration tests are tracked as a follow-up on the original issue.
-- **DTO hydration scope.** `DataObjectHydrator` coerces against a single declared property type; union and intersection types are passed through for PHP to enforce. It does not auto-project a Cycle entity into a Data object — feed it a row array (`select()->fetchData()`, a query result, or `$entity` mapped to an array). A repository-level read-model layer that returns Data objects directly is a follow-up.
+- **Read-model scope.** `readModel()` projects a single entity role's rows; joined/eager-loaded relations are not auto-mapped into nested Data objects yet (the hydrator *will* compose a nested `DataObjectInterface` when a row already carries the relation as an array — e.g. from a custom `Select` with `->load()`). The hydrator coerces against a single declared property type; union and intersection types are passed through for PHP to enforce.

--- a/src/Altair/Persistence/Configuration/CycleOrmConfiguration.php
+++ b/src/Altair/Persistence/Configuration/CycleOrmConfiguration.php
@@ -15,10 +15,12 @@ use Altair\Configuration\Contracts\ConfigurationInterface;
 use Altair\Configuration\Support\Env;
 use Altair\Container\Container;
 use Altair\Persistence\Contracts\EntityManagerInterface;
+use Altair\Persistence\Contracts\HydratorInterface;
 use Altair\Persistence\Contracts\RepositoryInterface;
 use Altair\Persistence\Contracts\UnitOfWorkInterface;
 use Altair\Persistence\Cycle\CycleEntityManager;
 use Altair\Persistence\Cycle\CycleUnitOfWork;
+use Altair\Persistence\Dto\DataObjectHydrator;
 use Altair\Persistence\Schema\SchemaProviderInterface;
 use Cycle\Database\DatabaseManager;
 use Cycle\Database\DatabaseProviderInterface;
@@ -69,6 +71,9 @@ final readonly class CycleOrmConfiguration implements ConfigurationInterface
         $container->singleton(CycleUnitOfWork::class);
         $container->alias(UnitOfWorkInterface::class, CycleUnitOfWork::class);
 
+        $container->singleton(DataObjectHydrator::class);
+        $container->alias(HydratorInterface::class, DataObjectHydrator::class);
+
         $container->factory(
             DatabaseSettings::class,
             static fn(Env $env): DatabaseSettings => DatabaseSettings::fromEnv(self::readEnv($env)),
@@ -97,7 +102,8 @@ final readonly class CycleOrmConfiguration implements ConfigurationInterface
                 ORMInterface $orm,
                 UnitOfWorkInterface $unitOfWork,
                 Container $resolver,
-            ): CycleEntityManager => new CycleEntityManager($orm, $unitOfWork, $resolver, $bindings),
+                HydratorInterface $hydrator,
+            ): CycleEntityManager => new CycleEntityManager($orm, $unitOfWork, $resolver, $hydrator, $bindings),
         )->shared();
         $container->factory(
             EntityManagerInterface::class,

--- a/src/Altair/Persistence/Contracts/EntityManagerInterface.php
+++ b/src/Altair/Persistence/Contracts/EntityManagerInterface.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Altair\Persistence\Contracts;
 
+use Altair\Data\Contracts\DataObjectInterface;
+
 /**
  * Top-level entry point for accessing repositories and the unit of work.
  *
@@ -29,6 +31,19 @@ interface EntityManagerInterface
      * @return RepositoryInterface<TEntity>
      */
     public function repository(string $entityClass): RepositoryInterface;
+
+    /**
+     * Resolve a read-only repository that projects the entity's rows into an
+     * immutable Data object — the read side of the persistence layer.
+     *
+     * @template TDataObject of DataObjectInterface
+     *
+     * @param class-string<TEntity>     $entityClass
+     * @param class-string<TDataObject> $dataObjectClass
+     *
+     * @return ReadModelRepositoryInterface<TDataObject>
+     */
+    public function readModel(string $entityClass, string $dataObjectClass): ReadModelRepositoryInterface;
 
     /**
      * Access the shared unit of work for batched writes.

--- a/src/Altair/Persistence/Contracts/HydratorInterface.php
+++ b/src/Altair/Persistence/Contracts/HydratorInterface.php
@@ -36,4 +36,18 @@ interface HydratorInterface
      * @return T
      */
     public function hydrate(string $dataObjectClass, array $data): DataObjectInterface;
+
+    /**
+     * Hydrate a collection of rows into a list of Data objects.
+     *
+     * @template T of DataObjectInterface
+     *
+     * @param class-string<T>                  $dataObjectClass
+     * @param iterable<array<string, mixed>>   $rows
+     *
+     * @throws PersistenceExceptionInterface when a value cannot satisfy the declared property type
+     *
+     * @return list<T>
+     */
+    public function hydrateMany(string $dataObjectClass, iterable $rows): array;
 }

--- a/src/Altair/Persistence/Contracts/HydratorInterface.php
+++ b/src/Altair/Persistence/Contracts/HydratorInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Persistence\Contracts;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Altair\Persistence\Exception\PersistenceExceptionInterface;
+
+/**
+ * Projects a storage row (or any associative array) into a typed, immutable
+ * {@see DataObjectInterface}, coercing each value to the target property's
+ * declared type.
+ *
+ * This is the read-model bridge: Cycle entities (and the Data package) stay
+ * coercion-free; type coercion and nested-object composition live here, in
+ * the persistence layer.
+ */
+interface HydratorInterface
+{
+    /**
+     * @template T of DataObjectInterface
+     *
+     * @param class-string<T>      $dataObjectClass
+     * @param array<string, mixed> $data
+     *
+     * @throws PersistenceExceptionInterface when a value cannot satisfy the declared property type
+     *
+     * @return T
+     */
+    public function hydrate(string $dataObjectClass, array $data): DataObjectInterface;
+}

--- a/src/Altair/Persistence/Contracts/ReadModelRepositoryInterface.php
+++ b/src/Altair/Persistence/Contracts/ReadModelRepositoryInterface.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Persistence\Contracts;
+
+use Altair\Data\Contracts\DataObjectInterface;
+
+/**
+ * Read-only repository that returns immutable Data objects rather than managed
+ * entities — the read side of the persistence layer.
+ *
+ * Writes are not part of this contract: they go through the entity
+ * {@see RepositoryInterface} and {@see UnitOfWorkInterface}. A read model
+ * projects storage rows into {@see DataObjectInterface} read models via a
+ * {@see HydratorInterface}.
+ *
+ * @template TDataObject of DataObjectInterface
+ */
+interface ReadModelRepositoryInterface
+{
+    /**
+     * Locate a single read model by primary key.
+     *
+     * @return TDataObject|null
+     */
+    public function find(int|string $id): ?DataObjectInterface;
+
+    /**
+     * Locate the first read model matching the given criteria.
+     *
+     * @param array<string, mixed> $criteria
+     *
+     * @return TDataObject|null
+     */
+    public function findOneBy(array $criteria): ?DataObjectInterface;
+
+    /**
+     * Locate every read model matching the given criteria.
+     *
+     * @param array<string, mixed> $criteria
+     *
+     * @return list<TDataObject>
+     */
+    public function findBy(array $criteria): array;
+
+    /**
+     * Locate every read model in the underlying storage.
+     *
+     * @return list<TDataObject>
+     */
+    public function findAll(): array;
+}

--- a/src/Altair/Persistence/Cycle/CycleEntityManager.php
+++ b/src/Altair/Persistence/Cycle/CycleEntityManager.php
@@ -11,9 +11,13 @@ declare(strict_types=1);
 
 namespace Altair\Persistence\Cycle;
 
+use Altair\Data\Contracts\DataObjectInterface;
 use Altair\Persistence\Contracts\EntityManagerInterface;
+use Altair\Persistence\Contracts\HydratorInterface;
+use Altair\Persistence\Contracts\ReadModelRepositoryInterface;
 use Altair\Persistence\Contracts\RepositoryInterface;
 use Altair\Persistence\Contracts\UnitOfWorkInterface;
+use Altair\Persistence\Dto\DataObjectHydrator;
 use Cycle\ORM\ORMInterface;
 use Override;
 use Psr\Container\ContainerInterface;
@@ -40,6 +44,7 @@ final readonly class CycleEntityManager implements EntityManagerInterface
         private ORMInterface $orm,
         private UnitOfWorkInterface $unitOfWork,
         private ContainerInterface $container,
+        private ?HydratorInterface $hydrator = null,
         private array $repositoryBindings = [],
     ) {}
 
@@ -55,6 +60,25 @@ final readonly class CycleEntityManager implements EntityManagerInterface
 
         /** @var class-string<TEntity> $entityClass */
         return new CycleRepository($entityClass, $this->orm, $this->unitOfWork);
+    }
+
+    /**
+     * @template TDataObject of DataObjectInterface
+     *
+     * @param class-string<TEntity>     $entityClass
+     * @param class-string<TDataObject> $dataObjectClass
+     *
+     * @return ReadModelRepositoryInterface<TDataObject>
+     */
+    #[Override]
+    public function readModel(string $entityClass, string $dataObjectClass): ReadModelRepositoryInterface
+    {
+        return new CycleReadModelRepository(
+            $entityClass,
+            $dataObjectClass,
+            $this->orm,
+            $this->hydrator ?? new DataObjectHydrator(),
+        );
     }
 
     #[Override]

--- a/src/Altair/Persistence/Cycle/CycleReadModelRepository.php
+++ b/src/Altair/Persistence/Cycle/CycleReadModelRepository.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Persistence\Cycle;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Altair\Persistence\Contracts\HydratorInterface;
+use Altair\Persistence\Contracts\ReadModelRepositoryInterface;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Select;
+use Override;
+
+/**
+ * Cycle-backed read model: selects raw rows for an entity role and projects
+ * each one into an immutable Data object through the hydrator.
+ *
+ * Reads bypass the identity map — {@see Select::fetchData()} returns plain
+ * arrays rather than managed entities — which is what you want for the read
+ * side. Coercion and nested-object composition are handled by the hydrator.
+ *
+ * @template TDataObject of DataObjectInterface
+ *
+ * @implements ReadModelRepositoryInterface<TDataObject>
+ */
+final readonly class CycleReadModelRepository implements ReadModelRepositoryInterface
+{
+    /**
+     * @param class-string             $entityClass     the Cycle entity role to read from
+     * @param class-string<TDataObject> $dataObjectClass the Data object to project rows into
+     */
+    public function __construct(
+        private string $entityClass,
+        private string $dataObjectClass,
+        private ORMInterface $orm,
+        private HydratorInterface $hydrator,
+    ) {}
+
+    #[Override]
+    public function find(int|string $id): ?DataObjectInterface
+    {
+        $row = $this->firstRow($this->select()->wherePK($id));
+
+        return $row === null ? null : $this->hydrator->hydrate($this->dataObjectClass, $row);
+    }
+
+    #[Override]
+    public function findOneBy(array $criteria): ?DataObjectInterface
+    {
+        $row = $this->firstRow($this->select()->where($criteria));
+
+        return $row === null ? null : $this->hydrator->hydrate($this->dataObjectClass, $row);
+    }
+
+    #[Override]
+    public function findBy(array $criteria): array
+    {
+        /** @var iterable<array<string, mixed>> $rows */
+        $rows = $this->select()->where($criteria)->fetchData();
+
+        return $this->hydrator->hydrateMany($this->dataObjectClass, $rows);
+    }
+
+    #[Override]
+    public function findAll(): array
+    {
+        /** @var iterable<array<string, mixed>> $rows */
+        $rows = $this->select()->fetchData();
+
+        return $this->hydrator->hydrateMany($this->dataObjectClass, $rows);
+    }
+
+    /**
+     * @return Select<object>
+     */
+    private function select(): Select
+    {
+        return new Select($this->orm, $this->entityClass);
+    }
+
+    /**
+     * @param Select<object> $select
+     *
+     * @return array<string, mixed>|null
+     */
+    private function firstRow(Select $select): ?array
+    {
+        foreach ($select->fetchData() as $row) {
+            /** @var array<string, mixed> $row */
+            return $row;
+        }
+
+        return null;
+    }
+}

--- a/src/Altair/Persistence/Dto/DataObjectHydrator.php
+++ b/src/Altair/Persistence/Dto/DataObjectHydrator.php
@@ -73,6 +73,25 @@ final class DataObjectHydrator implements HydratorInterface
         return $instance;
     }
 
+    /**
+     * @template T of DataObjectInterface
+     *
+     * @param class-string<T>                $dataObjectClass
+     * @param iterable<array<string, mixed>> $rows
+     *
+     * @return list<T>
+     */
+    #[Override]
+    public function hydrateMany(string $dataObjectClass, iterable $rows): array
+    {
+        $result = [];
+        foreach ($rows as $row) {
+            $result[] = $this->hydrate($dataObjectClass, $row);
+        }
+
+        return $result;
+    }
+
     private function coerce(mixed $value, ?ReflectionType $type, string $class, string $field): mixed
     {
         // Null passes through untouched; union/intersection types are left for

--- a/src/Altair/Persistence/Dto/DataObjectHydrator.php
+++ b/src/Altair/Persistence/Dto/DataObjectHydrator.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Persistence\Dto;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Altair\Persistence\Contracts\HydratorInterface;
+use Altair\Persistence\Exception\HydrationException;
+use DateTime;
+use DateTimeImmutable;
+use DateTimeInterface;
+use Exception;
+
+use const FILTER_NULL_ON_FAILURE;
+use const FILTER_VALIDATE_BOOLEAN;
+
+use Override;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionType;
+use Stringable;
+
+/**
+ * Reflection-driven hydrator that coerces a storage row into a typed,
+ * immutable {@see DataObjectInterface}.
+ *
+ * Each incoming value is coerced to the declared type of the matching
+ * property before construction, so the Data object's typed-property writes
+ * never see a mismatched type. Nested {@see DataObjectInterface} properties
+ * are hydrated recursively from an array, which is how composed read-models
+ * ("relations") are expressed. Keys with no matching property are dropped.
+ */
+final class DataObjectHydrator implements HydratorInterface
+{
+    /**
+     * @template T of DataObjectInterface
+     *
+     * @param class-string<T>      $dataObjectClass
+     * @param array<string, mixed> $data
+     *
+     * @return T
+     */
+    #[Override]
+    public function hydrate(string $dataObjectClass, array $data): DataObjectInterface
+    {
+        $reflection = new ReflectionClass($dataObjectClass);
+
+        $coerced = [];
+        foreach ($data as $key => $value) {
+            if (!$reflection->hasProperty($key)) {
+                continue;
+            }
+
+            $coerced[$key] = $this->coerce(
+                $value,
+                $reflection->getProperty($key)->getType(),
+                $dataObjectClass,
+                $key,
+            );
+        }
+
+        /** @var T $instance */
+        $instance = new $dataObjectClass($coerced);
+
+        return $instance;
+    }
+
+    private function coerce(mixed $value, ?ReflectionType $type, string $class, string $field): mixed
+    {
+        // Null passes through untouched; union/intersection types are left for
+        // PHP to enforce (coercion targets a single declared type only).
+        if ($value === null || !$type instanceof ReflectionNamedType) {
+            return $value;
+        }
+
+        $name = $type->getName();
+
+        if ($type->isBuiltin()) {
+            return $this->coerceBuiltin($value, $name, $class, $field);
+        }
+
+        if (is_a($name, DateTimeInterface::class, true)) {
+            return $this->coerceDateTime($value, $name, $class, $field);
+        }
+
+        if (is_a($name, DataObjectInterface::class, true)) {
+            if ($value instanceof DataObjectInterface) {
+                return $value;
+            }
+
+            if (\is_array($value)) {
+                /** @var array<string, mixed> $value */
+                return $this->hydrate($name, $value);
+            }
+
+            throw HydrationException::uncoercible($class, $field, $name, $value);
+        }
+
+        if ($value instanceof $name) {
+            return $value;
+        }
+
+        throw HydrationException::uncoercible($class, $field, $name, $value);
+    }
+
+    private function coerceBuiltin(mixed $value, string $type, string $class, string $field): mixed
+    {
+        switch ($type) {
+            case 'int':
+                if (\is_int($value)) {
+                    return $value;
+                }
+
+                if (\is_string($value) && preg_match('/^-?\d+$/', $value) === 1) {
+                    return (int) $value;
+                }
+
+                throw HydrationException::uncoercible($class, $field, 'int', $value);
+            case 'float':
+                if (\is_int($value) || \is_float($value)) {
+                    return (float) $value;
+                }
+
+                if (\is_string($value) && is_numeric($value)) {
+                    return (float) $value;
+                }
+
+                throw HydrationException::uncoercible($class, $field, 'float', $value);
+            case 'bool':
+                if (\is_bool($value)) {
+                    return $value;
+                }
+
+                $bool = filter_var($value, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+                if ($bool === null) {
+                    throw HydrationException::uncoercible($class, $field, 'bool', $value);
+                }
+
+                return $bool;
+            case 'string':
+                if (\is_string($value)) {
+                    return $value;
+                }
+
+                if (\is_int($value) || \is_float($value) || \is_bool($value) || $value instanceof Stringable) {
+                    return (string) $value;
+                }
+
+                throw HydrationException::uncoercible($class, $field, 'string', $value);
+            case 'array':
+                if (\is_array($value)) {
+                    return $value;
+                }
+
+                throw HydrationException::uncoercible($class, $field, 'array', $value);
+            default:
+                // mixed / object / iterable / callable — nothing to coerce.
+                return $value;
+        }
+    }
+
+    private function coerceDateTime(mixed $value, string $name, string $class, string $field): mixed
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value;
+        }
+
+        try {
+            if (\is_int($value)) {
+                return new DateTimeImmutable('@' . $value);
+            }
+
+            if (\is_string($value) && $value !== '') {
+                return $name === DateTime::class ? new DateTime($value) : new DateTimeImmutable($value);
+            }
+        } catch (Exception) {
+            throw HydrationException::uncoercible($class, $field, $name, $value);
+        }
+
+        throw HydrationException::uncoercible($class, $field, $name, $value);
+    }
+}

--- a/src/Altair/Persistence/Exception/HydrationException.php
+++ b/src/Altair/Persistence/Exception/HydrationException.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Persistence\Exception;
+
+use RuntimeException;
+
+final class HydrationException extends RuntimeException implements PersistenceExceptionInterface
+{
+    public static function uncoercible(string $dataObjectClass, string $field, string $expected, mixed $value): self
+    {
+        return new self(\sprintf(
+            'Cannot hydrate %s::$%s: value of type %s is not coercible to %s.',
+            $dataObjectClass,
+            $field,
+            get_debug_type($value),
+            $expected,
+        ));
+    }
+}

--- a/src/Altair/Persistence/composer.json
+++ b/src/Altair/Persistence/composer.json
@@ -17,7 +17,8 @@
         "spiral/tokenizer": "^3.13",
         "univeros/cli": "^2.0",
         "univeros/configuration": "^2.0",
-        "univeros/container": "^2.0"
+        "univeros/container": "^2.0",
+        "univeros/data": "^2.0"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Persistence/Cycle/CycleReadModelRepositoryTest.php
+++ b/tests/Persistence/Cycle/CycleReadModelRepositoryTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Cycle;
+
+use Altair\Persistence\Cycle\CycleEntityManager;
+use Altair\Persistence\Cycle\CycleReadModelRepository;
+use Altair\Persistence\Cycle\CycleRepository;
+use Altair\Persistence\Cycle\CycleUnitOfWork;
+use Altair\Persistence\Dto\DataObjectHydrator;
+use Altair\Tests\Persistence\Cycle\Fixture\Widget;
+use Altair\Tests\Persistence\Cycle\Fixture\WidgetDto;
+use Cycle\Database\DatabaseManager;
+use Cycle\ORM\Factory;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\ORM;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Schema;
+use Cycle\ORM\SchemaInterface;
+use Altair\Persistence\Configuration\DatabaseConnectionFactory;
+use Altair\Persistence\Configuration\DatabaseSettings;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+
+#[CoversClass(CycleReadModelRepository::class)]
+final class CycleReadModelRepositoryTest extends TestCase
+{
+    private DatabaseManager $databases;
+
+    private ORMInterface $orm;
+
+    private CycleUnitOfWork $unitOfWork;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->databases = (new DatabaseConnectionFactory())->create(new DatabaseSettings(
+            driver: DatabaseSettings::DRIVER_SQLITE,
+            database: ':memory:',
+        ));
+
+        $this->databases->database('default')->execute(
+            'CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)'
+        );
+
+        $this->orm = new ORM(new Factory($this->databases), new Schema([
+            'widget' => [
+                SchemaInterface::ENTITY => Widget::class,
+                SchemaInterface::MAPPER => Mapper::class,
+                SchemaInterface::DATABASE => 'default',
+                SchemaInterface::TABLE => 'widgets',
+                SchemaInterface::PRIMARY_KEY => ['id'],
+                SchemaInterface::COLUMNS => ['id' => 'id', 'name' => 'name'],
+                SchemaInterface::TYPECAST => ['id' => 'int'],
+                SchemaInterface::SCHEMA => [],
+                SchemaInterface::RELATIONS => [],
+            ],
+        ]));
+
+        $this->unitOfWork = new CycleUnitOfWork($this->orm);
+
+        $writes = new CycleRepository(Widget::class, $this->orm, $this->unitOfWork);
+        $writes->save(new Widget(id: 1, name: 'Alpha'));
+        $writes->save(new Widget(id: 2, name: 'Bravo'));
+    }
+
+    private function readModel(): CycleReadModelRepository
+    {
+        return new CycleReadModelRepository(Widget::class, WidgetDto::class, $this->orm, new DataObjectHydrator());
+    }
+
+    public function testFindReturnsHydratedDataObject(): void
+    {
+        $dto = $this->readModel()->find(1);
+
+        $this->assertInstanceOf(WidgetDto::class, $dto);
+        $this->assertSame(1, $dto->id);
+        $this->assertSame('Alpha', $dto->name);
+    }
+
+    public function testFindReturnsNullWhenMissing(): void
+    {
+        $this->assertNull($this->readModel()->find(999));
+    }
+
+    public function testFindOneByCriteria(): void
+    {
+        $dto = $this->readModel()->findOneBy(['name' => 'Bravo']);
+
+        $this->assertInstanceOf(WidgetDto::class, $dto);
+        $this->assertSame(2, $dto->id);
+    }
+
+    public function testFindAllReturnsEveryRowAsDataObject(): void
+    {
+        $dtos = $this->readModel()->findAll();
+
+        $this->assertCount(2, $dtos);
+        $this->assertContainsOnlyInstancesOf(WidgetDto::class, $dtos);
+
+        $names = array_map(static fn(WidgetDto $dto): ?string => $dto->name, $dtos);
+        sort($names);
+        $this->assertSame(['Alpha', 'Bravo'], $names);
+    }
+
+    public function testFindByCriteria(): void
+    {
+        $dtos = $this->readModel()->findBy(['name' => 'Alpha']);
+
+        $this->assertCount(1, $dtos);
+        $this->assertSame(1, $dtos[0]->id);
+    }
+
+    public function testReadModelObtainedThroughEntityManager(): void
+    {
+        $manager = new CycleEntityManager(
+            orm: $this->orm,
+            unitOfWork: $this->unitOfWork,
+            container: $this->createMock(ContainerInterface::class),
+            hydrator: new DataObjectHydrator(),
+        );
+
+        $dto = $manager->readModel(Widget::class, WidgetDto::class)->find(2);
+
+        $this->assertInstanceOf(WidgetDto::class, $dto);
+        $this->assertSame('Bravo', $dto->name);
+    }
+}

--- a/tests/Persistence/Cycle/Fixture/WidgetDto.php
+++ b/tests/Persistence/Cycle/Fixture/WidgetDto.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Cycle\Fixture;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Altair\Data\Traits\ImmutableAttributesAwareTrait;
+use Altair\Data\Traits\JsonSerializableAwareTrait;
+use Altair\Data\Traits\SerializeAwareTrait;
+
+final class WidgetDto implements DataObjectInterface
+{
+    use ImmutableAttributesAwareTrait;
+    use JsonSerializableAwareTrait;
+    use SerializeAwareTrait;
+
+    private ?int $id = null;
+
+    private ?string $name = null;
+}

--- a/tests/Persistence/Dto/DataObjectHydratorTest.php
+++ b/tests/Persistence/Dto/DataObjectHydratorTest.php
@@ -134,4 +134,24 @@ final class DataObjectHydratorTest extends TestCase
         // address expects an array (or AddressDto), not a scalar.
         $this->hydrator->hydrate(ProfileDto::class, ['address' => 'not-an-array']);
     }
+
+    public function testHydrateManyProjectsEveryRow(): void
+    {
+        $rows = [
+            ['id' => '1', 'name' => 'Vega'],
+            ['id' => '2', 'name' => 'Rigel'],
+        ];
+
+        $dtos = $this->hydrator->hydrateMany(ProfileDto::class, $rows);
+
+        $this->assertCount(2, $dtos);
+        $this->assertContainsOnlyInstancesOf(ProfileDto::class, $dtos);
+        $this->assertSame(1, $dtos[0]->id);
+        $this->assertSame('Rigel', $dtos[1]->name);
+    }
+
+    public function testHydrateManyReturnsEmptyListForNoRows(): void
+    {
+        $this->assertSame([], $this->hydrator->hydrateMany(ProfileDto::class, []));
+    }
 }

--- a/tests/Persistence/Dto/DataObjectHydratorTest.php
+++ b/tests/Persistence/Dto/DataObjectHydratorTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Dto;
+
+use Altair\Persistence\Dto\DataObjectHydrator;
+use Altair\Persistence\Exception\HydrationException;
+use Altair\Persistence\Exception\PersistenceExceptionInterface;
+use Altair\Tests\Persistence\Dto\Fixture\AddressDto;
+use Altair\Tests\Persistence\Dto\Fixture\ProfileDto;
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(DataObjectHydrator::class)]
+final class DataObjectHydratorTest extends TestCase
+{
+    private DataObjectHydrator $hydrator;
+
+    protected function setUp(): void
+    {
+        $this->hydrator = new DataObjectHydrator();
+    }
+
+    public function testCoercesScalarStringRowToTypedProperties(): void
+    {
+        // A row as a database driver would return it: everything stringy.
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => '42',
+            'name' => 'Vega',
+            'active' => '1',
+            'score' => '3.5',
+        ]);
+
+        $this->assertInstanceOf(ProfileDto::class, $dto);
+        $this->assertSame(42, $dto->id);
+        $this->assertSame('Vega', $dto->name);
+        $this->assertTrue($dto->active);
+        $this->assertSame(3.5, $dto->score);
+    }
+
+    public function testCoercesDateStringToDateTimeImmutable(): void
+    {
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => 1,
+            'created_at' => '2026-01-15 09:00:00',
+        ]);
+
+        $this->assertInstanceOf(DateTimeImmutable::class, $dto->created_at);
+        $this->assertSame('2026-01-15 09:00:00', $dto->created_at->format('Y-m-d H:i:s'));
+    }
+
+    public function testHydratesNestedDataObjectFromArray(): void
+    {
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => 1,
+            'address' => ['city' => 'New York', 'zip' => '10001'],
+        ]);
+
+        $this->assertInstanceOf(AddressDto::class, $dto->address);
+        $this->assertSame('New York', $dto->address->city);
+        $this->assertSame('10001', $dto->address->zip);
+    }
+
+    public function testNullValuesArePreserved(): void
+    {
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => 1,
+            'score' => null,
+            'created_at' => null,
+        ]);
+
+        $this->assertNull($dto->score);
+        $this->assertNull($dto->created_at);
+    }
+
+    public function testUnknownKeysAreIgnored(): void
+    {
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => 1,
+            'not_a_property' => 'whatever',
+        ]);
+
+        $this->assertSame(1, $dto->id);
+        $this->assertFalse($dto->has('not_a_property'));
+    }
+
+    public function testAlreadyCorrectTypesPassThrough(): void
+    {
+        $date = new DateTimeImmutable('2026-01-15 09:00:00');
+
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => 7,
+            'created_at' => $date,
+            'address' => new AddressDto(['city' => 'Oslo']),
+        ]);
+
+        $this->assertSame(7, $dto->id);
+        $this->assertSame($date, $dto->created_at);
+        $this->assertInstanceOf(AddressDto::class, $dto->address);
+        $this->assertSame('Oslo', $dto->address->city);
+    }
+
+    public function testBoolCoercionFromCommonRepresentations(): void
+    {
+        $this->assertFalse($this->hydrator->hydrate(ProfileDto::class, ['active' => '0'])->active);
+        $this->assertTrue($this->hydrator->hydrate(ProfileDto::class, ['active' => 'true'])->active);
+        $this->assertFalse($this->hydrator->hydrate(ProfileDto::class, ['active' => 0])->active);
+    }
+
+    public function testUncoercibleScalarThrowsHydrationExceptionWithFieldContext(): void
+    {
+        try {
+            $this->hydrator->hydrate(ProfileDto::class, ['id' => 'not-a-number']);
+            $this->fail('Expected HydrationException');
+        } catch (HydrationException $hydrationException) {
+            $this->assertInstanceOf(PersistenceExceptionInterface::class, $hydrationException);
+            $this->assertStringContainsString('id', $hydrationException->getMessage());
+        }
+    }
+
+    public function testUncoercibleNestedDataObjectThrows(): void
+    {
+        $this->expectException(HydrationException::class);
+
+        // address expects an array (or AddressDto), not a scalar.
+        $this->hydrator->hydrate(ProfileDto::class, ['address' => 'not-an-array']);
+    }
+}

--- a/tests/Persistence/Dto/Fixture/AddressDto.php
+++ b/tests/Persistence/Dto/Fixture/AddressDto.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Dto\Fixture;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Altair\Data\Traits\ImmutableAttributesAwareTrait;
+use Altair\Data\Traits\JsonSerializableAwareTrait;
+use Altair\Data\Traits\SerializeAwareTrait;
+
+final class AddressDto implements DataObjectInterface
+{
+    use ImmutableAttributesAwareTrait;
+    use JsonSerializableAwareTrait;
+    use SerializeAwareTrait;
+
+    private ?string $city = null;
+
+    private ?string $zip = null;
+}

--- a/tests/Persistence/Dto/Fixture/ProfileDto.php
+++ b/tests/Persistence/Dto/Fixture/ProfileDto.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Dto\Fixture;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Altair\Data\Traits\ImmutableAttributesAwareTrait;
+use Altair\Data\Traits\JsonSerializableAwareTrait;
+use Altair\Data\Traits\SerializeAwareTrait;
+use DateTimeImmutable;
+
+final class ProfileDto implements DataObjectInterface
+{
+    use ImmutableAttributesAwareTrait;
+    use JsonSerializableAwareTrait;
+    use SerializeAwareTrait;
+
+    private ?int $id = null;
+
+    private ?string $name = null;
+
+    private ?bool $active = null;
+
+    private ?float $score = null;
+
+    private ?DateTimeImmutable $created_at = null;
+
+    private ?AddressDto $address = null;
+}


### PR DESCRIPTION
## Summary

Realises the **Persistence → Data** arrow from #140: the persistence layer can now return immutable `Altair\Data\DataObjectInterface` **read models**, with type coercion living in Persistence (Data stays coercion-free and rejects mismatched typed-property writes).

The entity manager is the read-side entry point, mirroring how it hands out write repositories:

```php
$users = $em->readModel(User::class, UserProfileDto::class); // ReadModelRepositoryInterface<UserProfileDto>
$one  = $users->find(42);                    // ?UserProfileDto
$some = $users->findBy(['role' => 'admin']); // list<UserProfileDto>
$all  = $users->findAll();                   // list<UserProfileDto>
```

### What's included

- **`ReadModelRepositoryInterface`** — read-only (`find`/`findOneBy`/`findBy`/`findAll`), returns Data objects. Writes stay on the entity `RepositoryInterface` + unit of work (clean read/write split).
- **`CycleReadModelRepository`** — selects **raw rows** via `Select::fetchData()` (skips the identity map — the right trade for reads) and projects each through the hydrator.
- **`EntityManager::readModel(entity, dto)`** — added to the contract and `CycleEntityManager`; `CycleOrmConfiguration` binds `HydratorInterface → DataObjectHydrator` and injects it.
- **`DataObjectHydrator`** (+ `HydratorInterface`, `HydrationException`) — coerces a row to the target Data object's declared property types: numeric→`int`/`float`, `0`/`1`/`"true"`/`"false"`→`bool`, scalars/`Stringable`→`string`, date strings/timestamps→`DateTimeImmutable`/`DateTime`; nested `DataObjectInterface` props hydrate recursively (composed read-models = read side of a relation). `null` passes through, unknown keys drop, uncoercible values throw `HydrationException` naming the field. `hydrateMany()` for collections; usable standalone on any array (custom query, cache payload).
- `univeros/data` added to `univeros/persistence` require (the now-used arrow).

### v1 scope (documented limitations)

- `readModel()` projects a single entity role; joined/eager-loaded relations aren't auto-mapped into nested Data objects yet (though the hydrator *will* compose a nested Data object when a row already carries the relation as an array, e.g. a custom `Select` with `->load()`).
- Union/intersection property types are passed through for PHP to enforce.

## Test plan

- [x] Hydrator unit tests (11): scalar/date/bool coercion, nested DTO, null pass-through, unknown-key drop, already-correct pass-through, uncoercible scalar/nested → `HydrationException`, `hydrateMany`.
- [x] `CycleReadModelRepository` integration tests (in-memory SQLite): `find`/`findOneBy`/`findBy`/`findAll` return hydrated Data objects, missing → null, and obtained via `EntityManager::readModel()`.
- [x] `composer cs` / `stan` (level 8) / `rector` clean cache-free; full Persistence + Data suites green.
- [x] `.agent/packages/persistence.md` regenerated (only that manifest changed).