### PR TITLE
feat(http): opt-in FastRoute route cache via cachedDispatcher (#135)

### DIFF
--- a/.agent/packages/http.md
+++ b/.agent/packages/http.md
@@ -149,6 +149,7 @@
 ## Tests as documentation
 
 - `tests/Http/Base/PayloadTest.php`
+- `tests/Http/Configuration/FastRouteConfigurationTest.php`
 - `tests/Http/Formatter/JsonFormatterTest.php`
 - `tests/Http/Input/DtoInputHydratorTest.php`
 - `tests/Http/Jwt/LcobucciTokenGeneratorTest.php`

--- a/docs/packages/http.md
+++ b/docs/packages/http.md
@@ -209,7 +209,7 @@ $response = $relay->handle($request);
 
 ### Routing with FastRoute
 
-Routes are declared as a `RouteCollection` map. Each entry's key is a `"METHOD /path"` string; the value is an `Action` instance. `FastRouteConfiguration` registers a `FastRoute\Dispatcher` factory with the container using `simpleDispatcher` (no file-based cache).
+Routes are declared as a `RouteCollection` map. Each entry's key is a `"METHOD /path"` string; the value is an `Action` instance. `FastRouteConfiguration` registers a `FastRoute\Dispatcher` factory with the container. By default it uses `simpleDispatcher` (recompiles routes on every request — fine for dev). Pass an `Altair\Configuration\Support\Env` as the second constructor argument to opt into `cachedDispatcher`, then set `ROUTE_CACHE_FILE` in the environment to a writable file path; see the **Configuration** section below for the env-var contract.
 
 ```php
 use Altair\Http\Base\Action;
@@ -435,7 +435,14 @@ Each `Configuration` class implements `ConfigurationInterface` from `univeros/co
 
 **`RelayConfiguration`** wires `ContainerResolver` with the container instance and delegates `Relay\Relay` construction to a factory that reads `MiddlewareCollection` from the container. You must push your middleware into `MiddlewareCollection` before applying this configuration.
 
-**`FastRouteConfiguration`** registers a `FastRoute\Dispatcher` factory using `FastRoute\simpleDispatcher`. It iterates the `RouteCollection`, splits each key on the first space to get the HTTP method and path, and adds them to the FastRoute collector. There is no file-based route cache; if you need caching use `cachedDispatcher` and replace the factory.
+**`FastRouteConfiguration`** registers a `FastRoute\Dispatcher` factory. It iterates the `RouteCollection`, splits each key on the first space to get the HTTP method and path, and adds them to the FastRoute collector. The constructor takes an optional `Altair\Configuration\Support\Env` as a second argument; when omitted the factory uses `FastRoute\simpleDispatcher` (no file cache, recompiles every request — the dev default). When `Env` is provided the configuration reads these environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `ROUTE_CACHE_FILE` | unset | Absolute path to the compiled route-cache file. When unset or empty the configuration falls back to `simpleDispatcher`. The host must make the directory writable on deploy (pre-warm it in your build, or delete the file to bust the cache). |
+| `ROUTE_CACHE_DISABLED` | `false` | Kill switch. When truthy (`1`, `true`, `on`, `yes`) `simpleDispatcher` is used even if `ROUTE_CACHE_FILE` is set — useful for dev hosts that always export the cache path but want recompiles while editing routes. |
+
+`Action` implements `__set_state`, so the cached dispatch data round-trips through PHP's `var_export` correctly.
 
 **`PayloadConfiguration`** aliases `PayloadInterface` to `Payload`. This is required for the container to inject `PayloadInterface` automatically.
 
@@ -860,7 +867,7 @@ The Http package deliberately excludes several concerns:
 
 - **HTTP/2 server push** — Not supported, and largely moot (server push has been removed from major browsers); the package stays at the message-oriented PSR-7/PSR-15 level. Note that server-sent events *are* achievable over PSR-15 — Observatory's `ActivityStreamHandler` streams an SSE tail through an emit-and-close handler — they are simply not shipped as a built-in Http helper.
 - **WebSockets** — WebSocket connections require a protocol upgrade and persistent connection handling outside the PSR-15 request/response cycle.
-- **Route caching** — `FastRouteConfiguration` uses `simpleDispatcher`, which recompiles routes on every request. For high-traffic applications, replace the factory with `cachedDispatcher` and a file path.
+- **Route caching** — `FastRouteConfiguration` defaults to `simpleDispatcher` (recompiles every request, safe for dev). Set `ROUTE_CACHE_FILE` to a writable path to opt into FastRoute's `cachedDispatcher`; flip `ROUTE_CACHE_DISABLED=1` to force the simple path back on without un-setting the cache path. The cache file is a plain PHP file written via `var_export` — pre-warm it on deploy and delete it to bust the cache. See the **Configuration** section above.
 - **Rate limiting** — `RateLimitMiddleware` is a fixed-window PSR-15 limiter backed by any PSR-16 cache pool (`Altair\Cache` works out of the box). The default `IpKeyResolver` keys on the client IP, preferring the `ATTRIBUTE_IP_ADDRESS` attribute set by `IpAddressMiddleware` (so trusted-proxy resolution lives in one place — never trust `X-Forwarded-For` directly); pass a custom `KeyResolverInterface` for API-key or user-id keying. Under-limit requests pass through with informational `X-RateLimit-Limit / Remaining / Reset` headers; at-limit returns `429 Too Many Requests` with `Retry-After`. Fixed-window has the classic boundary burst (`2 × limit` across the window edge); layer a token-bucket on top if you need stricter accounting. Complements edge / reverse-proxy rate limiting; does not replace it.
 - **Request body streaming** — `JsonContentMiddleware` and `FormContentMiddleware` buffer the entire body string via `(string) $request->getBody()`. They are not suitable for very large request bodies.
 - **Multipart form data** — File upload parsing relies on PHP's built-in `$_FILES` superglobal via `ServerRequestFactory::fromGlobals()`. Complex multipart handling is outside the package's scope.

--- a/src/Altair/Http/Base/Action.php
+++ b/src/Altair/Http/Base/Action.php
@@ -50,6 +50,21 @@ class Action
     }
 
     /**
+     * Rehydrates an Action from a `var_export`-serialized state array.
+     *
+     * Required so that {@see \FastRoute\cachedDispatcher} can read back
+     * Actions stored in its compiled route-cache file — without this,
+     * the cache file would emit `Action::__set_state(...)` calls that
+     * PHP could not resolve.
+     *
+     * @param array{domain: string, responder: string, input: string} $data
+     */
+    public static function __set_state(array $data): self
+    {
+        return new self($data['domain'], $data['responder'], $data['input']);
+    }
+
+    /**
      * Returns the domain specification fully qualified class name.
      *
      * @return string of \Altair\Http\Contracts\DomainInterface

--- a/src/Altair/Http/Configuration/FastRouteConfiguration.php
+++ b/src/Altair/Http/Configuration/FastRouteConfiguration.php
@@ -12,21 +12,40 @@ declare(strict_types=1);
 namespace Altair\Http\Configuration;
 
 use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Configuration\Support\Env;
 use Altair\Container\Container;
 use Altair\Http\Collection\RouteCollection;
+
+use function FastRoute\cachedDispatcher;
+
 use FastRoute\Dispatcher;
 use FastRoute\RouteCollector;
 
 use function FastRoute\simpleDispatcher;
+
+use const FILTER_VALIDATE_BOOLEAN;
 
 use Override;
 
 class FastRouteConfiguration implements ConfigurationInterface
 {
     /**
-     * FastRouteConfiguration constructor.
+     * Environment key opting the dispatcher into FastRoute's file-based cache.
+     * When unset or empty, the dispatcher falls back to {@see simpleDispatcher}.
      */
