### PR TITLE
feat(splits): expand publishing pipeline to all 35 sub-packages (#14)

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -15,27 +15,46 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Single package to split (leave blank to split all 16)'
+        description: 'Single package to split (leave blank to split all 35)'
         required: false
         type: choice
         default: ''
         options:
           - ''
+          - agent-spec
+          - bootstrap
           - cache
+          - cli
           - common
           - configuration
           - container
           - cookie
           - courier
           - data
+          - doctor
+          - eval
+          - events
           - filesystem
           - happen
           - http
+          - index
+          - introspection
+          - mcp
+          - messaging
           - middleware
+          - migration-intelligence
+          - observability
+          - observatory
+          - persistence
+          - profiling
           - sanitation
+          - scaffold
           - security
           - session
           - structure
+          - suggest
+          - test-reporter
+          - tinker
           - validation
       dry_run:
         description: 'Compute splits but skip pushing to sub-repos'
@@ -61,30 +80,73 @@ jobs:
     outputs:
       matrix: ${{ steps.compute.outputs.matrix }}
     steps:
+      - name: Checkout (for drift check)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Build matrix JSON
         id: compute
         env:
           PACKAGE: ${{ github.event.inputs.package }}
         run: |
           set -euo pipefail
+          # Source of truth: every directory under src/Altair/ that ships a
+          # composer.json with a univeros/<name> package name. Keep this list
+          # alphabetically sorted by composer name so additions are obvious in
+          # review and so the workflow_dispatch dropdown matches.
           full='[
-            {"name":"cache",         "path":"src/Altair/Cache"},
-            {"name":"common",        "path":"src/Altair/Common"},
-            {"name":"configuration", "path":"src/Altair/Configuration"},
-            {"name":"container",     "path":"src/Altair/Container"},
-            {"name":"cookie",        "path":"src/Altair/Cookie"},
-            {"name":"courier",       "path":"src/Altair/Courier"},
-            {"name":"data",          "path":"src/Altair/Data"},
-            {"name":"filesystem",    "path":"src/Altair/Filesystem"},
-            {"name":"happen",        "path":"src/Altair/Happen"},
-            {"name":"http",          "path":"src/Altair/Http"},
-            {"name":"middleware",    "path":"src/Altair/Middleware"},
-            {"name":"sanitation",    "path":"src/Altair/Sanitation"},
-            {"name":"security",      "path":"src/Altair/Security"},
-            {"name":"session",       "path":"src/Altair/Session"},
-            {"name":"structure",     "path":"src/Altair/Structure"},
-            {"name":"validation",    "path":"src/Altair/Validation"}
+            {"name":"agent-spec",             "path":"src/Altair/AgentSpec"},
+            {"name":"bootstrap",              "path":"src/Altair/Bootstrap"},
+            {"name":"cache",                  "path":"src/Altair/Cache"},
+            {"name":"cli",                    "path":"src/Altair/Cli"},
+            {"name":"common",                 "path":"src/Altair/Common"},
+            {"name":"configuration",          "path":"src/Altair/Configuration"},
+            {"name":"container",              "path":"src/Altair/Container"},
+            {"name":"cookie",                 "path":"src/Altair/Cookie"},
+            {"name":"courier",                "path":"src/Altair/Courier"},
+            {"name":"data",                   "path":"src/Altair/Data"},
+            {"name":"doctor",                 "path":"src/Altair/Doctor"},
+            {"name":"eval",                   "path":"src/Altair/Eval"},
+            {"name":"events",                 "path":"src/Altair/Events"},
+            {"name":"filesystem",             "path":"src/Altair/Filesystem"},
+            {"name":"happen",                 "path":"src/Altair/Happen"},
+            {"name":"http",                   "path":"src/Altair/Http"},
+            {"name":"index",                  "path":"src/Altair/Index"},
+            {"name":"introspection",          "path":"src/Altair/Introspection"},
+            {"name":"mcp",                    "path":"src/Altair/Mcp"},
+            {"name":"messaging",              "path":"src/Altair/Messaging"},
+            {"name":"middleware",             "path":"src/Altair/Middleware"},
+            {"name":"migration-intelligence", "path":"src/Altair/MigrationIntelligence"},
+            {"name":"observability",          "path":"src/Altair/Observability"},
+            {"name":"observatory",            "path":"src/Altair/Observatory"},
+            {"name":"persistence",            "path":"src/Altair/Persistence"},
+            {"name":"profiling",              "path":"src/Altair/Profiling"},
+            {"name":"sanitation",             "path":"src/Altair/Sanitation"},
+            {"name":"scaffold",               "path":"src/Altair/Scaffold"},
+            {"name":"security",               "path":"src/Altair/Security"},
+            {"name":"session",                "path":"src/Altair/Session"},
+            {"name":"structure",              "path":"src/Altair/Structure"},
+            {"name":"suggest",                "path":"src/Altair/Suggest"},
+            {"name":"test-reporter",          "path":"src/Altair/TestReporter"},
+            {"name":"tinker",                 "path":"src/Altair/Tinker"},
+            {"name":"validation",             "path":"src/Altair/Validation"}
           ]'
