### PR TITLE
feat: eager-load and nest relations in Persistence read models

### DIFF
--- a/.agent/packages/persistence.md
+++ b/.agent/packages/persistence.md
@@ -30,6 +30,7 @@
 
 - `ArraySchemaProvider` _(final)_ — implements `SchemaProviderInterface`
 - `AttributeSchemaProvider` _(final)_ — implements `SchemaProviderInterface`
+- `CollectionOf` _(final)_
 - `CycleEntityManager` _(final)_ — implements `EntityManagerInterface`
 - `CycleOrmConfiguration` _(final)_ — implements `ConfigurationInterface`
 - `CycleReadModelRepository` _(final)_ — implements `ReadModelRepositoryInterface`
@@ -51,6 +52,7 @@
 - `tests/Persistence/Configuration/DatabaseConnectionFactoryTest.php`
 - `tests/Persistence/Configuration/DatabaseSettingsTest.php`
 - `tests/Persistence/Cycle/CycleEntityManagerTest.php`
+- `tests/Persistence/Cycle/CycleReadModelRelationTest.php`
 - `tests/Persistence/Cycle/CycleReadModelRepositoryTest.php`
 - `tests/Persistence/Cycle/CycleRepositoryTest.php`
 - `tests/Persistence/Dto/DataObjectHydratorTest.php`

--- a/docs/packages/persistence.md
+++ b/docs/packages/persistence.md
@@ -211,6 +211,31 @@ $all  = $users->findAll();                      // list<UserProfileDto>
 
 `readModel()` returns a `ReadModelRepositoryInterface` — `find` / `findOneBy` / `findBy` / `findAll`, no writes. Writes stay on the entity `RepositoryInterface` and the unit of work; reads come back as Data objects. The Cycle implementation selects **raw rows** (`Select::fetchData()`) rather than managed entities, so reads skip the identity map — the right trade for the read side.
 
+#### Relations (nested read models)
+
+When the target read model declares a property whose name matches one of the entity's relations, the read model **eager-loads that relation** and nests it. A to-one relation maps onto a property typed as another `DataObjectInterface`; a to-many relation maps onto an `array` property annotated with `#[CollectionOf(...)]` (PHP can't express `array<Dto>` natively, so the attribute names the element type):
+
+```php
+use Altair\Persistence\Dto\Attribute\CollectionOf;
+
+final class WidgetDto implements DataObjectInterface
+{
+    use ImmutableAttributesAwareTrait; use JsonSerializableAwareTrait; use SerializeAwareTrait;
+
+    private ?int    $id   = null;
+    private ?string $name = null;
+
+    /** @var list<PartDto>|null */
+    #[CollectionOf(PartDto::class)]
+    private ?array $parts = null;   // matches the `parts` has-many relation
+}
+
+$widget = $em->readModel(Widget::class, WidgetDto::class)->find(1);
+// $widget->parts === [PartDto, PartDto, ...]  (eager-loaded and hydrated)
+```
+
+The match is by name: the DTO property must be named like the relation. Only declared, matching relations are loaded — no over-fetching.
+
 #### Coercion (the hydrator underneath)
 
 Each row is projected through a `HydratorInterface` (`DataObjectHydrator` by default, bound in `CycleOrmConfiguration` and swappable). This is the bridge the Data package deliberately does not provide: `Data` assigns values as-is (its typed-property writes reject a mismatched type), so **type coercion lives here, in the persistence layer**, never in `Data`. The dependency arrow is one-way — `univeros/persistence` depends on `univeros/data`, never the reverse.
@@ -362,4 +387,4 @@ What you should **not** extend: `CycleEntityManager` is `final`. Replace it via 
 - **Doctrine bridge.** Not in this package. A separate `univeros/doctrine` could implement the same contracts; the wrap is already shaped for it.
 - **`--dry-run` SQL preview.** `db:migrate --dry-run` currently lists pending migration names. A per-migration SQL dump is a follow-up — Cycle's `Migrator` does not expose a non-destructive SQL preview out of the box.
 - **Postgres / MySQL CI matrix.** Tests today exercise in-memory SQLite. Real-driver integration tests are tracked as a follow-up on the original issue.