-    public function __construct(protected RouteCollection $routeCollection) {}
+    public const string ENV_ROUTE_CACHE_FILE = 'ROUTE_CACHE_FILE';
+
+    /**
+     * Environment kill switch — when truthy, {@see simpleDispatcher} is used
+     * even if {@see self::ENV_ROUTE_CACHE_FILE} is set. Useful for dev hosts
+     * that always export the cache path but want recompiles on every request.
+     */
+    public const string ENV_ROUTE_CACHE_DISABLED = 'ROUTE_CACHE_DISABLED';
+
+    public function __construct(
+        protected RouteCollection $routeCollection,
+        protected ?Env $env = null,
+    ) {}
 
     /**
      * @inheritDoc
@@ -34,14 +53,45 @@ class FastRouteConfiguration implements ConfigurationInterface
     #[Override]
     public function apply(Container $container): void
     {
-        $factory = fn() => simpleDispatcher(
-            function (RouteCollector $routeCollector): void {
-                foreach ($this->routeCollection as $request => $action) {
-                    [$method, $path] = explode(' ', $request, 2);
-                    $routeCollector->addRoute($method, $path, $action);
-                }
+        $cacheFile = $this->resolveCacheFile();
+
+        $definition = function (RouteCollector $routeCollector): void {
+            foreach ($this->routeCollection as $request => $action) {
+                [$method, $path] = explode(' ', $request, 2);
+                $routeCollector->addRoute($method, $path, $action);
             }
-        );
+        };
+
+        $factory = $cacheFile === null
+            ? fn(): Dispatcher => simpleDispatcher($definition)
+            : fn(): Dispatcher => cachedDispatcher($definition, ['cacheFile' => $cacheFile]);
+
         $container->factory(Dispatcher::class, $factory);
+    }
+
+    /**
+     * Returns the configured route-cache file path, or null when the dispatcher
+     * should keep using {@see simpleDispatcher} (cache disabled or unconfigured).
+     */
+    private function resolveCacheFile(): ?string
+    {
+        if (!$this->env instanceof Env) {
+            return null;
+        }
+
+        $disabled = filter_var(
+            $this->env->get(self::ENV_ROUTE_CACHE_DISABLED, false),
+            FILTER_VALIDATE_BOOLEAN,
+        );
+        if ($disabled) {
+            return null;
+        }
+
+        $cacheFile = $this->env->get(self::ENV_ROUTE_CACHE_FILE);
+        if (!\is_string($cacheFile) || $cacheFile === '') {
+            return null;
+        }
+
+        return $cacheFile;
     }
 }

