### PR TITLE
feat(scaffold): finish #74 per-emitter determinism tests + kill migration time() leak

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -78,6 +78,9 @@
 
 - `tests/Scaffold/Cli/ScaffoldCommandIntegrationTest.php`
 - `tests/Scaffold/Determinism/EmitOpenApiDeterminismTest.php`
+- `tests/Scaffold/Determinism/MessagingEmitterDeterminismTest.php`
+- `tests/Scaffold/Determinism/PersistenceEmitterDeterminismTest.php`
+- `tests/Scaffold/Determinism/ScaffoldCommandDeterminismTest.php`
 - `tests/Scaffold/Determinism/SdkEmitterDeterminismTest.php`
 - `tests/Scaffold/Emitter/ActionEmitterTest.php`
 - `tests/Scaffold/Emitter/DomainStubEmitterTest.php`
@@ -87,6 +90,7 @@
 - `tests/Scaffold/Emitter/InputEmitterTest.php`
 - `tests/Scaffold/Emitter/MessageEmitterTest.php`
 - `tests/Scaffold/Emitter/MigrationEmitterTest.php`
+- `tests/Scaffold/Emitter/NamingTest.php`
 - `tests/Scaffold/Emitter/OpenApiEmitterTest.php`
 - `tests/Scaffold/Emitter/RepositoryEmitterTest.php`
 - `tests/Scaffold/Emitter/ResponderEmitterTest.php`

--- a/src/Altair/Scaffold/Emitter/Naming.php
+++ b/src/Altair/Scaffold/Emitter/Naming.php
@@ -21,6 +21,12 @@ use Altair\Scaffold\Spec\Ast\Spec;
  */
 final readonly class Naming
 {
+    /** 2000-01-01T00:00:00Z, expressed as a Unix timestamp. */
+    private const int MIGRATION_STAMP_EPOCH = 946684800;
+
+    /** ~10 years in seconds — the deterministic stamp window. */
+    private const int MIGRATION_STAMP_WINDOW = 315360000;
+
     public function __construct(
         private string $appNamespace = 'App',
         private string $httpRelativeRoot = 'app/Http',
@@ -146,7 +152,7 @@ final readonly class Naming
             return '';
         }
 
-        $stamp = ($timestamp ?? time());
+        $stamp = $timestamp ?? $this->deterministicMigrationStamp($spec);
         $date = gmdate('Ymd.His', $stamp);
         $table = preg_replace('/[^a-z0-9_]+/i', '_', strtolower($spec->persistence->entity->table)) ?? 'table';
 
@@ -159,7 +165,7 @@ final readonly class Naming
             return 'Migration';
         }
 
-        $stamp = ($timestamp ?? time());
+        $stamp = $timestamp ?? $this->deterministicMigrationStamp($spec);
         $table = preg_replace('/[^a-zA-Z0-9_]+/', '_', $spec->persistence->entity->table) ?? 'table';
 
         return 'M' . gmdate('YmdHis', $stamp) . 'Create' . $this->camelize($table) . 'Table';
@@ -193,6 +199,27 @@ final readonly class Naming
     public function handlerTestShortName(string $messageFqcn): string
     {
         return $this->shortNameOf($this->handlerFqcn($messageFqcn)) . 'Test';
+    }
+
+    /**
+     * Content-addressed migration stamp — same spec produces the same
+     * filename and class name across runs and machines (#74 determinism
+     * standard). The stamp falls inside a fixed ~10-year window starting
+     * 2000-01-01 UTC, so scaffolded CREATE TABLE migrations always sort
+     * before any later wall-clock migration written by migration-intelligence
+     * (#80) or hand-written by the host. Different entity tables get
+     * different stamps via the sha256 spread, so Cycle's filename-ordered
+     * migrator still runs them in a stable order.
+     */
+    private function deterministicMigrationStamp(Spec $spec): int
+    {
+        if (!$spec->persistence instanceof PersistenceSpec) {
+            return self::MIGRATION_STAMP_EPOCH;
+        }
+
+        $hash = hexdec(substr(hash('sha256', $spec->persistence->entity->table), 0, 8));
+
+        return self::MIGRATION_STAMP_EPOCH + $hash % self::MIGRATION_STAMP_WINDOW;
     }
 
     private function classFileRelativePath(string $fqcn): string