-- **Read-model scope.** `readModel()` projects a single entity role's rows; joined/eager-loaded relations are not auto-mapped into nested Data objects yet (the hydrator *will* compose a nested `DataObjectInterface` when a row already carries the relation as an array — e.g. from a custom `Select` with `->load()`). The hydrator coerces against a single declared property type; union and intersection types are passed through for PHP to enforce.
+- **Read-model relations.** A read model eager-loads and nests relations whose name matches a `DataObjectInterface` (to-one) or `#[CollectionOf(...)]` (to-many) property on the DTO. The match is by name, so a DTO property must be named like the relation; relations exposed under a different property name, and nesting deeper than one level, are not auto-loaded — drop to a custom `Select` with explicit `->load()` and hydrate the rows yourself. The hydrator coerces against a single declared property type; union and intersection types are passed through for PHP to enforce.

--- a/src/Altair/Persistence/Cycle/CycleReadModelRepository.php
+++ b/src/Altair/Persistence/Cycle/CycleReadModelRepository.php
@@ -14,9 +14,13 @@ namespace Altair\Persistence\Cycle;
 use Altair\Data\Contracts\DataObjectInterface;
 use Altair\Persistence\Contracts\HydratorInterface;
 use Altair\Persistence\Contracts\ReadModelRepositoryInterface;
+use Altair\Persistence\Dto\Attribute\CollectionOf;
 use Cycle\ORM\ORMInterface;
 use Cycle\ORM\Select;
 use Override;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
 
 /**
  * Cycle-backed read model: selects raw rows for an entity role and projects
@@ -82,7 +86,55 @@ final readonly class CycleReadModelRepository implements ReadModelRepositoryInte
      */
     private function select(): Select
     {
-        return new Select($this->orm, $this->entityClass);
+        $select = new Select($this->orm, $this->entityClass);
+
+        foreach ($this->relationsToLoad() as $relation) {
+            $select->load($relation);
+        }
+
+        return $select;
+    }
+
+    /**
+     * Relations to eager-load: the entity's schema relations whose name matches
+     * a nested-Data-object or {@see CollectionOf} property on the target DTO.
+     *
+     * @return list<string>
+     */
+    private function relationsToLoad(): array
+    {
+        $schema = $this->orm->getSchema();
+        if (!$schema->defines($this->entityClass)) {
+            return [];
+        }
+
+        $relationNames = $schema->getRelations($this->entityClass);
+        if ($relationNames === []) {
+            return [];
+        }
+
+        $load = [];
+        foreach ((new ReflectionClass($this->dataObjectClass))->getProperties() as $property) {
+            $name = $property->getName();
+            if (\in_array($name, $relationNames, true) && $this->isRelationProperty($property)) {
+                $load[] = $name;
+            }
+        }
+
+        return $load;
+    }
+
+    private function isRelationProperty(ReflectionProperty $property): bool
+    {
+        if ($property->getAttributes(CollectionOf::class) !== []) {
+            return true;
+        }
+
+        $type = $property->getType();
+
+        return $type instanceof ReflectionNamedType
+            && !$type->isBuiltin()
+            && is_a($type->getName(), DataObjectInterface::class, true);
     }
 
     /**

--- a/src/Altair/Persistence/Dto/Attribute/CollectionOf.php
+++ b/src/Altair/Persistence/Dto/Attribute/CollectionOf.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Persistence\Dto\Attribute;
+
+use Altair\Data\Contracts\DataObjectInterface;
+use Attribute;
+
+/**
+ * Declares the element type of an `array` Data-object property so the hydrator
+ * can project a list of rows (a to-many relation) into a list of Data objects.
+ *
+ * PHP cannot express `array<DataObjectInterface>` natively, so a to-many read
+ * model annotates its collection property:
+ *
+ *     #[CollectionOf(OrderDto::class)]
+ *     private ?array $orders = null;
+ */
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final readonly class CollectionOf
+{
+    /**
+     * @param class-string<DataObjectInterface> $type
+     */
+    public function __construct(public string $type) {}
+}

