### PR TITLE
feat: enforce determinism standard (#74 v1) — CI gate + per-emitter tests

### DIFF
--- a/.agent/packages/agent-spec.md
+++ b/.agent/packages/agent-spec.md
@@ -44,6 +44,7 @@
 ## Tests as documentation
 
 - `tests/AgentSpec/ApplicationManifestGeneratorTest.php`
+- `tests/AgentSpec/Determinism/ManifestDeterminismTest.php`
 - `tests/AgentSpec/Fixtures/TestsRoot/SamplePackage/SampleGreeterTest.php`
 - `tests/AgentSpec/IndexGeneratorTest.php`
 - `tests/AgentSpec/ManifestPipelineTest.php`

--- a/.agent/packages/happen.md
+++ b/.agent/packages/happen.md
@@ -26,7 +26,7 @@
 |  | `withArgument(string, mixed)` | `EventInterface` |  |
 |  | `withArguments(array)` | `EventInterface` |  |
 |  | `withName(string)` | `EventInterface` |  |
-| `EventStackInterface` | `addEvent(EventInterface\|string)` | `EventStackInterface` |  |
+| `EventStackInterface` | `addEvent(EventInterface\|string)` | `self` |  |
 |  | `getStack()` | `array` |  |
 | `EventSubscriberInterface` | `getSubscribedEvents()` | `array` |  |
 | `ListenerInterface` | `__invoke(EventInterface)` | `void` |  |

--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -77,6 +77,8 @@
 ## Tests as documentation
 
 - `tests/Scaffold/Cli/ScaffoldCommandIntegrationTest.php`
+- `tests/Scaffold/Determinism/EmitOpenApiDeterminismTest.php`
+- `tests/Scaffold/Determinism/SdkEmitterDeterminismTest.php`
 - `tests/Scaffold/Emitter/ActionEmitterTest.php`
 - `tests/Scaffold/Emitter/DomainStubEmitterTest.php`
 - `tests/Scaffold/Emitter/EntityEmitterTest.php`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,37 @@ jobs:
 
       - name: Rector dry-run
         run: vendor/bin/rector process --dry-run
+
+  determinism:
+    name: Determinism gate (#74)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: intl, json, mbstring, openssl
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      # The byte-stability gate: regenerate the framework's own committed
+      # generated content, then assert that nothing changed. A non-empty
+      # `git diff` here means an emitter is non-deterministic — agents
+      # would see phantom drift, which is the failure mode #74 prevents.
+      - name: Regenerate manifests
+        run: php bin/altair manifest:generate
+
+      - name: Assert .agent/ is byte-stable
+        run: |
+          if ! git diff --exit-code .agent/; then
+            echo "::error::Generated content under .agent/ changed after regeneration." \
+                 "An emitter is non-deterministic; see AGENT.md §5 for the standard."
+            exit 1
+          fi

--- a/AGENT.md
+++ b/AGENT.md
@@ -198,7 +198,14 @@ The standard — a deterministic emitter has:
 4. **No machine identifiers** — no hostname, username, or absolute paths.
 5. **No nondeterministic randomness** — derive any UUID from the spec SHA (`uuid5`), never `random_*`.
 
-Enforcement: every emitter ships a "run twice, diff empty" PHPUnit test; `bin/altair doctor`'s `determinism_check` runs the regenerate-and-diff gate (see `univeros/doctor`); host projects run the same gate in CI. **Any new package added to the framework must meet this standard** — it's a review gate, tracked in [#74](https://github.com/univeros/framework/issues/74).
+Enforcement is layered and live:
+
+- **In-process tests** — `tests/Determinism/TwiceHarness.php` is the shared harness, and `tests/AgentSpec/Determinism/`, `tests/Scaffold/Determinism/` ship "run twice, diff empty" tests for the manifest pipeline, the OpenAPI fragment merger, and the TypeScript + Python SDK emitters. Add one anywhere you add a new emitter.
+- **CI determinism gate** — `.github/workflows/ci.yml` regenerates `.agent/` and `git diff --exit-code`s it on every PR. A non-deterministic emitter fails the gate.
+- **`bin/altair doctor`** — the `determinism_check` from `univeros/doctor` runs the same regenerate-and-diff gate against any generators a host configures (see `DoctorConfiguration`'s constructor).
+- **Skeleton workflow** — `src/Altair/Bootstrap/resources/skeleton/.github/workflows/determinism.yml` ships with `bin/altair new`, so generated host projects inherit the gate.
+
+**Any new package added to the framework must meet this standard.** Tracked in [#74](https://github.com/univeros/framework/issues/74).
 
 ---
 

--- a/src/Altair/Bootstrap/resources/skeleton/.github/workflows/determinism.yml
+++ b/src/Altair/Bootstrap/resources/skeleton/.github/workflows/determinism.yml
@@ -1,0 +1,72 @@
+name: Determinism gate
+
+# The Altair determinism gate (#74): every emitter that writes files or
+# produces --format=json MUST be byte-stable across runs. This workflow
+# regenerates the committed generated content (.agent/, scaffolded code,
+# emitted OpenAPI), then `git diff --exit-code`s those paths. Any drift
+# means an emitter is non-deterministic — agents would see phantom
+# changes and may produce mistaken edits.
+#
+# See AGENT.md §Determinism for the standard.
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  determinism:
+    name: Byte-stable generated content
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          extensions: intl, json, mbstring, openssl
+          coverage: none
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      # Regenerate every emitted artefact. Add new commands here as the
+      # project grows (e.g. SDK emitters, OpenAPI merge).
+      - name: Regenerate manifests
+        run: |
+          if [ -f bin/altair ] && php bin/altair manifest:generate --help >/dev/null 2>&1; then
+            php bin/altair manifest:generate
+          fi
+
+      - name: Regenerate scaffolded artefacts (if specs exist)
+        run: |
+          if [ -d api ] && [ -f bin/altair ]; then
+            php bin/altair spec:scaffold api/ --force || true
+          fi
+
+      - name: Regenerate merged OpenAPI (if fragments exist)
+        run: |
+          if [ -d docs/openapi ] && [ -f bin/altair ]; then
+            php bin/altair spec:emit-openapi --out docs/openapi.yaml || true
+          fi
+
+      - name: Assert all generated paths are byte-stable
+        run: |
+          paths=(.agent app docs/openapi.yaml)
+          existing=()
+          for p in "${paths[@]}"; do
+            [ -e "$p" ] && existing+=("$p")
+          done
+          if [ ${#existing[@]} -eq 0 ]; then
+            echo "No generated paths exist yet; nothing to check."
+            exit 0
+          fi
+          if ! git diff --exit-code "${existing[@]}"; then
+            echo "::error::Generated content changed after regeneration." \
+                 "An emitter is non-deterministic; see AGENT.md §Determinism."
+            exit 1
+          fi

--- a/tests/AgentSpec/Determinism/ManifestDeterminismTest.php
+++ b/tests/AgentSpec/Determinism/ManifestDeterminismTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\AgentSpec\Determinism;
+
+use Altair\AgentSpec\Cli\ManifestGenerateCommand;
+use Altair\Tests\Determinism\TwiceHarness;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * The #74 acceptance gate for the manifest emitter: running it twice from
+ * the same source tree must produce byte-identical files. If this fails,
+ * something in the manifest pipeline is iterating an unsorted map / leaking
+ * a wall-clock timestamp / depending on inode-order FS traversal.
+ */
+#[CoversClass(ManifestGenerateCommand::class)]
+final class ManifestDeterminismTest extends TestCase
+{
+    private TwiceHarness $harness;
+
+    protected function setUp(): void
+    {
+        $this->harness = new TwiceHarness('altair-determinism-manifest');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->harness->cleanup();
+    }
+
+    public function testManifestGeneratorProducesByteIdenticalOutputAcrossRuns(): void
+    {
+        $command = new ManifestGenerateCommand();
+        [$first, $second] = $this->harness->pair(function (string $outputDir) use ($command): void {
+            ob_start();
+            $command(output: $outputDir);
+            ob_end_clean();
+        });
+
+        $this->harness->assertTreesByteEqual($first, $second);
+    }
+}

--- a/tests/Determinism/TwiceHarness.php
+++ b/tests/Determinism/TwiceHarness.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Determinism;
+
+use FilesystemIterator;
+use PHPUnit\Framework\Assert;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+/**
+ * Reusable test harness for the #74 determinism gate.
+ *
+ * For each test, the harness creates two sibling temp directories, hands them
+ * to a caller-supplied action (which runs the emitter targeting each
+ * directory in turn), and then asserts that the resulting trees — or files —
+ * are byte-identical.
+ *
+ * Comparing both the file set (so a missing file is caught) and each file's
+ * raw bytes (so a one-character timestamp drift is caught) is what makes
+ * this an honest enforcement of the "byte-stable across runs" standard.
+ */
+final readonly class TwiceHarness
+{
+    private string $base;
+
+    public function __construct(string $prefix)
+    {
+        $this->base = sys_get_temp_dir() . '/' . $prefix . '-' . bin2hex(random_bytes(5));
+        mkdir($this->base . '/first', 0o755, true);
+        mkdir($this->base . '/second', 0o755, true);
+    }
+
+    /**
+     * Invoke the action twice — once per output directory — and return both
+     * paths so the caller can diff them.
+     *
+     * @param callable(string): void $action
+     *
+     * @return array{0: string, 1: string}
+     */
+    public function pair(callable $action): array
+    {
+        $first = $this->base . '/first';
+        $second = $this->base . '/second';
+
+        $action($first);
+        $action($second);
+
+        return [$first, $second];
+    }
+
+    public function assertTreesByteEqual(string $first, string $second): void
+    {
+        $a = $this->listFiles($first);
+        $b = $this->listFiles($second);
+
+        Assert::assertSame($a, $b, 'emitter produced different file sets across runs');
+
+        foreach ($a as $relative) {
+            $this->assertFilesByteEqual($first . '/' . $relative, $second . '/' . $relative);
+        }
+    }
+
+    public function assertFilesByteEqual(string $first, string $second): void
+    {
+        $a = (string) file_get_contents($first);
+        $b = (string) file_get_contents($second);
+
+        if ($a === $b) {
+            Assert::assertTrue(true);
+
+            return;
+        }
+
+        Assert::fail(\sprintf(
+            "Emitter output differs between runs (non-deterministic):\n  first:  %s (%d bytes)\n  second: %s (%d bytes)\n  diff bytes: %d",
+            $first,
+            \strlen($a),
+            $second,
+            \strlen($b),
+            \strlen($a) - \strlen($b),
+        ));
+    }
+
+    public function cleanup(): void
+    {
+        if (!is_dir($this->base)) {
+            return;
+        }
+
+        $this->rrmdir($this->base);
+    }
+
+    /**
+     * @return list<string> file paths relative to $root, sorted alphabetically
+     */
+    private function listFiles(string $root): array
+    {
+        if (!is_dir($root)) {
+            return [];
+        }
+
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        $files = [];
+        /** @var SplFileInfo $file */
+        foreach ($iterator as $file) {
+            if (!$file->isFile()) {
+                continue;
+            }
+
+            $relative = substr($file->getPathname(), \strlen($root) + 1);
+            $files[] = str_replace('\\', '/', $relative);
+        }
+
+        sort($files);
+
+        return $files;
+    }
+
+    private function rrmdir(string $dir): void
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        /** @var SplFileInfo $entry */
+        foreach ($iterator as $entry) {
+            if ($entry->isDir()) {
+                @rmdir($entry->getPathname());
+            } else {
+                @unlink($entry->getPathname());
+            }
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Scaffold/Determinism/EmitOpenApiDeterminismTest.php
+++ b/tests/Scaffold/Determinism/EmitOpenApiDeterminismTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Scaffold\Determinism;
+
+use Altair\Scaffold\Cli\EmitOpenApiCommand;
+use Altair\Tests\Determinism\TwiceHarness;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #74 acceptance: the OpenAPI fragment-merger must produce byte-identical
+ * output across runs. With multiple fragments under `docs/openapi/`, this
+ * exercises both the fragment-ordering (FS-iteration order is inode-defined,
+ * so the merger must sort) and the YAML dumper's stability.
+ */
+#[CoversClass(EmitOpenApiCommand::class)]
+final class EmitOpenApiDeterminismTest extends TestCase
+{
+    private TwiceHarness $harness;
+
+    private string $fragmentsDir = '';
+
+    protected function setUp(): void
+    {
+        $this->harness = new TwiceHarness('altair-determinism-openapi');
+
+        // Two fragments — exercises the cross-fragment merge ordering, not
+        // just the single-document emit. The fragments are dropped into the
+        // temp dir in a deliberately-unsorted order: a deterministic emitter
+        // must produce the same merged YAML regardless.
+        $this->fragmentsDir = sys_get_temp_dir() . '/altair-openapi-frags-' . bin2hex(random_bytes(4));
+        mkdir($this->fragmentsDir, 0o755, true);
+        file_put_contents($this->fragmentsDir . '/zeta.yaml', $this->fragment('GET', '/zeta'));
+        file_put_contents($this->fragmentsDir . '/alpha.yaml', $this->fragment('GET', '/alpha'));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->fragmentsDir . '/*') ?: [] as $file) {
+            @unlink($file);
+        }
+
+        @rmdir($this->fragmentsDir);
+        $this->harness->cleanup();
+    }
+
+    public function testOpenApiEmitterIsByteDeterministicAcrossRuns(): void
+    {
+        $command = new EmitOpenApiCommand();
+        $fragmentsDir = $this->fragmentsDir;
+
+        [$first, $second] = $this->harness->pair(function (string $outDir) use ($command, $fragmentsDir): void {
+            ob_start();
+            $command(fragmentsDir: $fragmentsDir, outFile: $outDir . '/openapi.yaml');
+            ob_end_clean();
+        });
+
+        $this->harness->assertFilesByteEqual($first . '/openapi.yaml', $second . '/openapi.yaml');
+    }
+
+    private function fragment(string $method, string $path): string
+    {
+        return <<<YAML
+            openapi: 3.1.0
+            info:
+              title: Frag
+              version: 1.0.0
+            paths:
+              "{$path}":
+                {$method}:
+                  summary: Frag handler for {$path}
+                  responses:
+                    "200":
+                      description: ok
+            YAML;
+    }
+}

--- a/tests/Scaffold/Determinism/SdkEmitterDeterminismTest.php
+++ b/tests/Scaffold/Determinism/SdkEmitterDeterminismTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Scaffold\Determinism;
+
+use Altair\Scaffold\Cli\EmitSdkCommand;
+use Altair\Tests\Determinism\TwiceHarness;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #74 acceptance: every SDK emitter must produce byte-identical output across
+ * runs given the same OpenAPI input. A drift here would mean the emitter is
+ * iterating an unordered schema map or stamping a timestamp into the output.
+ */
+#[CoversClass(EmitSdkCommand::class)]
+final class SdkEmitterDeterminismTest extends TestCase
+{
+    private TwiceHarness $harness;
+
+    private string $openapiPath;
+
+    protected function setUp(): void
+    {
+        $this->harness = new TwiceHarness('altair-determinism-sdk');
+        $this->openapiPath = __DIR__ . '/../Sdk/Fixtures/users-api.yaml';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->harness->cleanup();
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function languages(): iterable
+    {
+        yield 'typescript' => ['typescript'];
+        yield 'python' => ['python'];
+    }
+
+    #[DataProvider('languages')]
+    public function testSdkEmitterIsByteDeterministicAcrossRuns(string $language): void
+    {
+        $openapi = $this->openapiPath;
+        $command = new EmitSdkCommand();
+
+        [$first, $second] = $this->harness->pair(function (string $out) use ($command, $openapi, $language): void {
+            ob_start();
+            $command(language: $language, openapi: $openapi, out: $out, multiFile: true);
+            ob_end_clean();
+        });
+
+        $this->harness->assertTreesByteEqual($first, $second);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **#74 v1**. The framework's emitters were already deterministic (I audited: `manifest:generate`, `doctor --format=json`, and all five introspection commands produce byte-identical output across runs). This PR locks that property in **programmatically** so a future regression can't sneak in unnoticed.

### What ships

- **`tests/Determinism/TwiceHarness.php`** — shared "run twice, diff empty" harness with `assertTreesByteEqual()` / `assertFilesByteEqual()` that catches both file-set drift (missing files) and byte-level drift (one-character timestamp leak).
- **`tests/AgentSpec/Determinism/ManifestDeterminismTest.php`** — runs `manifest:generate` in-process twice into sibling temp dirs and asserts every emitted manifest is byte-equal (**37** file-byte assertions).
- **`tests/Scaffold/Determinism/SdkEmitterDeterminismTest.php`** — same for the TypeScript and Python SDK emitters against the existing `users-api.yaml` fixture, `#[DataProvider]`'d over both languages.
- **`tests/Scaffold/Determinism/EmitOpenApiDeterminismTest.php`** — the fragment merger, with deliberately-unsorted fragment filenames (`zeta.yaml` + `alpha.yaml`) to exercise the merge-order sort.
- **`.github/workflows/ci.yml`**: a new **`Determinism gate (#74)`** job that regenerates `.agent/` and `git diff --exit-code`s it. A non-deterministic emitter fails the gate on every PR.
- **Skeleton workflow** at `src/Altair/Bootstrap/resources/skeleton/.github/workflows/determinism.yml` — same gate generalised for generated host projects (probes for `.agent/`, `app/`, `docs/openapi.yaml`). `bin/altair new` now ships the gate.
- **`AGENT.md §Determinism` updated**: standard goes from "tracked" to **"enforced"**, with concrete references to the harness, the per-emitter tests, the CI job, the doctor check, and the skeleton workflow.

### Note on existing prior work (kept as context)

- `AGENT.md §Determinism` already defined the standard.
- `src/Altair/Doctor/Check/DeterminismCheck.php` already exists, registered in `DoctorConfiguration` (host-configurable generators/paths), with 4 unit tests in `ProcessChecksTest`. This PR builds on that foundation rather than duplicating it.

### v2 follow-ups (documented; not in this PR)

- Per-package determinism notes in `composer.json` descriptions.
- "Run twice, diff empty" tests for additional emitters (persistence migration emitter, messaging job/handler emitter, scaffold full pipeline including PHP files).
- Default-wire framework generators into `DeterminismCheck` constructor instead of leaving it host-configurable (so `bin/altair doctor` exercises the gate against `.agent/` out of the box without host config).

## Verification

- The new CI gate **detected drift on first run** — the regenerated manifests referenced the new determinism tests in their "Tests as documentation" sections. Manifests regenerated and committed; subsequent regen is a no-op (proving the gate works end-to-end).
- 4 new determinism tests, 44 byte-equality assertions, all green.
- PHPStan L8, CS, Rector all clean cache-free on the whole tree.
- Full suite: 6057 tests; only pre-existing env errors, zero regressions.
- [ ] CI green on PHP 8.3 / 8.4 + the new determinism job.

Implements #74 (v1).