+
+          # Drift guard: every src/Altair/* directory that ships a composer.json
+          # is a publishable sub-package, so it MUST appear in the matrix above.
+          # Surface drift here instead of silently skipping the new package.
+          expected=$(find src/Altair -mindepth 2 -maxdepth 2 -name composer.json -print0 \
+            | xargs -0 -n1 dirname \
+            | sort)
+          actual=$(jq -r '.[].path' <<< "$full" | sort)
+          if ! diff -u <(echo "$expected") <(echo "$actual") >/tmp/matrix-drift.diff; then
+            echo "::error::split.yml matrix is out of sync with src/Altair/*. Diff:"
+            cat /tmp/matrix-drift.diff
+            echo "::error::Add or remove entries in the 'full' JSON array above to match the filesystem."
+            exit 1
+          fi
 
           if [[ -z "${PACKAGE}" ]]; then
             matrix=$(jq -c '.' <<< "$full")

--- a/README.md
+++ b/README.md
@@ -11,6 +11,30 @@ Nothing is yet published on composer, API is being defined as it goes and if you
 
 ## Univeros
 
+## Sub-packages
+
+The framework is composed of 35 standalone PHP packages under [src/Altair/](src/Altair/). Each is published as a read-only repository at `github.com/univeros/<name>` and registered on Packagist as `univeros/<name>`. Pull the whole framework via:
+
+```bash
+composer require univeros/framework
+```
+
+…or compose individual packages. A few representative ones:
+
+```bash
+composer require univeros/http          # PSR-7 + PSR-15 stack, single-pass middleware
+composer require univeros/scaffold      # YAML spec → Action/Input/Responder + OpenAPI + tests
+composer require univeros/persistence   # Repository/UnitOfWork bridge over Cycle ORM v2
+composer require univeros/messaging     # MessageBus bridge over Symfony Messenger
+composer require univeros/events        # Append-only mutation event log for agents
+```
+
+Per-package documentation lives under [docs/packages/](docs/packages/). The complete published list:
+
+`agent-spec`, `bootstrap`, `cache`, `cli`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `doctor`, `eval`, `events`, `filesystem`, `happen`, `http`, `index`, `introspection`, `mcp`, `messaging`, `middleware`, `migration-intelligence`, `observability`, `observatory`, `persistence`, `profiling`, `sanitation`, `scaffold`, `security`, `session`, `structure`, `suggest`, `test-reporter`, `tinker`, `validation`.
+
+Splits are produced automatically by [.github/workflows/split.yml](.github/workflows/split.yml) — see [docs/packages/split-publish.md](docs/packages/split-publish.md) for the operator runbook. All changes belong in this monorepo; the split repos are read-only mirrors.
+
 ## Learning Univeros
 
 ## Contributing