--- a/src/Altair/Persistence/Dto/DataObjectHydrator.php
+++ b/src/Altair/Persistence/Dto/DataObjectHydrator.php
@@ -13,6 +13,7 @@ namespace Altair\Persistence\Dto;
 
 use Altair\Data\Contracts\DataObjectInterface;
 use Altair\Persistence\Contracts\HydratorInterface;
+use Altair\Persistence\Dto\Attribute\CollectionOf;
 use Altair\Persistence\Exception\HydrationException;
 use DateTime;
 use DateTimeImmutable;
@@ -25,6 +26,7 @@ use const FILTER_VALIDATE_BOOLEAN;
 use Override;
 use ReflectionClass;
 use ReflectionNamedType;
+use ReflectionProperty;
 use ReflectionType;
 use Stringable;
 
@@ -59,12 +61,16 @@ final class DataObjectHydrator implements HydratorInterface
                 continue;
             }
 
-            $coerced[$key] = $this->coerce(
-                $value,
-                $reflection->getProperty($key)->getType(),
-                $dataObjectClass,
-                $key,
-            );
+            $property = $reflection->getProperty($key);
+
+            $elementType = $this->collectionElementType($property);
+            if ($elementType !== null) {
+                $coerced[$key] = $this->coerceCollection($value, $elementType, $dataObjectClass, $key);
+
+                continue;
+            }
+
+            $coerced[$key] = $this->coerce($value, $property->getType(), $dataObjectClass, $key);
         }
 
         /** @var T $instance */
@@ -90,6 +96,52 @@ final class DataObjectHydrator implements HydratorInterface
         }
 
         return $result;
+    }
+
+    /**
+     * @return class-string<DataObjectInterface>|null
+     */
+    private function collectionElementType(ReflectionProperty $property): ?string
+    {
+        $attributes = $property->getAttributes(CollectionOf::class);
+
+        return $attributes === [] ? null : $attributes[0]->newInstance()->type;
+    }
+
+    /**
+     * @param class-string<DataObjectInterface> $elementClass
+     *
+     * @return list<DataObjectInterface>|null
+     */
+    private function coerceCollection(mixed $value, string $elementClass, string $class, string $field): ?array
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if (!\is_array($value)) {
+            throw HydrationException::uncoercible($class, $field, 'list<' . $elementClass . '>', $value);
+        }
+
+        $items = [];
+        foreach ($value as $element) {
+            if ($element instanceof DataObjectInterface) {
+                $items[] = $element;
+
+                continue;
+            }
+
+            if (\is_array($element)) {
+                /** @var array<string, mixed> $element */
+                $items[] = $this->hydrate($elementClass, $element);
+
+                continue;
+            }
+
+            throw HydrationException::uncoercible($class, $field, $elementClass, $element);
+        }
+
+        return $items;
     }
 
     private function coerce(mixed $value, ?ReflectionType $type, string $class, string $field): mixed