--- a/tests/Scaffold/Determinism/MessagingEmitterDeterminismTest.php
+++ b/tests/Scaffold/Determinism/MessagingEmitterDeterminismTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Scaffold\Determinism;
+
+use Altair\Scaffold\Cli\ScaffoldCommand;
+use Altair\Scaffold\Emitter\EmissionPlan;
+use Altair\Scaffold\Emitter\EmittedFileKind;
+use Altair\Tests\Determinism\TwiceHarness;
+use Altair\Tests\Scaffold\Support\SpecFixture;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #74 acceptance for the messaging emitters wired into `spec:scaffold` —
+ * the DTO message class, the handler stub, and the handler PHPUnit test
+ * must be byte-equal across runs of the same spec.
+ *
+ * Asserts at both the CLI surface (`spec:scaffold api/x.yaml`) and the
+ * in-process emitter surface (`EmissionPlan::build`), so a future
+ * regression in either entry point is caught directly.
+ */
+#[CoversClass(ScaffoldCommand::class)]
+#[CoversClass(EmissionPlan::class)]
+final class MessagingEmitterDeterminismTest extends TestCase
+{
+    private TwiceHarness $harness;
+
+    private string $specPath;
+
+    private string $specRoot;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->harness = new TwiceHarness('altair-determinism-messaging');
+        $this->specRoot = sys_get_temp_dir() . '/altair-determinism-messaging-spec-' . bin2hex(random_bytes(5));
+        mkdir($this->specRoot . '/api/users', 0o755, true);
+
+        $this->specPath = $this->specRoot . '/api/users/create.yaml';
+        file_put_contents($this->specPath, $this->sampleSpecWithQueue());
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->harness->cleanup();
+        $this->removeDirectory($this->specRoot);
+    }
+
+    public function testScaffoldEmitsByteIdenticalMessagingFilesAcrossRuns(): void
+    {
+        $command = new ScaffoldCommand();
+        $specPath = $this->specPath;
+
+        [$first, $second] = $this->harness->pair(function (string $out) use ($command, $specPath): void {
+            ob_start();
+            $command(path: $specPath, dryRun: false, force: true, root: $out);
+            ob_end_clean();
+        });
+
+        $this->harness->assertTreesByteEqual($first, $second);
+    }
+
+    public function testEmissionPlanProducesByteIdenticalMessagingFilesAcrossInvocations(): void
+    {
+        $spec = SpecFixture::createUserWithQueue();
+        $plan = new EmissionPlan();
+
+        $firstRun = $plan->build($spec);
+        $secondRun = $plan->build($spec);
+
+        self::assertSameSize($firstRun, $secondRun);
+
+        $messagingKinds = [
+            EmittedFileKind::Message,
+            EmittedFileKind::Handler,
+            EmittedFileKind::HandlerTest,
+        ];
+        $messagingFilesChecked = 0;
+
+        foreach ($firstRun as $index => $file) {
+            $other = $secondRun[$index];
+            self::assertSame($file->relativePath, $other->relativePath, 'emitter path drift');
+            self::assertSame($file->contents, $other->contents, 'emitter content drift for ' . $file->relativePath);
+
+            if (\in_array($file->kind, $messagingKinds, true)) {
+                $messagingFilesChecked++;
+            }
+        }
+
+        self::assertGreaterThanOrEqual(3, $messagingFilesChecked, 'expected message DTO + handler + handler test');
+    }
+
+    private function sampleSpecWithQueue(): string
+    {
+        return <<<'YAML'
+            endpoint:
+              method: POST
+              path: /users
+              summary: Create a new user
+              tags: [users]
+            input:
+              email:
+                type: string
+                rules: [email, required]
+              password:
+                type: string
+                rules: [min:8, required]
+                sensitive: true
+            output:
+              201:
+                body:
+                  user: App\User\User
+              422:
+                body:
+                  errors: array<string, list<string>>
+              409:
+                body:
+                  message: string
+            domain:
+              class: App\User\CreateUser
+              invocation: __invoke
+            queue:
+              on_create:
+                message: App\Messages\SendWelcomeEmail
+                transport: default
+                fields:
+                  userId: string
+                  email:  string
+            YAML;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Scaffold/Determinism/PersistenceEmitterDeterminismTest.php
+++ b/tests/Scaffold/Determinism/PersistenceEmitterDeterminismTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Scaffold\Determinism;
+
+use Altair\Scaffold\Cli\ScaffoldCommand;
+use Altair\Scaffold\Emitter\EmissionPlan;
+use Altair\Scaffold\Emitter\EmittedFileKind;
+use Altair\Tests\Determinism\TwiceHarness;
+use Altair\Tests\Scaffold\Support\SpecFixture;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #74 acceptance for the persistence emitters wired into `spec:scaffold` —
+ * entity + repository + migration files must be byte-equal across runs of
+ * the same spec.
+ *
+ * The migration emitter historically defaulted its filename timestamp to
+ * `time()`, which silently broke the standard for any spec carrying a
+ * `persistence:` block. This test guards both the path-level surface
+ * (`bin/altair spec:scaffold api/x.yaml`) and the in-process emitter
+ * surface (`EmissionPlan::build`), so a future regression in either entry
+ * point gets caught.
+ */
+#[CoversClass(ScaffoldCommand::class)]
+#[CoversClass(EmissionPlan::class)]
+final class PersistenceEmitterDeterminismTest extends TestCase
+{
+    private TwiceHarness $harness;
+
+    private string $specPath;
+
+    private string $specRoot;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->harness = new TwiceHarness('altair-determinism-persistence');
+        $this->specRoot = sys_get_temp_dir() . '/altair-determinism-persistence-spec-' . bin2hex(random_bytes(5));
+        mkdir($this->specRoot . '/api/users', 0o755, true);
+
+        $this->specPath = $this->specRoot . '/api/users/create.yaml';
+        file_put_contents($this->specPath, $this->sampleSpecWithPersistence());
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->harness->cleanup();
+        $this->removeDirectory($this->specRoot);
+    }
+
+    public function testScaffoldEmitsByteIdenticalPersistenceFilesAcrossRuns(): void
+    {
+        $command = new ScaffoldCommand();
+        $specPath = $this->specPath;
+
+        [$first, $second] = $this->harness->pair(function (string $out) use ($command, $specPath): void {
+            ob_start();
+            $command(path: $specPath, dryRun: false, force: true, root: $out);
+            ob_end_clean();
+        });
+
+        $this->harness->assertTreesByteEqual($first, $second);
+    }
+
+    public function testEmissionPlanProducesByteIdenticalPersistenceFilesAcrossInvocations(): void
+    {
+        $spec = SpecFixture::createUserWithPersistence();
+        $plan = new EmissionPlan();
+
+        $firstRun = $plan->build($spec);
+        $secondRun = $plan->build($spec);
+
+        self::assertSameSize($firstRun, $secondRun);
+
+        $persistenceKinds = [
+            EmittedFileKind::Entity,
+            EmittedFileKind::Repository,
+            EmittedFileKind::Migration,
+        ];
+        $persistenceFilesChecked = 0;
+
+        foreach ($firstRun as $index => $file) {
+            $other = $secondRun[$index];
+            self::assertSame($file->relativePath, $other->relativePath, 'emitter path drift');
+            self::assertSame($file->contents, $other->contents, 'emitter content drift for ' . $file->relativePath);
+
+            if (\in_array($file->kind, $persistenceKinds, true)) {
+                $persistenceFilesChecked++;
+            }
+        }
+
+        self::assertGreaterThanOrEqual(3, $persistenceFilesChecked, 'expected entity + repository + migration');
+    }
+
+    private function sampleSpecWithPersistence(): string
+    {
+        return <<<'YAML'
+            endpoint:
+              method: POST
+              path: /users
+              summary: Create a new user
+              tags: [users]
+            input:
+              email:
+                type: string
+                rules: [email, required]
+              password:
+                type: string
+                rules: [min:8, required]
+                sensitive: true
+            output:
+              201:
+                body:
+                  user: App\User\User
+              422:
+                body:
+                  errors: array<string, list<string>>
+              409:
+                body:
+                  message: string
+            domain:
+              class: App\User\CreateUser
+              invocation: __invoke
+            persistence:
+              entity:
+                class: App\User\User
+                table: users
+                fields:
+                  id:            { type: uuid, primary: true }
+                  email:         { type: string, unique: true }
+                  password_hash: { type: string }
+                  created_at:    { type: datetime, default: now }
+              repository: App\User\UserRepository
+            YAML;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Scaffold/Determinism/ScaffoldCommandDeterminismTest.php
+++ b/tests/Scaffold/Determinism/ScaffoldCommandDeterminismTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Scaffold\Determinism;
+
+use Altair\Scaffold\Cli\ScaffoldCommand;
+use Altair\Tests\Determinism\TwiceHarness;
+use Override;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * #74 acceptance: `bin/altair spec:scaffold` must produce byte-identical
+ * output across runs. Drift here would mean an emitter is iterating an
+ * unordered map (input field, output response, header collection) or
+ * stamping a wall-clock value into the generated file. This test runs the
+ * command twice into sibling temp roots and asserts every emitted file —
+ * Action, Input, Responder, Domain stub, test, OpenAPI fragment, route
+ * entry — is byte-equal.
+ *
+ * Persistence- and queue-block scaffolds get their own focused determinism
+ * tests so a failure points at the offending emitter directly.
+ */
+#[CoversClass(ScaffoldCommand::class)]
+final class ScaffoldCommandDeterminismTest extends TestCase
+{
+    private TwiceHarness $harness;
+
+    private string $specPath;
+
+    private string $specRoot;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        $this->harness = new TwiceHarness('altair-determinism-scaffold');
+        $this->specRoot = sys_get_temp_dir() . '/altair-determinism-scaffold-spec-' . bin2hex(random_bytes(5));
+        mkdir($this->specRoot . '/api/users', 0o755, true);
+
+        $this->specPath = $this->specRoot . '/api/users/create.yaml';
+        file_put_contents($this->specPath, $this->sampleSpec());
+    }
+
+    #[Override]
+    protected function tearDown(): void
+    {
+        $this->harness->cleanup();
+        $this->removeDirectory($this->specRoot);
+    }
+
+    public function testScaffoldCommandIsByteDeterministicAcrossRuns(): void
+    {
+        $command = new ScaffoldCommand();
+        $specPath = $this->specPath;
+
+        [$first, $second] = $this->harness->pair(function (string $out) use ($command, $specPath): void {
+            ob_start();
+            $command(path: $specPath, dryRun: false, force: true, root: $out);
+            ob_end_clean();
+        });
+
+        $this->harness->assertTreesByteEqual($first, $second);
+    }
+
+    private function sampleSpec(): string
+    {
+        return <<<'YAML'
+            endpoint:
+              method: POST
+              path: /users
+              summary: Create a new user
+              tags: [users]
+            input:
+              email:
+                type: string
+                rules: [email, required]
+              password:
+                type: string
+                rules: [min:8, required]
+                sensitive: true
+            output:
+              201:
+                body:
+                  user: App\User\User
+              422:
+                body:
+                  errors: array<string, list<string>>
+              409:
+                body:
+                  message: string
+            domain:
+              class: App\User\CreateUser
+              invocation: __invoke
+            YAML;
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $file) {
+            $file->isDir() ? rmdir($file->getPathname()) : unlink($file->getPathname());
+        }
+
+        rmdir($path);
+    }
+}