--- a/tests/Http/Configuration/FastRouteConfigurationTest.php
+++ b/tests/Http/Configuration/FastRouteConfigurationTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Http\Configuration;
+
+use Altair\Configuration\Support\Env;
+use Altair\Container\Container;
+use Altair\Http\Base\Action;
+use Altair\Http\Collection\RouteCollection;
+use Altair\Http\Configuration\FastRouteConfiguration;
+use FastRoute\Dispatcher;
+use Override;
+use PHPUnit\Framework\TestCase;
+
+class FastRouteConfigurationTest extends TestCase
+{
+    /** @var list<string> */
+    private array $appliedKeys = [];
+
+    private ?string $cacheFile = null;
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        foreach ($this->appliedKeys as $key) {
+            unset($_ENV[$key], $_SERVER[$key]);
+            putenv($key);
+        }
+
+        $this->appliedKeys = [];
+
+        if ($this->cacheFile !== null && \file_exists($this->cacheFile)) {
+            \unlink($this->cacheFile);
+        }
+
+        $this->cacheFile = null;
+
+        parent::tearDown();
+    }
+
+    public function testDefaultsToSimpleDispatcherWhenEnvIsNotProvided(): void
+    {
+        $container = new Container();
+        $routes = $this->routes();
+
+        (new FastRouteConfiguration($routes))->apply($container);
+
+        $dispatcher = $container->get(Dispatcher::class);
+
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
+        $result = $dispatcher->dispatch('GET', '/users/42');
+        $this->assertSame(Dispatcher::FOUND, $result[0]);
+        $this->assertInstanceOf(Action::class, $result[1]);
+        $this->assertSame(['id' => '42'], $result[2]);
+    }
+
+    public function testSimpleDispatcherFallbackWhenRouteCacheFileIsNotSet(): void
+    {
+        $container = new Container();
+
+        (new FastRouteConfiguration($this->routes(), new Env()))->apply($container);
+
+        $dispatcher = $container->get(Dispatcher::class);
+
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
+        $result = $dispatcher->dispatch('GET', '/users/42');
+        $this->assertSame(Dispatcher::FOUND, $result[0]);
+    }
+
+    public function testCachedDispatcherWritesCacheFileWhenRouteCacheFileIsSet(): void
+    {
+        $this->cacheFile = \sys_get_temp_dir() . '/altair-fastroute-' . \uniqid('', true) . '.php';
+        $this->assertFileDoesNotExist($this->cacheFile);
+
+        $this->setEnv(['ROUTE_CACHE_FILE' => $this->cacheFile]);
+
+        $container = new Container();
+        (new FastRouteConfiguration($this->routes(), new Env()))->apply($container);
+
+        $dispatcher = $container->get(Dispatcher::class);
+
+        $this->assertFileExists($this->cacheFile);
+        $cached = require $this->cacheFile;
+        $this->assertIsArray($cached);
+
+        $result = $dispatcher->dispatch('GET', '/users/42');
+        $this->assertSame(Dispatcher::FOUND, $result[0]);
+    }
+
+    public function testCachedDispatcherReadsExistingCacheFileWithoutRecompiling(): void
+    {
+        $this->cacheFile = \sys_get_temp_dir() . '/altair-fastroute-' . \uniqid('', true) . '.php';
+        $this->setEnv(['ROUTE_CACHE_FILE' => $this->cacheFile]);
+
+        // First boot: compiles + writes the cache file.
+        $first = new Container();
+        (new FastRouteConfiguration($this->routes(), new Env()))->apply($first);
+        $first->get(Dispatcher::class);
+        $this->assertFileExists($this->cacheFile);
+
+        $cachedMtime = \filemtime($this->cacheFile);
+
+        // Second boot with an empty collection — if the cache were ignored the route
+        // would not be found. Reading the cache file proves the warm path is taken.
+        $second = new Container();
+        (new FastRouteConfiguration(new RouteCollection(), new Env()))->apply($second);
+        $dispatcher = $second->get(Dispatcher::class);
+
+        $result = $dispatcher->dispatch('GET', '/users/42');
+        $this->assertSame(Dispatcher::FOUND, $result[0]);
+        $this->assertSame($cachedMtime, \filemtime($this->cacheFile), 'cache file should not be rewritten on warm boot');
+    }
+
+    public function testRouteCacheDisabledForcesSimpleDispatcherEvenWhenCacheFileIsSet(): void
+    {
+        $this->cacheFile = \sys_get_temp_dir() . '/altair-fastroute-' . \uniqid('', true) . '.php';
+        $this->setEnv([
+            'ROUTE_CACHE_FILE' => $this->cacheFile,
+            'ROUTE_CACHE_DISABLED' => '1',
+        ]);
+
+        $container = new Container();
+        (new FastRouteConfiguration($this->routes(), new Env()))->apply($container);
+
+        $dispatcher = $container->get(Dispatcher::class);
+
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
+        $this->assertFileDoesNotExist(
+            $this->cacheFile,
+            'cache file must not be written when ROUTE_CACHE_DISABLED is truthy',
+        );
+
+        $result = $dispatcher->dispatch('GET', '/users/42');
+        $this->assertSame(Dispatcher::FOUND, $result[0]);
+    }
+
+    public function testEmptyRouteCacheFileFallsBackToSimpleDispatcher(): void
+    {
+        $this->setEnv(['ROUTE_CACHE_FILE' => '']);
+
+        $container = new Container();
+        (new FastRouteConfiguration($this->routes(), new Env()))->apply($container);
+
+        $dispatcher = $container->get(Dispatcher::class);
+
+        $this->assertInstanceOf(Dispatcher::class, $dispatcher);
+        $result = $dispatcher->dispatch('GET', '/users/42');
+        $this->assertSame(Dispatcher::FOUND, $result[0]);
+    }
+
+    private function routes(): RouteCollection
+    {
+        $routes = new RouteCollection();
+        $routes->put('GET /users/{id:\d+}', new Action(\stdClass::class));
+
+        return $routes;
+    }
+
+    /**
+     * @param array<string, string> $values
+     */
+    private function setEnv(array $values): void
+    {
+        foreach ($values as $key => $value) {
+            $_ENV[$key] = $value;
+            $_SERVER[$key] = $value;
+            \putenv($key . '=' . $value);
+            $this->appliedKeys[] = $key;
+        }
+    }
+}