--- a/tests/Persistence/Cycle/CycleReadModelRelationTest.php
+++ b/tests/Persistence/Cycle/CycleReadModelRelationTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Cycle;
+
+use Altair\Persistence\Configuration\DatabaseConnectionFactory;
+use Altair\Persistence\Configuration\DatabaseSettings;
+use Altair\Persistence\Cycle\CycleReadModelRepository;
+use Altair\Persistence\Dto\DataObjectHydrator;
+use Altair\Tests\Persistence\Cycle\Fixture\Part;
+use Altair\Tests\Persistence\Cycle\Fixture\PartDto;
+use Altair\Tests\Persistence\Cycle\Fixture\Widget;
+use Altair\Tests\Persistence\Cycle\Fixture\WidgetWithPartsDto;
+use Cycle\ORM\Factory;
+use Cycle\ORM\Mapper\Mapper;
+use Cycle\ORM\ORM;
+use Cycle\ORM\ORMInterface;
+use Cycle\ORM\Relation;
+use Cycle\ORM\Schema;
+use Cycle\ORM\SchemaInterface;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(CycleReadModelRepository::class)]
+final class CycleReadModelRelationTest extends TestCase
+{
+    private ORMInterface $orm;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $databases = (new DatabaseConnectionFactory())->create(new DatabaseSettings(
+            driver: DatabaseSettings::DRIVER_SQLITE,
+            database: ':memory:',
+        ));
+
+        $db = $databases->database('default');
+        $db->execute('CREATE TABLE widgets (id INTEGER PRIMARY KEY, name TEXT NOT NULL)');
+        $db->execute('CREATE TABLE parts (id INTEGER PRIMARY KEY, widget_id INTEGER NOT NULL, label TEXT NOT NULL)');
+        $db->execute('INSERT INTO widgets (id, name) VALUES (1, ?), (2, ?)', ['Alpha', 'Bravo']);
+        $db->execute('INSERT INTO parts (id, widget_id, label) VALUES (1, 1, ?), (2, 1, ?)', ['p1', 'p2']);
+
+        $this->orm = new ORM(new Factory($databases), $this->schema());
+    }
+
+    private function readModel(): CycleReadModelRepository
+    {
+        return new CycleReadModelRepository(
+            Widget::class,
+            WidgetWithPartsDto::class,
+            $this->orm,
+            new DataObjectHydrator(),
+        );
+    }
+
+    public function testFindEagerLoadsAndNestsHasManyRelation(): void
+    {
+        $dto = $this->readModel()->find(1);
+
+        $this->assertInstanceOf(WidgetWithPartsDto::class, $dto);
+        $this->assertSame('Alpha', $dto->name);
+        $this->assertIsArray($dto->parts);
+        $this->assertCount(2, $dto->parts);
+        $this->assertContainsOnlyInstancesOf(PartDto::class, $dto->parts);
+
+        $labels = array_map(static fn(PartDto $part): ?string => $part->label, $dto->parts);
+        sort($labels);
+        $this->assertSame(['p1', 'p2'], $labels);
+    }
+
+    public function testRelationIsEmptyListWhenNoChildren(): void
+    {
+        $dto = $this->readModel()->find(2);
+
+        $this->assertInstanceOf(WidgetWithPartsDto::class, $dto);
+        $this->assertSame([], $dto->parts);
+    }
+
+    public function testFindAllEagerLoadsRelationForEveryRow(): void
+    {
+        $dtos = $this->readModel()->findAll();
+
+        $this->assertCount(2, $dtos);
+        $byId = [];
+        foreach ($dtos as $dto) {
+            $byId[$dto->id] = $dto;
+        }
+
+        $this->assertCount(2, $byId[1]->parts);
+        $this->assertSame([], $byId[2]->parts);
+    }
+
+    private function schema(): Schema
+    {
+        return new Schema([
+            'widget' => [
+                SchemaInterface::ENTITY => Widget::class,
+                SchemaInterface::MAPPER => Mapper::class,
+                SchemaInterface::DATABASE => 'default',
+                SchemaInterface::TABLE => 'widgets',
+                SchemaInterface::PRIMARY_KEY => ['id'],
+                SchemaInterface::COLUMNS => ['id' => 'id', 'name' => 'name'],
+                SchemaInterface::TYPECAST => ['id' => 'int'],
+                SchemaInterface::SCHEMA => [],
+                SchemaInterface::RELATIONS => [
+                    'parts' => [
+                        Relation::TYPE => Relation::HAS_MANY,
+                        Relation::TARGET => 'part',
+                        Relation::LOAD => Relation::LOAD_PROMISE,
+                        Relation::SCHEMA => [
+                            Relation::CASCADE => true,
+                            Relation::INNER_KEY => 'id',
+                            Relation::OUTER_KEY => 'widget_id',
+                        ],
+                    ],
+                ],
+            ],
+            'part' => [
+                SchemaInterface::ENTITY => Part::class,
+                SchemaInterface::MAPPER => Mapper::class,
+                SchemaInterface::DATABASE => 'default',
+                SchemaInterface::TABLE => 'parts',
+                SchemaInterface::PRIMARY_KEY => ['id'],
+                SchemaInterface::COLUMNS => ['id' => 'id', 'widget_id' => 'widget_id', 'label' => 'label'],
+                SchemaInterface::TYPECAST => ['id' => 'int', 'widget_id' => 'int'],
+                SchemaInterface::SCHEMA => [],
+                SchemaInterface::RELATIONS => [],
+            ],
+        ]);
+    }
+}