--- a/docs/packages/split-publish.md
+++ b/docs/packages/split-publish.md
@@ -1,0 +1,134 @@
+# Split publishing
+
+> Operator runbook for publishing every `src/Altair/*` sub-package as a standalone read-only repository at `github.com/univeros/<name>` and as `univeros/<name>` on Packagist. Driven by [`.github/workflows/split.yml`](../../.github/workflows/split.yml).
+
+**Source of truth:** `src/Altair/<Package>/` in the [`univeros/framework`](https://github.com/univeros/framework) monorepo. Every directory under `src/Altair/` that ships a `composer.json` is automatically a publishable package; the workflow's drift guard fails if the matrix in `split.yml` falls out of sync with the filesystem.
+
+## How the workflow works
+
+`splitsh/lite` rewrites the monorepo's history for a single subtree (`src/Altair/<Package>/`) into a synthetic commit graph whose root is that subtree. The resulting SHA is force-pushed to `master` (or the tag ref, on tag pushes) of `github.com/univeros/<name>`. Each sub-repo therefore looks like it had always lived at the top level of its own repository — `composer require univeros/cache` pulls the package alone, not the whole framework.
+
+The split is reproducible: re-running it on the same commit produces the same SHA. The split SHAs are not the same as the monorepo's commit SHAs.
+
+## Initial setup (one-time)
+
+Before the workflow can push anything, the following must exist:
+
+1. **GitHub repositories** for each of the 35 packages. The original 16 (`cache`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `filesystem`, `happen`, `http`, `middleware`, `sanitation`, `security`, `session`, `structure`, `validation`) already exist. The other 19 must be created:
+
+   ```bash
+   for pkg in agent-spec bootstrap cli doctor eval events index introspection \
+              mcp messaging migration-intelligence observability observatory \
+              persistence profiling scaffold suggest test-reporter tinker; do
+     gh repo create "univeros/$pkg" \
+       --public \
+       --description "[READ ONLY] Subtree split of the Univeros $pkg component" \
+       --homepage "https://univeros.io"
+   done
+   ```
+
+   Each new repo can be empty — the first workflow run will force-push the split contents.
+
+2. **Delete stale repositories** that no longer correspond to a `src/Altair/*` directory:
+
+   ```bash
+   gh repo delete univeros/queue --yes   # replaced by univeros/messaging in 2026-05
+   ```
+
+3. **Authentication token.** Generate a fine-grained personal access token with `Contents: write` on all 35 sub-repos (or a classic PAT with the `repo` scope). Store it on `univeros/framework` as the `SPLIT_TOKEN` repository secret:
+
+   ```bash
+   gh secret set SPLIT_TOKEN --repo univeros/framework --body "<the-token>"
+   ```
+
+   Deploy keys (one keypair per sub-repo) are the alternative if PAT rotation is a concern; the workflow would need to be adapted to use SSH URLs in that case.
+
+4. **Default branch on each sub-repo** must be `master` (matching the monorepo). New `gh repo create` defaults to `main` — fix it:
+
+   ```bash
+   for pkg in $(gh repo list univeros --json name -q '.[].name' | grep -v '^framework$\|^univeros$'); do
+     gh api -X PATCH "repos/univeros/$pkg" -f default_branch=master 2>/dev/null || true
+   done
+   ```
+
+## Running the workflow
+
+Triggered manually via `workflow_dispatch` — the comment at the top of `split.yml` explains the rationale (the framework is not yet 1.0; auto-on-push will be enabled once it is).
+
+```bash
+# Dry-run: compute splits for every package without pushing
+gh workflow run split.yml -f dry_run=true
+
+# Real run: split + push all 35 packages
+gh workflow run split.yml
+
+# Single package (matches the workflow_dispatch dropdown)
+gh workflow run split.yml -f package=scaffold
+```
+
+Tail it:
+
+```bash
+gh run watch
+```
+
+## First release: tagging `v2.0.0`
+
+Tags propagate the same way branches do — push `v2.0.0` to the monorepo, the workflow re-splits each package at the tagged commit and pushes the same tag to each sub-repo.
+
+```bash
+git tag -a v2.0.0 -m "Univeros 2.0.0 — PHP 8.3 modernization"
+git push origin v2.0.0
+gh workflow run split.yml   # triggers split + tag propagation
+```
+
+Verify the tag landed on a sample sub-repo:
+
+```bash
+gh release list --repo univeros/cache
+gh api repos/univeros/cache/git/refs/tags/v2.0.0
+```
+
+## Packagist registration
+
+Each sub-package must be submitted to packagist.org once. After that, Packagist subscribes to the GitHub webhook and picks up future tags automatically.
+
+Submit in dependency order so each upload finds its declared deps already present on Packagist:
+
+1. Leaf packages (no inter-deps): `common`, `structure`
+2. `container` (depends on `structure`)
+3. `configuration` (depends on `container`)
+4. `middleware`, `security` (no `univeros/*` deps)
+5. Middle layer: `cache`, `cookie`, `data`, `events`, `happen`, `session`
+6. Top of the original stack: `filesystem`, `sanitation`, `validation`, `courier`, `http`
+7. The 2026 additions, in alphabetical order — none of them are required by the original 16, so the order inside this batch does not matter: `agent-spec`, `bootstrap`, `cli`, `doctor`, `eval`, `index`, `introspection`, `mcp`, `messaging`, `migration-intelligence`, `observability`, `observatory`, `persistence`, `profiling`, `scaffold`, `suggest`, `test-reporter`, `tinker`
+
+## Adding a new sub-package
+
+1. Create the package under `src/Altair/<Name>/` with its own `composer.json` declaring `"name": "univeros/<name>"`.
+2. Add the matrix entry to `.github/workflows/split.yml` in the `full=` JSON block. The drift guard will refuse to run until this is done.
+3. Add the package name to the `workflow_dispatch.inputs.package.options` list so the dropdown stays in sync.
+4. Create the GitHub repository (`gh repo create univeros/<name> --public ...`) and grant `SPLIT_TOKEN` write access to it.
+5. Submit to Packagist after the next tagged release.
+
+## Removing a sub-package
+
+1. Delete `src/Altair/<Name>/` (the matrix drift guard will block the workflow until you also drop its entry).
+2. Remove the matrix entry from `split.yml` and from the dropdown options.
+3. Archive (don't delete) the GitHub repository so existing `composer.lock` files keep resolving:
+
+   ```bash
+   gh api -X PATCH repos/univeros/<name> -f archived=true
+   ```
+
+4. Mark the package as abandoned on Packagist, pointing to its replacement if any.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `splitsh-lite produced an empty SHA` | The path in the matrix doesn't exist, or the subtree is empty at the chosen ref. |
+| `403 from github.com` when pushing | `SPLIT_TOKEN` doesn't have write access to that sub-repo, or it shadowed the GitHub Actions token (the workflow already disables `persist-credentials` for the main checkout and clears `extraheader` on push — don't re-enable those). |
+| `split.yml matrix is out of sync with src/Altair/*` | A package directory exists with a `composer.json` but is missing from the matrix, or the matrix references a path that no longer exists. The error message includes a diff. |
+| Tag propagated to some sub-repos but not others | `fail-fast: false` is set, so individual sub-repos can fail independently. Check the matrix job logs and re-run the failed jobs once the cause is fixed. |
+| Packagist shows an old version after a fresh tag | The GitHub webhook may not be wired up. Trigger a manual update at `https://packagist.org/packages/univeros/<name>` → "Update". |


### PR DESCRIPTION
## Summary

Closes #14. Brings the split-publish workflow up to the post-modernization reality and prevents this gap from happening again.

- **Matrix: 16 → 35.** Every `src/Altair/*` directory that ships a `composer.json` is now published as `univeros/<name>`. The original 16 plus the 19 added during the PHP 8.3 modernization sweep (`agent-spec`, `bootstrap`, `cli`, `doctor`, `eval`, `events`, `index`, `introspection`, `mcp`, `messaging`, `migration-intelligence`, `observability`, `observatory`, `persistence`, `profiling`, `scaffold`, `suggest`, `test-reporter`, `tinker`).
- **Drift guard** (the load-bearing change): the `setup-matrix` job now `diff`s the matrix against `find src/Altair -mindepth 2 -maxdepth 2 -name composer.json` and fails the workflow on mismatch. The silent drift that left 19 packages unpublished for months can't recur.
- **`workflow_dispatch` dropdown** updated to match the matrix.
- **README** gains a `## Sub-packages` section with the install pattern and a link to per-package docs.
- **`docs/packages/split-publish.md`** ships as the operator runbook.

## Out of scope (deliberate)

The PR is the workflow + docs only. The following are still **manual operator steps**, documented in `docs/packages/split-publish.md`:

1. Create the 19 missing GitHub repositories (`agent-spec`, `bootstrap`, `cli`, ... copy-pasteable loop in the runbook).
2. Delete `univeros/queue` (replaced by `univeros/messaging` during the 2026-05 modernization; no longer matches any `src/Altair/*` directory).
3. Generate a fine-grained PAT and set `SPLIT_TOKEN` on `univeros/framework`.
4. Trigger the workflow with `dry_run=true` first, then a real run.
5. Tag `v2.0.0`, propagate to all 35 sub-repos.
6. Submit each package to Packagist in dependency order.

Each of these is a "shared-state" or destructive action that needs an explicit hand on the wheel — putting them in this PR would mean opening a PR with bound side effects that fire on merge, which isn't reversible.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/split.yml'))"` passes.
- [x] Local simulation of the drift guard: `find src/Altair -mindepth 2 -maxdepth 2 -name composer.json | xargs -n1 dirname | sort` matches the 35 paths in the matrix exactly.
- [ ] After merge, operator runs `gh workflow run split.yml -f dry_run=true` and confirms 35 jobs succeed (no `splitsh-lite produced an empty SHA` errors, no `403` push failures even though pushing is skipped on dry-run).
- [ ] After GitHub repos are created and `SPLIT_TOKEN` is set, operator runs the workflow live and inspects 2–3 sub-repos to confirm contents match `src/Altair/<Pkg>/`.
- [ ] Operator tags `v2.0.0`, runs the workflow once more, confirms the tag landed on every sub-repo.
- [ ] Packagist registration completes for all 35 packages in the dependency order documented in `docs/packages/split-publish.md`.

## Why now

Issue #14 was opened with the 2017-era split-script context. Since then the modernization sweep added 19 sub-packages, each with a proper `composer.json` declaring `univeros/<name>` — but the workflow matrix never grew with them, so they would have silently never been published. This PR closes that gap and installs a guard so the next package author doesn't have to remember to update the workflow.