### PR DESCRIPTION
Closes #135.

## Summary

- `FastRouteConfiguration` now accepts an optional `Env` as a second constructor argument. When `Env` is provided **and** `ROUTE_CACHE_FILE` is set, the dispatcher factory uses FastRoute's `cachedDispatcher` (compile once, read back on every subsequent request). When `Env` is absent — or `ROUTE_CACHE_FILE` is empty — the factory keeps using `simpleDispatcher`, preserving today's behaviour for every existing host.
- `ROUTE_CACHE_DISABLED=1` is a kill switch that forces `simpleDispatcher` even when the cache file path is set. Convenient for dev hosts that always export the path but want recompiles while editing routes.
- `Action::__set_state` is added so the `var_export`-serialized dispatch data round-trips through the cache file. Without it, the file would emit `Action::__set_state(...)` calls that PHP couldn't resolve, and `require`ing the cache would fatal.

## Acceptance criteria (from issue)

- [x] `cachedDispatcher` used when configured; `simpleDispatcher` fallback preserved (dev default).
- [x] Env-driven, no behavioural change for hosts that don't set the cache path.
- [x] Test covering both paths (cached file produced + dispatch works; fallback when unset).
- [x] `docs/packages/http.md` "Route caching" limitation updated to document the new behaviour.