--- a/tests/Persistence/Cycle/Fixture/Part.php
+++ b/tests/Persistence/Cycle/Fixture/Part.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Persistence\Cycle\Fixture;
+
+/**
+ * Child entity for the has-many relation used in read-model relation tests.
+ */
+final class Part
+{
+    public function __construct(
+        public int $id,
+        public int $widget_id,
+        public string $label,
+    ) {}
+}

--- a/tests/Persistence/Cycle/Fixture/PartDto.php
+++ b/tests/Persistence/Cycle/Fixture/PartDto.php
@@ -9,16 +9,14 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Altair\Tests\Persistence\Dto\Fixture;
+namespace Altair\Tests\Persistence\Cycle\Fixture;
 
 use Altair\Data\Contracts\DataObjectInterface;
 use Altair\Data\Traits\ImmutableAttributesAwareTrait;
 use Altair\Data\Traits\JsonSerializableAwareTrait;
 use Altair\Data\Traits\SerializeAwareTrait;
-use Altair\Persistence\Dto\Attribute\CollectionOf;
-use DateTimeImmutable;
 
-final class ProfileDto implements DataObjectInterface
+final class PartDto implements DataObjectInterface
 {
     use ImmutableAttributesAwareTrait;
     use JsonSerializableAwareTrait;
@@ -26,17 +24,5 @@ final class ProfileDto implements DataObjectInterface
 
     private ?int $id = null;
 
-    private ?string $name = null;
-
-    private ?bool $active = null;
-
-    private ?float $score = null;
-
-    private ?DateTimeImmutable $created_at = null;
-
-    private ?AddressDto $address = null;
-
-    /** @var list<AddressDto>|null */
-    #[CollectionOf(AddressDto::class)]
-    private ?array $addresses = null;
+    private ?string $label = null;
 }

--- a/tests/Persistence/Cycle/Fixture/WidgetWithPartsDto.php
+++ b/tests/Persistence/Cycle/Fixture/WidgetWithPartsDto.php
@@ -9,16 +9,15 @@ declare(strict_types=1);
  * the LICENSE file that was distributed with this source code.
  */
 
-namespace Altair\Tests\Persistence\Dto\Fixture;
+namespace Altair\Tests\Persistence\Cycle\Fixture;
 
 use Altair\Data\Contracts\DataObjectInterface;
 use Altair\Data\Traits\ImmutableAttributesAwareTrait;
 use Altair\Data\Traits\JsonSerializableAwareTrait;
 use Altair\Data\Traits\SerializeAwareTrait;
 use Altair\Persistence\Dto\Attribute\CollectionOf;
-use DateTimeImmutable;
 
-final class ProfileDto implements DataObjectInterface
+final class WidgetWithPartsDto implements DataObjectInterface
 {
     use ImmutableAttributesAwareTrait;
     use JsonSerializableAwareTrait;
@@ -28,15 +27,7 @@ final class ProfileDto implements DataObjectInterface
 
     private ?string $name = null;
 
-    private ?bool $active = null;
-
-    private ?float $score = null;
-
-    private ?DateTimeImmutable $created_at = null;
-
-    private ?AddressDto $address = null;
-
-    /** @var list<AddressDto>|null */
-    #[CollectionOf(AddressDto::class)]
-    private ?array $addresses = null;
+    /** @var list<PartDto>|null */
+    #[CollectionOf(PartDto::class)]
+    private ?array $parts = null;
 }

--- a/tests/Persistence/Dto/DataObjectHydratorTest.php
+++ b/tests/Persistence/Dto/DataObjectHydratorTest.php
@@ -154,4 +154,51 @@ final class DataObjectHydratorTest extends TestCase
     {
         $this->assertSame([], $this->hydrator->hydrateMany(ProfileDto::class, []));
     }