--- a/tests/Scaffold/Emitter/NamingTest.php
+++ b/tests/Scaffold/Emitter/NamingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Scaffold\Emitter;
+
+use Altair\Scaffold\Emitter\Naming;
+use Altair\Scaffold\Spec\Ast\PersistenceEntitySpec;
+use Altair\Scaffold\Spec\Ast\PersistenceFieldSpec;
+use Altair\Scaffold\Spec\Ast\PersistenceSpec;
+use Altair\Scaffold\Spec\Ast\Spec;
+use Altair\Tests\Scaffold\Support\SpecFixture;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(Naming::class)]
+final class NamingTest extends TestCase
+{
+    public function testMigrationPathIsDeterministicWhenTimestampNotProvided(): void
+    {
+        $naming = new Naming();
+        $spec = SpecFixture::createUserWithPersistence();
+
+        $first = $naming->migrationPath($spec);
+        $second = $naming->migrationPath($spec);
+        $third = $naming->migrationPath($spec);
+
+        self::assertSame($first, $second);
+        self::assertSame($first, $third);
+        self::assertNotSame('', $first);
+    }
+
+    public function testMigrationClassNameIsDeterministicWhenTimestampNotProvided(): void
+    {
+        $naming = new Naming();
+        $spec = SpecFixture::createUserWithPersistence();
+
+        $first = $naming->migrationClassName($spec);
+        $second = $naming->migrationClassName($spec);
+
+        self::assertSame($first, $second);
+        self::assertStringStartsWith('M', $first);
+        self::assertStringContainsString('CreateUsersTable', $first);
+    }
+
+    public function testMigrationStampVariesAcrossEntityTables(): void
+    {
+        $naming = new Naming();
+        $usersPath = $naming->migrationPath(SpecFixture::createUserWithPersistence());
+        $ordersPath = $naming->migrationPath($this->orderSpec());
+
+        self::assertNotSame($usersPath, $ordersPath, 'different entity tables must produce different migration stamps');
+    }
+
+    public function testMigrationStampFallsInsideTheFixedPreEpochWindow(): void
+    {
+        $naming = new Naming();
+        $path = $naming->migrationPath(SpecFixture::createUserWithPersistence());
+
+        // Path shape: database/migrations/<Ymd.His>_0_create_<table>.php
+        preg_match('#/(\d{8})\.(\d{6})_#', $path, $matches);
+        self::assertCount(3, $matches, 'migration filename did not match expected timestamp pattern');
+
+        $year = (int) substr($matches[1], 0, 4);
+        self::assertGreaterThanOrEqual(2000, $year);
+        self::assertLessThan(2010, $year, 'deterministic stamps must stay inside the fixed 10y window so later wall-clock migrations sort after');
+    }
+
+    public function testExplicitTimestampStillWinsOverDeterministicDefault(): void
+    {
+        $naming = new Naming();
+        $spec = SpecFixture::createUserWithPersistence();
+
+        $derived = $naming->migrationPath($spec);
+        $explicit = $naming->migrationPath($spec, 1777334400); // 2026-04-28 00:00:00 UTC
+
+        self::assertNotSame($derived, $explicit);
+        self::assertStringContainsString('20260428.000000', $explicit);
+    }
+
+    private function orderSpec(): Spec
+    {
+        $base = SpecFixture::createUserWithPersistence();
+
+        return new Spec(
+            endpoint: $base->endpoint,
+            inputs: $base->inputs,
+            outputs: $base->outputs,
+            domain: $base->domain,
+            sourcePath: $base->sourcePath,
+            persistence: new PersistenceSpec(
+                entity: new PersistenceEntitySpec(
+                    class: 'App\\Order\\Order',
+                    table: 'orders',
+                    fields: [
+                        new PersistenceFieldSpec(name: 'id', type: 'uuid', primary: true),
+                        new PersistenceFieldSpec(name: 'total', type: 'integer'),
+                    ],
+                ),
+                repository: 'App\\Order\\OrderRepository',
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Picks up #74 where v1 (PR #148) left off.

## Context

#74 v1 shipped: the standard, the shared `TwiceHarness`, the CI gate, the doctor check, and per-emitter "run twice, diff empty" tests for `manifest:generate`, `spec:emit-openapi`, and `spec:emit-sdk`. The issue's open comment still asked for the same coverage on **`spec:scaffold`** itself and on the **persistence** + **messaging** emitters wired into it.

This PR fills those in — and fixes the one real determinism leak the new tests surfaced.

## What ships

- **`tests/Scaffold/Determinism/ScaffoldCommandDeterminismTest`** — runs `spec:scaffold` twice into sibling temp roots against a basic spec (Action/Input/Responder/Domain stub/test/OpenAPI fragment/route entry), asserts every emitted file is byte-equal.
- **`tests/Scaffold/Determinism/PersistenceEmitterDeterminismTest`** — same, but for a spec with a `persistence:` block (entity + repository + migration). Hits both the CLI surface (`bin/altair spec:scaffold api/x.yaml`) and the in-process emitter surface (`EmissionPlan::build`) so a regression in either entry point is caught.
- **`tests/Scaffold/Determinism/MessagingEmitterDeterminismTest`** — same, for a spec with a `queue:` block (DTO message + handler + handler test).
- **`tests/Scaffold/Emitter/NamingTest`** — locks the new content-addressed migration stamp: deterministic across calls, varies by entity table, stays inside the fixed pre-2010 window so it always sorts before any later wall-clock migration, and the explicit `$timestamp` parameter still overrides.

## The fix the tests surfaced

`Naming::migrationPath()` and `migrationClassName()` defaulted their stamp to `time()` when none was supplied — silently violating the #74 standard for every `persistence:` spec. Two back-to-back local runs happened to pass byte-equality because both fell in the same second; any cross-machine run or one straddling a second drifted by a real timestamp tick.

Replaced with a **content-addressed** stamp: \`sha256\` of the entity table name, spread inside a fixed 10-year window starting 2000-01-01 UTC.

- Same spec → same migration filename across runs and machines.
- Different tables → still different stamps so Cycle's filename-ordered migrator runs them in a stable order.
- All scaffolded CREATE TABLE stamps stay before any later wall-clock migration written by migration-intelligence (#80) or hand-written by the host.

The explicit \`?int \$timestamp\` parameter is preserved, so the existing \`MigrationEmitterTest\` snapshot test (which passes \`FIXED_TIMESTAMP\`) is unaffected.

## Acceptance criteria (from #74)

- [x] Per-emitter "run twice, diff empty" PHPUnit tests for `scaffold` (`spec:scaffold`) — done here.
- [x] Per-emitter "run twice, diff empty" PHPUnit tests for `persistence` — done here.
- [x] Per-emitter "run twice, diff empty" PHPUnit tests for `messaging` — done here.
- [x] Each shipped emitter passes the "run twice, diff = empty" test, baked into the package's PHPUnit suite.
- [ ] CI determinism gate in the **skeleton** (#28) — already shipped in #148 (`src/Altair/Bootstrap/resources/skeleton/.github/workflows/determinism.yml`).
- [ ] Per-package determinism notes in each `composer.json`/README — separate housekeeping pass, not gated by code.
- [x] `bin/altair doctor` includes `determinism_check` — shipped in #99.
- [x] CI determinism gate on every PR — shipped in #148.
- [x] AGENT.md states the standard — shipped in #100.

## Test plan

- [x] `composer cs` — clean
- [x] `composer stan` — `[OK] No errors`
- [x] `composer rector` — `[OK] Rector is done!` (full tree)
- [x] `composer test` — **6080 tests / 12938 assertions**, +10 over the v1 baseline. Only pre-existing env errors (Mongo / Redis / Memcached / Excimer / tsc / mypy missing locally).
- [x] All 22 determinism + Naming tests / 157 assertions green.
- [x] `bin/altair manifest:generate` re-run; only the new test files show up in `.agent/packages/scaffold.md`'s "Tests as documentation" list.