## Caveats called out in the issue, addressed in this PR

- The cache file is a plain PHP file written via `file_put_contents` — host must make the directory writable on deploy. Documented in `docs/packages/http.md` Configuration + Limitations sections.
- Cache busting = `rm` the file (or pre-warm it in the build). Documented. A `bin/altair routes:cache-clear` helper is intentionally out of scope per the issue.
- Stale-prone while editing routes in dev — exactly why this is opt-in, and why `ROUTE_CACHE_DISABLED` exists.

## Test plan

- [x] `composer cs` — clean
- [x] `composer stan` — `[OK] No errors`
- [x] `composer rector` — `[OK] Rector is done!` (full tree)
- [x] `composer test -- --filter '/Altair\\(Tests\\Http|Http\\)/'` — 157 tests / 245 assertions pass (warning is the missing xdebug coverage driver, not a real failure)
- [x] `bin/altair manifest:generate` re-run; only the new test file shows up in `.agent/packages/http.md`'s "Tests as documentation" list

## Tests added (`tests/Http/Configuration/FastRouteConfigurationTest.php`)

- `testDefaultsToSimpleDispatcherWhenEnvIsNotProvided` — bare constructor path (no env arg).
- `testSimpleDispatcherFallbackWhenRouteCacheFileIsNotSet` — Env present, no cache file → still simple.
- `testCachedDispatcherWritesCacheFileWhenRouteCacheFileIsSet` — cold boot writes the PHP cache file and dispatches.
- `testCachedDispatcherReadsExistingCacheFileWithoutRecompiling` — warm boot with an empty `RouteCollection` still finds the route, proving the cache file (not the closure) is the source of truth; cache mtime is unchanged.
- `testRouteCacheDisabledForcesSimpleDispatcherEvenWhenCacheFileIsSet` — kill switch beats path.
- `testEmptyRouteCacheFileFallsBackToSimpleDispatcher` — defensive: empty string is treated as unset.