+
+    public function testHydratesCollectionOfNestedDataObjects(): void
+    {
+        $dto = $this->hydrator->hydrate(ProfileDto::class, [
+            'id' => 1,
+            'addresses' => [
+                ['city' => 'New York', 'zip' => '10001'],
+                ['city' => 'Oslo'],
+            ],
+        ]);
+
+        $this->assertIsArray($dto->addresses);
+        $this->assertCount(2, $dto->addresses);
+        $this->assertContainsOnlyInstancesOf(AddressDto::class, $dto->addresses);
+        $this->assertSame('New York', $dto->addresses[0]->city);
+        $this->assertSame('Oslo', $dto->addresses[1]->city);
+    }
+
+    public function testCollectionPassesThroughExistingInstances(): void
+    {
+        $existing = new AddressDto(['city' => 'Berlin']);
+
+        $dto = $this->hydrator->hydrate(ProfileDto::class, ['addresses' => [$existing]]);
+
+        $this->assertSame($existing, $dto->addresses[0]);
+    }
+
+    public function testNullCollectionStaysNull(): void
+    {
+        $dto = $this->hydrator->hydrate(ProfileDto::class, ['addresses' => null]);
+
+        $this->assertNull($dto->addresses);
+    }
+
+    public function testCollectionFromNonArrayThrows(): void
+    {
+        $this->expectException(HydrationException::class);
+
+        $this->hydrator->hydrate(ProfileDto::class, ['addresses' => 'nope']);
+    }
+
+    public function testCollectionElementFromNonArrayThrows(): void
+    {
+        $this->expectException(HydrationException::class);
+
+        $this->hydrator->hydrate(ProfileDto::class, ['addresses' => ['not-an-array']]);
+    }
 }


### PR DESCRIPTION
## Summary

Closes the v1 read-model limitation from #142: read models now project **relations** into nested Data objects, not just scalar columns.

When the target DTO declares a property matching one of the entity's Cycle relations, the read model eager-loads it and hydrates the nested rows:

```php
use Altair\Persistence\Dto\Attribute\CollectionOf;

final class WidgetDto implements DataObjectInterface
{
    use ImmutableAttributesAwareTrait; use JsonSerializableAwareTrait; use SerializeAwareTrait;

    private ?int    $id   = null;
    private ?string $name = null;

    /** @var list<PartDto>|null */
    #[CollectionOf(PartDto::class)]
    private ?array $parts = null;   // matches the `parts` has-many relation
}

$widget = $em->readModel(Widget::class, WidgetDto::class)->find(1);
// $widget->parts === [PartDto, PartDto, ...]
```

- **To-one** relations map onto a property typed as another `DataObjectInterface`.
- **To-many** relations map onto an `array` property annotated with the new **`#[CollectionOf(Dto::class)]`** attribute (PHP can't express `array<Dto>` natively, so the attribute names the element type).
- `CycleReadModelRepository` matches the DTO's relation properties against the entity's schema relations **by name**, adds the matching `->load()` calls to its `Select`, and `fetchData()` returns the nested rows the hydrator composes. Only declared, matching relations are loaded — no over-fetching.

## Design notes

- `#[CollectionOf]` lives in `Altair\Persistence\Dto\Attribute` (a hydration directive), keeping the Data package free of persistence concerns.
- Matching is by property name (DTO field named like the relation). Documented remaining limitations: relations exposed under a different property name, and nesting deeper than one level, need a custom `Select` with explicit `->load()`.

## Test plan

- [x] Hydrator collection unit tests: `#[CollectionOf]` nesting, existing-instance pass-through, null stays null, non-array + non-array-element throw `HydrationException`.
- [x] `CycleReadModelRelationTest` integration (in-memory SQLite, `Widget hasMany Part`): `find` / `findAll` eager-load and nest `parts`, empty relation -> `[]`.
- [x] `composer cs` / `stan` (level 8) / `rector` clean cache-free; full Persistence + Data suites green.
- [x] `.agent/packages/persistence.md` regenerated (only that manifest changed).