### PR TITLE
feat(splits): publish docs and starter as univeros/docs and univeros/univeros

### DIFF
--- a/.github/workflows/split.yml
+++ b/.github/workflows/split.yml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch:
     inputs:
       package:
-        description: 'Single package to split (leave blank to split all 35)'
+        description: 'Single split to publish (leave blank to publish all 37: 35 packages + docs + univeros starter)'
         required: false
         type: choice
         default: ''
@@ -32,6 +32,7 @@ on:
           - courier
           - data
           - doctor
+          - docs
           - eval
           - events
           - filesystem
@@ -55,6 +56,7 @@ on:
           - suggest
           - test-reporter
           - tinker
+          - univeros
           - validation
       dry_run:
         description: 'Compute splits but skip pushing to sub-repos'
@@ -92,10 +94,16 @@ jobs:
           PACKAGE: ${{ github.event.inputs.package }}
         run: |
           set -euo pipefail
-          # Source of truth: every directory under src/Altair/ that ships a
-          # composer.json with a univeros/<name> package name. Keep this list
-          # alphabetically sorted by composer name so additions are obvious in
-          # review and so the workflow_dispatch dropdown matches.
+          # The matrix has two kinds of entries:
+          #   1. Per-package splits under src/Altair/* (the bulk of the work).
+          #      The drift guard below enforces that EVERY src/Altair/*/composer.json
+          #      is represented here — the gap that left 19 packages unpublished
+          #      for months can't recur.
+          #   2. Non-package splits (docs, univeros starter). These are managed
+          #      manually and intentionally NOT in src/Altair/.
+          #
+          # Keep alphabetically sorted by name so the workflow_dispatch dropdown
+          # stays in lockstep.
           full='[
             {"name":"agent-spec",             "path":"src/Altair/AgentSpec"},
             {"name":"bootstrap",              "path":"src/Altair/Bootstrap"},
@@ -108,6 +116,7 @@ jobs:
             {"name":"courier",                "path":"src/Altair/Courier"},
             {"name":"data",                   "path":"src/Altair/Data"},
             {"name":"doctor",                 "path":"src/Altair/Doctor"},
+            {"name":"docs",                   "path":"docs"},
             {"name":"eval",                   "path":"src/Altair/Eval"},
             {"name":"events",                 "path":"src/Altair/Events"},
             {"name":"filesystem",             "path":"src/Altair/Filesystem"},
@@ -131,16 +140,18 @@ jobs:
             {"name":"suggest",                "path":"src/Altair/Suggest"},
             {"name":"test-reporter",          "path":"src/Altair/TestReporter"},
             {"name":"tinker",                 "path":"src/Altair/Tinker"},
+            {"name":"univeros",               "path":"src/Altair/Bootstrap/resources/skeleton"},
             {"name":"validation",             "path":"src/Altair/Validation"}
           ]'
 
           # Drift guard: every src/Altair/* directory that ships a composer.json
           # is a publishable sub-package, so it MUST appear in the matrix above.
-          # Surface drift here instead of silently skipping the new package.
+          # Non-package matrix entries (docs, univeros) are filtered out before
+          # comparing — they're allowed to exist without a filesystem twin.
           expected=$(find src/Altair -mindepth 2 -maxdepth 2 -name composer.json -print0 \
             | xargs -0 -n1 dirname \
             | sort)
-          actual=$(jq -r '.[].path' <<< "$full" | sort)
+          actual=$(jq -r '.[].path | select(startswith("src/Altair/") and (split("/") | length) == 3)' <<< "$full" | sort)
           if ! diff -u <(echo "$expected") <(echo "$actual") >/tmp/matrix-drift.diff; then
             echo "::error::split.yml matrix is out of sync with src/Altair/*. Diff:"
             cat /tmp/matrix-drift.diff

--- a/README.md
+++ b/README.md
@@ -11,9 +11,17 @@ Nothing is yet published on composer, API is being defined as it goes and if you
 
 ## Univeros
 
+## Repositories
+
+Univeros is split across three top-level repositories — `univeros/univeros`, `univeros/framework`, `univeros/docs` — plus a read-only mirror per sub-package.
+
+- **[univeros/univeros](https://github.com/univeros/univeros)** — the create-project starter. `composer create-project univeros/univeros myapp` lays down a runnable Altair API.
+- **[univeros/framework](https://github.com/univeros/framework)** — this repo. The library you depend on (`composer require univeros/framework`).
+- **[univeros/docs](https://github.com/univeros/docs)** — read-only mirror of the [docs/](docs/) tree from this monorepo. Open issues and PRs against `univeros/framework`; the docs repo is the published surface only.
+
 ## Sub-packages
 
-The framework is composed of 35 standalone PHP packages under [src/Altair/](src/Altair/). Each is published as a read-only repository at `github.com/univeros/<name>` and registered on Packagist as `univeros/<name>`. Pull the whole framework via:
+The framework is composed of 35 standalone PHP packages under [src/Altair/](src/Altair/). Each is published as a read-only repository at `github.com/univeros/<name>`. Pull the whole framework via:
 
 ```bash
 composer require univeros/framework
@@ -33,7 +41,7 @@ Per-package documentation lives under [docs/packages/](docs/packages/). The comp
 
 `agent-spec`, `bootstrap`, `cache`, `cli`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `doctor`, `eval`, `events`, `filesystem`, `happen`, `http`, `index`, `introspection`, `mcp`, `messaging`, `middleware`, `migration-intelligence`, `observability`, `observatory`, `persistence`, `profiling`, `sanitation`, `scaffold`, `security`, `session`, `structure`, `suggest`, `test-reporter`, `tinker`, `validation`.
 
-Splits are produced automatically by [.github/workflows/split.yml](.github/workflows/split.yml) — see [docs/packages/split-publish.md](docs/packages/split-publish.md) for the operator runbook. All changes belong in this monorepo; the split repos are read-only mirrors.
+Splits are produced automatically by [.github/workflows/split.yml](.github/workflows/split.yml) — see [docs/packages/split-publish.md](docs/packages/split-publish.md) for the operator runbook. All changes belong in this monorepo; every split repo (including `univeros/univeros` and `univeros/docs`) is a read-only mirror.
 
 ## Learning Univeros
 

--- a/docs/benchmarks/tokens-to-ship.md
+++ b/docs/benchmarks/tokens-to-ship.md
@@ -29,7 +29,7 @@ correct, typed, tested, and documented to the same bar on both arms.**
 ## 2. The task (frozen)
 
 A single realistic feature, specified once and never changed:
-[`benchmarks/tokens-to-ship/task.md`](../../benchmarks/tokens-to-ship/task.md).
+[`benchmarks/tokens-to-ship/task.md`](https://github.com/univeros/framework/blob/master/benchmarks/tokens-to-ship/task.md).
 
 > Build a **Posts** REST resource: `POST /posts`, `GET /posts`, `GET /posts/{id}`,
 > `PUT /posts/{id}`, `DELETE /posts/{id}`. Input validation, persistence
@@ -108,7 +108,7 @@ Two supported protocols, in increasing rigor:
   but still auditable.
 
 Either way, per-run records land in a usage log and are aggregated by
-[`benchmarks/tokens-to-ship/score.php`](../../benchmarks/tokens-to-ship/score.php)
+[`benchmarks/tokens-to-ship/score.php`](https://github.com/univeros/framework/blob/master/benchmarks/tokens-to-ship/score.php)
 into `results/results.json` plus a printed table.
 
 ## 7. Threats to validity (state these publicly)

--- a/docs/packages/doctor.md
+++ b/docs/packages/doctor.md
@@ -347,15 +347,15 @@ An unknown `--format` raises a `DoctorException` listing the formats that are av
 
 The published tests under `tests/Doctor/` double as worked examples of every extension point:
 
-- [tests/Doctor/DoctorTest.php](../../tests/Doctor/DoctorTest.php) — the runner: `--only`/`--skip` filtering, dependency-skip behaviour, `--fix` re-run.
-- [tests/Doctor/Check/PureChecksTest.php](../../tests/Doctor/Check/PureChecksTest.php) — `php_version`, `extensions_loaded` (using the injectable probe).
-- [tests/Doctor/Check/ProcessChecksTest.php](../../tests/Doctor/Check/ProcessChecksTest.php) — the process-backed checks against the fake runner.
-- [tests/Doctor/Check/HostAppChecksTest.php](../../tests/Doctor/Check/HostAppChecksTest.php) — the host-hook checks, including the `skipped`-when-absent path.
-- [tests/Doctor/Output/RenderersTest.php](../../tests/Doctor/Output/RenderersTest.php) — human + JSON rendering, determinism of the JSON projection.
-- [tests/Doctor/Result/ResultObjectsTest.php](../../tests/Doctor/Result/ResultObjectsTest.php) — `CheckResult`/`Report`/`AgentAction` shape and `toArray()`.
-- [tests/Doctor/Configuration/DoctorConfigurationTest.php](../../tests/Doctor/Configuration/DoctorConfigurationTest.php) — env-derived requirements + Container wiring.
+- [tests/Doctor/DoctorTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/DoctorTest.php) — the runner: `--only`/`--skip` filtering, dependency-skip behaviour, `--fix` re-run.
+- [tests/Doctor/Check/PureChecksTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Check/PureChecksTest.php) — `php_version`, `extensions_loaded` (using the injectable probe).
+- [tests/Doctor/Check/ProcessChecksTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Check/ProcessChecksTest.php) — the process-backed checks against the fake runner.
+- [tests/Doctor/Check/HostAppChecksTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Check/HostAppChecksTest.php) — the host-hook checks, including the `skipped`-when-absent path.
+- [tests/Doctor/Output/RenderersTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Output/RenderersTest.php) — human + JSON rendering, determinism of the JSON projection.
+- [tests/Doctor/Result/ResultObjectsTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Result/ResultObjectsTest.php) — `CheckResult`/`Report`/`AgentAction` shape and `toArray()`.
+- [tests/Doctor/Configuration/DoctorConfigurationTest.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Configuration/DoctorConfigurationTest.php) — env-derived requirements + Container wiring.
 
-The key testing tool is the in-memory `FakeProcessRunner` ([tests/Doctor/Support/FakeProcessRunner.php](../../tests/Doctor/Support/FakeProcessRunner.php)): you script a result per command and assert on the calls made, so a process-backed check is exercised end-to-end without ever spawning a subprocess.
+The key testing tool is the in-memory `FakeProcessRunner` ([tests/Doctor/Support/FakeProcessRunner.php](https://github.com/univeros/framework/blob/master/tests/Doctor/Support/FakeProcessRunner.php)): you script a result per command and assert on the calls made, so a process-backed check is exercised end-to-end without ever spawning a subprocess.
 
 ```php
 use Altair\Tests\Doctor\Support\FakeProcessRunner;

--- a/docs/packages/eval.md
+++ b/docs/packages/eval.md
@@ -233,12 +233,12 @@ use Altair\Eval\Configuration\EvalConfiguration;
 
 The published tests under `tests/Eval/` are real subprocess tests — they prove the sandbox actually sandboxes, not just that the flags are present:
 
-- [tests/Eval/Encoder/ValueEncoderTest.php](../../tests/Eval/Encoder/ValueEncoderTest.php) — golden tests for every encoded shape, including object cycles, infinite generators, and depth-cap truncation.
-- [tests/Eval/Encoder/ExceptionEncoderTest.php](../../tests/Eval/Encoder/ExceptionEncoderTest.php) — frame rendering and chain-walking.
-- [tests/Eval/Runner/SecurityProfileTest.php](../../tests/Eval/Runner/SecurityProfileTest.php) — the `php -d` flag matrix for default / `--network` / `--unsafe`.
-- [tests/Eval/Runner/WrapperBuilderTest.php](../../tests/Eval/Runner/WrapperBuilderTest.php) — generated source contains the snippet verbatim and passes `php -l`.
-- [tests/Eval/EvaluatorTest.php](../../tests/Eval/EvaluatorTest.php) — full subprocess integration. Asserts that `disable_functions` blocks `exec`, that `open_basedir` blocks writes outside the project root, that a runaway loop is killed at the wall-clock deadline, and that `container()` resolves bindings from an explicit bootstrap file.
-- [tests/Eval/Cli/EvalCommandTest.php](../../tests/Eval/Cli/EvalCommandTest.php) — every command path including `--unsafe` event recording and `--file=…`.
+- [tests/Eval/Encoder/ValueEncoderTest.php](https://github.com/univeros/framework/blob/master/tests/Eval/Encoder/ValueEncoderTest.php) — golden tests for every encoded shape, including object cycles, infinite generators, and depth-cap truncation.
+- [tests/Eval/Encoder/ExceptionEncoderTest.php](https://github.com/univeros/framework/blob/master/tests/Eval/Encoder/ExceptionEncoderTest.php) — frame rendering and chain-walking.
+- [tests/Eval/Runner/SecurityProfileTest.php](https://github.com/univeros/framework/blob/master/tests/Eval/Runner/SecurityProfileTest.php) — the `php -d` flag matrix for default / `--network` / `--unsafe`.
+- [tests/Eval/Runner/WrapperBuilderTest.php](https://github.com/univeros/framework/blob/master/tests/Eval/Runner/WrapperBuilderTest.php) — generated source contains the snippet verbatim and passes `php -l`.
+- [tests/Eval/EvaluatorTest.php](https://github.com/univeros/framework/blob/master/tests/Eval/EvaluatorTest.php) — full subprocess integration. Asserts that `disable_functions` blocks `exec`, that `open_basedir` blocks writes outside the project root, that a runaway loop is killed at the wall-clock deadline, and that `container()` resolves bindings from an explicit bootstrap file.
+- [tests/Eval/Cli/EvalCommandTest.php](https://github.com/univeros/framework/blob/master/tests/Eval/Cli/EvalCommandTest.php) — every command path including `--unsafe` event recording and `--file=…`.
 
 When you add a guard or a security policy, mirror this pattern: write a snippet that *would* break it, run it through the real `Evaluator`, and assert the guard held.
 

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -173,11 +173,11 @@ $container->make(UsageQuery::class);   // shared, against the configured project
 
 The published tests under `tests/Index/` double as worked examples:
 
-- [tests/Index/Parser/PhpFileWalkerTest.php](../../tests/Index/Parser/PhpFileWalkerTest.php) — golden tests for every symbol kind and every usage kind, including the deliberate non-linking of untyped instance calls.
-- [tests/Index/Parser/YamlSpecWalkerTest.php](../../tests/Index/Parser/YamlSpecWalkerTest.php) — `spec_endpoint`/`spec_entity` extraction.
-- [tests/Index/Query/QueryLayerTest.php](../../tests/Index/Query/QueryLayerTest.php) — find-usages, implementers, extenders, callers, unused (with a true-positive dead-code fixture), impact, and orphans over a hand-seeded database.
-- [tests/Index/Builder/IndexBuilderTest.php](../../tests/Index/Builder/IndexBuilderTest.php) — full build, incremental skip-on-unchanged, and deletion handling over a real temp project.
-- [tests/Index/Cli/CommandsTest.php](../../tests/Index/Cli/CommandsTest.php) — every command end-to-end, including exit codes and the `--no-build` bail.
+- [tests/Index/Parser/PhpFileWalkerTest.php](https://github.com/univeros/framework/blob/master/tests/Index/Parser/PhpFileWalkerTest.php) — golden tests for every symbol kind and every usage kind, including the deliberate non-linking of untyped instance calls.
+- [tests/Index/Parser/YamlSpecWalkerTest.php](https://github.com/univeros/framework/blob/master/tests/Index/Parser/YamlSpecWalkerTest.php) — `spec_endpoint`/`spec_entity` extraction.
+- [tests/Index/Query/QueryLayerTest.php](https://github.com/univeros/framework/blob/master/tests/Index/Query/QueryLayerTest.php) — find-usages, implementers, extenders, callers, unused (with a true-positive dead-code fixture), impact, and orphans over a hand-seeded database.
+- [tests/Index/Builder/IndexBuilderTest.php](https://github.com/univeros/framework/blob/master/tests/Index/Builder/IndexBuilderTest.php) — full build, incremental skip-on-unchanged, and deletion handling over a real temp project.
+- [tests/Index/Cli/CommandsTest.php](https://github.com/univeros/framework/blob/master/tests/Index/Cli/CommandsTest.php) — every command end-to-end, including exit codes and the `--no-build` bail.
 
 Walkers and queries are deterministic and need no Container, so tests hand-build source strings or seed the storage directly and assert on the result.
 

--- a/docs/packages/messaging.md
+++ b/docs/packages/messaging.md
@@ -200,15 +200,15 @@ Workers run via `WorkerFactory`, which builds a Symfony `Worker` with the config
 
 ## Test as documentation
 
-- [tests/Messaging/Attribute/AsHandlerTest.php](../../tests/Messaging/Attribute/AsHandlerTest.php) — reading the `#[AsHandler]` attribute.
-- [tests/Messaging/Discovery/AttributeHandlerDiscovererTest.php](../../tests/Messaging/Discovery/AttributeHandlerDiscovererTest.php) — filesystem scan + registry build.
-- [tests/Messaging/Discovery/HandlerRegistryTest.php](../../tests/Messaging/Discovery/HandlerRegistryTest.php) — priority ordering, transport filtering.
-- [tests/Messaging/HandlerLocatorTest.php](../../tests/Messaging/HandlerLocatorTest.php) — descriptor resolution through `Container`.
-- [tests/Messaging/MessageBusTest.php](../../tests/Messaging/MessageBusTest.php) — wrapping the Symfony bus.
-- [tests/Messaging/Configuration/TransportSettingsTest.php](../../tests/Messaging/Configuration/TransportSettingsTest.php) — env → settings parsing.
-- [tests/Messaging/Configuration/MessengerConfigurationTest.php](../../tests/Messaging/Configuration/MessengerConfigurationTest.php) — end-to-end container wiring.
-- [tests/Messaging/Integration/DispatchAndConsumeTest.php](../../tests/Messaging/Integration/DispatchAndConsumeTest.php) — sync dispatch + async InMemory transport + worker consume.
-- [tests/Messaging/Middleware/LoggingMiddlewareTest.php](../../tests/Messaging/Middleware/LoggingMiddlewareTest.php) — optional logging middleware.
+- [tests/Messaging/Attribute/AsHandlerTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Attribute/AsHandlerTest.php) — reading the `#[AsHandler]` attribute.
+- [tests/Messaging/Discovery/AttributeHandlerDiscovererTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Discovery/AttributeHandlerDiscovererTest.php) — filesystem scan + registry build.
+- [tests/Messaging/Discovery/HandlerRegistryTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Discovery/HandlerRegistryTest.php) — priority ordering, transport filtering.
+- [tests/Messaging/HandlerLocatorTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/HandlerLocatorTest.php) — descriptor resolution through `Container`.
+- [tests/Messaging/MessageBusTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/MessageBusTest.php) — wrapping the Symfony bus.
+- [tests/Messaging/Configuration/TransportSettingsTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Configuration/TransportSettingsTest.php) — env → settings parsing.
+- [tests/Messaging/Configuration/MessengerConfigurationTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Configuration/MessengerConfigurationTest.php) — end-to-end container wiring.
+- [tests/Messaging/Integration/DispatchAndConsumeTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Integration/DispatchAndConsumeTest.php) — sync dispatch + async InMemory transport + worker consume.
+- [tests/Messaging/Middleware/LoggingMiddlewareTest.php](https://github.com/univeros/framework/blob/master/tests/Messaging/Middleware/LoggingMiddlewareTest.php) — optional logging middleware.
 
 ## Related packages
 

--- a/docs/packages/migration-intelligence.md
+++ b/docs/packages/migration-intelligence.md
@@ -175,14 +175,14 @@ Every service is stateless. The database is not opened at boot: it is read on de
 
 The tests under `tests/MigrationIntelligence/` double as worked examples. The pure pieces (differ, planners, emitter, renderers) are tested with hand-built shapes and plans — no database. The schema reader and safety checks are tested against a real in-memory SQLite database built by `Support\SqliteDatabaseFactory`, so the Cycle introspection and the counting queries are exercised for real:
 
-- [tests/MigrationIntelligence/Schema/](../../tests/MigrationIntelligence/Schema/) — the canonical type model and column equivalence.
-- [tests/MigrationIntelligence/Reader/](../../tests/MigrationIntelligence/Reader/) — spec, entity-reflection, and live-SQLite readers.
-- [tests/MigrationIntelligence/Diff/SchemaDifferTest.php](../../tests/MigrationIntelligence/Diff/SchemaDifferTest.php) — every intent kind, rename hints, safe vs. incompatible type changes.
-- [tests/MigrationIntelligence/Planner/](../../tests/MigrationIntelligence/Planner/) — golden preview SQL per dialect, the SQLite ALTER-COLUMN note, driver-alias resolution.
-- [tests/MigrationIntelligence/Safety/SafetyRunnerTest.php](../../tests/MigrationIntelligence/Safety/SafetyRunnerTest.php) — each check against seeded SQLite fixtures (duplicates, orphans, nulls, non-castable data, force).
-- [tests/MigrationIntelligence/Plan/PlanBuilderTest.php](../../tests/MigrationIntelligence/Plan/PlanBuilderTest.php) — single-phase and two-phase rename expansion, deterministic naming.
-- [tests/MigrationIntelligence/Emitter/CycleMigrationEmitterTest.php](../../tests/MigrationIntelligence/Emitter/CycleMigrationEmitterTest.php) — emitted migrations are asserted to be syntactically valid PHP (`php -l`).
-- [tests/MigrationIntelligence/Cli/PlanCommandTest.php](../../tests/MigrationIntelligence/Cli/PlanCommandTest.php) — diff-source resolution, formats, file writing, exit codes.
+- [tests/MigrationIntelligence/Schema/](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Schema/) — the canonical type model and column equivalence.
+- [tests/MigrationIntelligence/Reader/](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Reader/) — spec, entity-reflection, and live-SQLite readers.
+- [tests/MigrationIntelligence/Diff/SchemaDifferTest.php](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Diff/SchemaDifferTest.php) — every intent kind, rename hints, safe vs. incompatible type changes.
+- [tests/MigrationIntelligence/Planner/](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Planner/) — golden preview SQL per dialect, the SQLite ALTER-COLUMN note, driver-alias resolution.
+- [tests/MigrationIntelligence/Safety/SafetyRunnerTest.php](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Safety/SafetyRunnerTest.php) — each check against seeded SQLite fixtures (duplicates, orphans, nulls, non-castable data, force).
+- [tests/MigrationIntelligence/Plan/PlanBuilderTest.php](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Plan/PlanBuilderTest.php) — single-phase and two-phase rename expansion, deterministic naming.
+- [tests/MigrationIntelligence/Emitter/CycleMigrationEmitterTest.php](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Emitter/CycleMigrationEmitterTest.php) — emitted migrations are asserted to be syntactically valid PHP (`php -l`).
+- [tests/MigrationIntelligence/Cli/PlanCommandTest.php](https://github.com/univeros/framework/blob/master/tests/MigrationIntelligence/Cli/PlanCommandTest.php) — diff-source resolution, formats, file writing, exit codes.
 
 ## Extending
 

--- a/docs/packages/split-publish.md
+++ b/docs/packages/split-publish.md
@@ -1,12 +1,17 @@
 # Split publishing
 
-> Operator runbook for publishing every `src/Altair/*` sub-package as a standalone read-only repository at `github.com/univeros/<name>` and as `univeros/<name>` on Packagist. Driven by [`.github/workflows/split.yml`](../../.github/workflows/split.yml).
+> Operator runbook for publishing each `src/Altair/*` sub-package as `univeros/<name>`, plus the framework's `docs/` and starter (`src/Altair/Bootstrap/resources/skeleton/`) as the dedicated `univeros/docs` and `univeros/univeros` repos. Driven by [`.github/workflows/split.yml`](https://github.com/univeros/framework/blob/master/.github/workflows/split.yml).
 
-**Source of truth:** `src/Altair/<Package>/` in the [`univeros/framework`](https://github.com/univeros/framework) monorepo. Every directory under `src/Altair/` that ships a `composer.json` is automatically a publishable package; the workflow's drift guard fails if the matrix in `split.yml` falls out of sync with the filesystem.
+**Source of truth:** the [`univeros/framework`](https://github.com/univeros/framework) monorepo. The matrix has two kinds of entries:
+
+- **Package splits** — every `src/Altair/<Package>/` directory that ships a `composer.json`. The workflow's drift guard fails if any are missing from the matrix; new packages can't slip through unpublished.
+- **Non-package splits** — `docs` (from `docs/`) and `univeros` (from `src/Altair/Bootstrap/resources/skeleton/`). Managed by hand and excluded from the drift check.
+
+All three top-level repos — `univeros/univeros` (starter), `univeros/framework` (library), `univeros/docs` (documentation) — are visible on the org page; the package splits are read-only mirrors used by Composer.
 
 ## How the workflow works
 
-`splitsh/lite` rewrites the monorepo's history for a single subtree (`src/Altair/<Package>/`) into a synthetic commit graph whose root is that subtree. The resulting SHA is force-pushed to `master` (or the tag ref, on tag pushes) of `github.com/univeros/<name>`. Each sub-repo therefore looks like it had always lived at the top level of its own repository — `composer require univeros/cache` pulls the package alone, not the whole framework.
+`splitsh/lite` rewrites the monorepo's history for a single subtree (e.g. `src/Altair/Cache/` or `docs/`) into a synthetic commit graph whose root is that subtree. The resulting SHA is force-pushed to `master` (or the tag ref, on tag pushes) of `github.com/univeros/<name>`. Each sub-repo therefore looks like it had always lived at the top level of its own repository — `composer require univeros/cache` pulls the package alone, not the whole framework, and `composer create-project univeros/univeros myapp` materialises the starter.
 
 The split is reproducible: re-running it on the same commit produces the same SHA. The split SHAs are not the same as the monorepo's commit SHAs.
 
@@ -14,7 +19,7 @@ The split is reproducible: re-running it on the same commit produces the same SH
 
 Before the workflow can push anything, the following must exist:
 
-1. **GitHub repositories** for each of the 35 packages. The original 16 (`cache`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `filesystem`, `happen`, `http`, `middleware`, `sanitation`, `security`, `session`, `structure`, `validation`) already exist. The other 19 must be created:
+1. **GitHub repositories** for each of the 35 packages plus the three top-level repos (`univeros/univeros`, `univeros/framework`, `univeros/docs`). The original 16 sub-package repos (`cache`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `filesystem`, `happen`, `http`, `middleware`, `sanitation`, `security`, `session`, `structure`, `validation`) plus `univeros/univeros` and `univeros/framework` already exist. Create the remaining 19 sub-package repos and `univeros/docs`:
 
    ```bash
    for pkg in agent-spec bootstrap cli doctor eval events index introspection \
@@ -25,9 +30,15 @@ Before the workflow can push anything, the following must exist:
        --description "[READ ONLY] Subtree split of the Univeros $pkg component" \
        --homepage "https://univeros.io"
    done
+
+   # Plus the dedicated docs mirror
+   gh repo create univeros/docs \
+     --public \
+     --description "[READ ONLY] Subtree split of the Univeros framework documentation" \
+     --homepage "https://univeros.io"
    ```
 
-   Each new repo can be empty — the first workflow run will force-push the split contents.
+   `univeros/univeros` already exists from the 2017-era stub — the first workflow run will force-push the current starter contents over it. Other new repos can be empty; the first run creates `master`.
 
 2. **Delete stale repositories** that no longer correspond to a `src/Altair/*` directory:
 
@@ -35,7 +46,7 @@ Before the workflow can push anything, the following must exist:
    gh repo delete univeros/queue --yes   # replaced by univeros/messaging in 2026-05
    ```
 
-3. **Authentication token.** Generate a fine-grained personal access token with `Contents: write` on all 35 sub-repos (or a classic PAT with the `repo` scope). Store it on `univeros/framework` as the `SPLIT_TOKEN` repository secret:
+3. **Authentication token.** Generate a fine-grained personal access token with `Contents: write` on **all repositories under the `univeros` org** (35 sub-repos + `univeros/docs` + `univeros/univeros` = 37 push targets). Use "All repositories" rather than "Selected repositories" — the latter forgets to include each new sub-package until you remember to edit the token. Store it on `univeros/framework` as the `SPLIT_TOKEN` repository secret:
 
    ```bash
    gh secret set SPLIT_TOKEN --repo univeros/framework --body "<the-token>"
@@ -56,14 +67,16 @@ Before the workflow can push anything, the following must exist:
 Triggered manually via `workflow_dispatch` — the comment at the top of `split.yml` explains the rationale (the framework is not yet 1.0; auto-on-push will be enabled once it is).
 
 ```bash
-# Dry-run: compute splits for every package without pushing
+# Dry-run: compute splits for every entry without pushing
 gh workflow run split.yml -f dry_run=true
 
-# Real run: split + push all 35 packages
+# Real run: split + push all 37 entries (35 packages + docs + univeros)
 gh workflow run split.yml
 
-# Single package (matches the workflow_dispatch dropdown)
+# Single split (matches the workflow_dispatch dropdown)
 gh workflow run split.yml -f package=scaffold
+gh workflow run split.yml -f package=docs
+gh workflow run split.yml -f package=univeros
 ```
 
 Tail it:
@@ -128,7 +141,7 @@ Submit in dependency order so each upload finds its declared deps already presen
 | Symptom | Likely cause |
 |---|---|
 | `splitsh-lite produced an empty SHA` | The path in the matrix doesn't exist, or the subtree is empty at the chosen ref. |
-| `403 from github.com` when pushing | `SPLIT_TOKEN` doesn't have write access to that sub-repo, or it shadowed the GitHub Actions token (the workflow already disables `persist-credentials` for the main checkout and clears `extraheader` on push — don't re-enable those). |
-| `split.yml matrix is out of sync with src/Altair/*` | A package directory exists with a `composer.json` but is missing from the matrix, or the matrix references a path that no longer exists. The error message includes a diff. |
+| `403 from github.com` when pushing | `SPLIT_TOKEN` doesn't have write access to that target repo. Fine-grained PATs scoped to "Selected repositories" need every new sub-repo added explicitly — switch to "All repositories" to avoid this. Also check the workflow hasn't accidentally re-enabled `persist-credentials` or set `extraheader`. |
+| `split.yml matrix is out of sync with src/Altair/*` | A package directory exists with a `composer.json` but is missing from the matrix, or the matrix references a `src/Altair/<name>` path that no longer exists. The error message includes a diff. Non-package entries like `docs` and `univeros` are exempt — only `src/Altair/<name>` paths are checked. |
 | Tag propagated to some sub-repos but not others | `fail-fast: false` is set, so individual sub-repos can fail independently. Check the matrix job logs and re-run the failed jobs once the cause is fixed. |
 | Packagist shows an old version after a fresh tag | The GitHub webhook may not be wired up. Trigger a manual update at `https://packagist.org/packages/univeros/<name>` → "Update". |

--- a/docs/packages/suggest.md
+++ b/docs/packages/suggest.md
@@ -273,12 +273,12 @@ self::assertSame(Severity::Warning, $suggestions[0]->severity);
 self::assertSame('order.placed', $suggestions[0]->subject);
 ```
 
-- [tests/Suggest/Rule/](../../tests/Suggest/Rule/) — one focused test per rule, each over hand-built snapshots.
-- [tests/Suggest/SuggestionEngineTest.php](../../tests/Suggest/SuggestionEngineTest.php) — the engine: aggregation, the `--severity` floor, `--only`/`--skip`, deterministic ordering.
-- [tests/Suggest/Snapshot/SnapshotFactoryTest.php](../../tests/Suggest/Snapshot/SnapshotFactoryTest.php) — the one integration test: builds real inspectors over fixtures and asserts the reflected dependency/interface enrichment.
-- [tests/Suggest/Output/RenderersTest.php](../../tests/Suggest/Output/RenderersTest.php) — human + JSON rendering, determinism of the JSON projection.
-- [tests/Suggest/Cli/SuggestCommandTest.php](../../tests/Suggest/Cli/SuggestCommandTest.php) — exit codes, format/severity handling, flag forwarding.
-- [tests/Suggest/Configuration/SuggestConfigurationTest.php](../../tests/Suggest/Configuration/SuggestConfigurationTest.php) — Container wiring and graceful degradation without introspection.
+- [tests/Suggest/Rule/](https://github.com/univeros/framework/blob/master/tests/Suggest/Rule/) — one focused test per rule, each over hand-built snapshots.
+- [tests/Suggest/SuggestionEngineTest.php](https://github.com/univeros/framework/blob/master/tests/Suggest/SuggestionEngineTest.php) — the engine: aggregation, the `--severity` floor, `--only`/`--skip`, deterministic ordering.
+- [tests/Suggest/Snapshot/SnapshotFactoryTest.php](https://github.com/univeros/framework/blob/master/tests/Suggest/Snapshot/SnapshotFactoryTest.php) — the one integration test: builds real inspectors over fixtures and asserts the reflected dependency/interface enrichment.
+- [tests/Suggest/Output/RenderersTest.php](https://github.com/univeros/framework/blob/master/tests/Suggest/Output/RenderersTest.php) — human + JSON rendering, determinism of the JSON projection.
+- [tests/Suggest/Cli/SuggestCommandTest.php](https://github.com/univeros/framework/blob/master/tests/Suggest/Cli/SuggestCommandTest.php) — exit codes, format/severity handling, flag forwarding.
+- [tests/Suggest/Configuration/SuggestConfigurationTest.php](https://github.com/univeros/framework/blob/master/tests/Suggest/Configuration/SuggestConfigurationTest.php) — Container wiring and graceful degradation without introspection.
 
 When you add a rule, mirror this: construct a `Snapshot` with exactly the nodes the rule reasons about, and assert on the resulting suggestions. No rule should require a real Container or a booted app to test.
 

--- a/docs/packages/tinker.md
+++ b/docs/packages/tinker.md
@@ -112,13 +112,13 @@ Now `$db` and `$now` are available alongside `$container` in the shell.
 
 Everything except the one interactive line is unit-tested — the PsySH seam keeps it that way:
 
-- [tests/Tinker/Repl/PsyConfigurationFactoryTest.php](../../tests/Tinker/Repl/PsyConfigurationFactoryTest.php) — history file and startup banner land on the `Psy\Configuration`.
-- [tests/Tinker/Repl/PsyShellReplTest.php](../../tests/Tinker/Repl/PsyShellReplTest.php) — `build()` produces a `Psy\Shell` with the scope variables set (no `run()`).
-- [tests/Tinker/Repl/ContainerCasterTest.php](../../tests/Tinker/Repl/ContainerCasterTest.php) — the container summary caster.
-- [tests/Tinker/Repl/ReplContextTest.php](../../tests/Tinker/Repl/ReplContextTest.php) — immutable scope-variable layering.
-- [tests/Tinker/Preamble/PreambleBuilderTest.php](../../tests/Tinker/Preamble/PreambleBuilderTest.php) — the banner with and without inspectors (graceful degradation).
-- [tests/Tinker/Cli/TinkerCommandTest.php](../../tests/Tinker/Cli/TinkerCommandTest.php) — with a `FakeRepl`: preamble passed through, history override, the PsySH-missing exit-2 path, fresh-container fallback.
-- [tests/Tinker/Configuration/TinkerConfigurationTest.php](../../tests/Tinker/Configuration/TinkerConfigurationTest.php) — the real container is captured into scope; preamble and REPL resolve.
+- [tests/Tinker/Repl/PsyConfigurationFactoryTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Repl/PsyConfigurationFactoryTest.php) — history file and startup banner land on the `Psy\Configuration`.
+- [tests/Tinker/Repl/PsyShellReplTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Repl/PsyShellReplTest.php) — `build()` produces a `Psy\Shell` with the scope variables set (no `run()`).
+- [tests/Tinker/Repl/ContainerCasterTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Repl/ContainerCasterTest.php) — the container summary caster.
+- [tests/Tinker/Repl/ReplContextTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Repl/ReplContextTest.php) — immutable scope-variable layering.
+- [tests/Tinker/Preamble/PreambleBuilderTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Preamble/PreambleBuilderTest.php) — the banner with and without inspectors (graceful degradation).
+- [tests/Tinker/Cli/TinkerCommandTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Cli/TinkerCommandTest.php) — with a `FakeRepl`: preamble passed through, history override, the PsySH-missing exit-2 path, fresh-container fallback.
+- [tests/Tinker/Configuration/TinkerConfigurationTest.php](https://github.com/univeros/framework/blob/master/tests/Tinker/Configuration/TinkerConfigurationTest.php) — the real container is captured into scope; preamble and REPL resolve.
 
 The single uncovered line is `PsyShellRepl::run()`'s `$shell->run()`, which blocks on stdin and cannot be unit-tested.
 

--- a/src/Altair/AgentSpec/README.md
+++ b/src/Altair/AgentSpec/README.md
@@ -1,0 +1,21 @@
+# Univeros Agent Spec
+
+> Generates AI-readable manifests describing every framework package and the host application
+
+## Installation
+
+```bash
+composer require univeros/agent-spec
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/agent-spec.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/AgentSpec/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Bootstrap/README.md
+++ b/src/Altair/Bootstrap/README.md
@@ -1,0 +1,21 @@
+# Univeros Bootstrap
+
+> Zero-to-running project bootstrap: the bin/altair new command that materialises a runnable Altair API from the skeleton template
+
+## Installation
+
+```bash
+composer require univeros/bootstrap
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/bootstrap.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Bootstrap/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Cache/README.md
+++ b/src/Altair/Cache/README.md
@@ -1,0 +1,21 @@
+# Univeros Cache
+
+> The Altair Cache package
+
+## Installation
+
+```bash
+composer require univeros/cache
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/cache.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Cache/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Cli/README.md
+++ b/src/Altair/Cli/README.md
@@ -1,0 +1,21 @@
+# Univeros CLI
+
+> Attribute-driven CLI built on top of Symfony Console
+
+## Installation
+
+```bash
+composer require univeros/cli
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/cli.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Cli/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Common/README.md
+++ b/src/Altair/Common/README.md
@@ -1,0 +1,21 @@
+# Univeros Common
+
+> The Altair Common package
+
+## Installation
+
+```bash
+composer require univeros/common
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/common.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Common/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Configuration/README.md
+++ b/src/Altair/Configuration/README.md
@@ -1,0 +1,21 @@
+# Univeros Configuration
+
+> The Altair Configuration package
+
+## Installation
+
+```bash
+composer require univeros/configuration
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/configuration.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Configuration/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Container/README.md
+++ b/src/Altair/Container/README.md
@@ -1,0 +1,21 @@
+# Univeros Container
+
+> The Altair Container package
+
+## Installation
+
+```bash
+composer require univeros/container
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/container.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Container/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Cookie/README.md
+++ b/src/Altair/Cookie/README.md
@@ -1,0 +1,21 @@
+# Univeros Cookie
+
+> The Altair Cookie package
+
+## Installation
+
+```bash
+composer require univeros/cookie
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/cookie.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Cookie/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Courier/README.md
+++ b/src/Altair/Courier/README.md
@@ -1,0 +1,21 @@
+# Univeros Courier
+
+> The Altair Courier package
+
+## Installation
+
+```bash
+composer require univeros/courier
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/courier.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Courier/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Data/README.md
+++ b/src/Altair/Data/README.md
@@ -1,0 +1,21 @@
+# Univeros Data
+
+> The Altair Data package
+
+## Installation
+
+```bash
+composer require univeros/data
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/data.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Data/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Doctor/README.md
+++ b/src/Altair/Doctor/README.md
@@ -1,0 +1,21 @@
+# Univeros Doctor
+
+> bin/altair doctor — health checks with agent-actionable output. Deterministic JSON for agents, scannable text for humans
+
+## Installation
+
+```bash
+composer require univeros/doctor
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/doctor.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Doctor/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Eval/README.md
+++ b/src/Altair/Eval/README.md
@@ -1,0 +1,21 @@
+# Univeros Eval
+
+> bin/altair eval — a sandboxed scratchpad that executes a short PHP snippet inside the project's container in a guarded subprocess (disable_functions, open_basedir, memory + wall-clock limits) and returns a structured JSON result. The agent's "let me check" primitive
+
+## Installation
+
+```bash
+composer require univeros/eval
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/eval.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Eval/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Events/README.md
+++ b/src/Altair/Events/README.md
@@ -1,0 +1,21 @@
+# Univeros Events
+
+> Append-only mutation event log (.altair/events.jsonl) — session memory for agents and humans
+
+## Installation
+
+```bash
+composer require univeros/events
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/events.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Events/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Filesystem/README.md
+++ b/src/Altair/Filesystem/README.md
@@ -1,0 +1,21 @@
+# Univeros Filesystem
+
+> The Altair Filesystem package
+
+## Installation
+
+```bash
+composer require univeros/filesystem
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/filesystem.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Filesystem/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Happen/README.md
+++ b/src/Altair/Happen/README.md
@@ -1,0 +1,21 @@
+# Univeros Happen
+
+> The Altair Event package
+
+## Installation
+
+```bash
+composer require univeros/happen
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/happen.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Happen/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Http/README.md
+++ b/src/Altair/Http/README.md
@@ -1,0 +1,21 @@
+# Univeros HTTP
+
+> The Altair Http package
+
+## Installation
+
+```bash
+composer require univeros/http
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/http.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Http/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Index/README.md
+++ b/src/Altair/Index/README.md
@@ -1,0 +1,21 @@
+# Univeros Index
+
+> bin/altair index — a symbol-usage index built from the PHP AST plus spec awareness. Answers find-usages, implementers, callers-of, dead-code, and refactor-impact queries in milliseconds, as deterministic JSON for agents and CI. SQLite-backed
+
+## Installation
+
+```bash
+composer require univeros/index
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/index.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Index/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Introspection/README.md
+++ b/src/Altair/Introspection/README.md
@@ -1,0 +1,21 @@
+# Univeros Introspection
+
+> What's wired into this project right now? CLI commands + inspectors for the Container, routes, listeners, middleware, manifests, specs, and config
+
+## Installation
+
+```bash
+composer require univeros/introspection
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/introspection.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Introspection/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Mcp/README.md
+++ b/src/Altair/Mcp/README.md
@@ -1,0 +1,21 @@
+# Univeros MCP
+
+> Model Context Protocol server: exposes the framework's capabilities as MCP tools so any MCP-capable agent can drive an Altair project natively
+
+## Installation
+
+```bash
+composer require univeros/mcp
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/mcp.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Mcp/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Messaging/README.md
+++ b/src/Altair/Messaging/README.md
@@ -1,0 +1,21 @@
+# Univeros Messaging
+
+> Thin MessageBus + worker bridge over Symfony Messenger, wired through Altair's Container
+
+## Installation
+
+```bash
+composer require univeros/messaging
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/messaging.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Messaging/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Middleware/README.md
+++ b/src/Altair/Middleware/README.md
@@ -1,0 +1,21 @@
+# Univeros Middleware
+
+> The Altair Middleware package
+
+## Installation
+
+```bash
+composer require univeros/middleware
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/middleware.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Middleware/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/MigrationIntelligence/README.md
+++ b/src/Altair/MigrationIntelligence/README.md
@@ -1,0 +1,21 @@
+# Univeros Migration Intelligence
+
+> bin/altair db:migration-plan — proposes safe Cycle migrations from spec/entity diffs with read-only safety checks (NOT NULL backfill, unique dupes, FK orphans, type-cast, large tables) and two-phase rename/type-change plans. Deterministic JSON for agents and CI
+
+## Installation
+
+```bash
+composer require univeros/migration-intelligence
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/migration-intelligence.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/MigrationIntelligence/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Observability/README.md
+++ b/src/Altair/Observability/README.md
@@ -1,0 +1,21 @@
+# Univeros Observability
+
+> bin/altair observability:* — framework-native runtime observability. OpenTelemetry-compatible spans + metrics emitted natively (OTLP-JSON over HTTP, no SDK dependency), a PSR-15 middleware for per-request tracing, and a JSONL log under .altair/observability/ for local inspection and after-the-fact analysis
+
+## Installation
+
+```bash
+composer require univeros/observability
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/observability.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Observability/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Observatory/README.md
+++ b/src/Altair/Observatory/README.md
@@ -1,0 +1,21 @@
+# Univeros Observatory
+
+> Observatory — a dev-only web monitoring panel for Altair apps. A thin, gated presentation layer over the framework's introspection, doctor, events, messaging and persistence data sources
+
+## Installation
+
+```bash
+composer require univeros/observatory
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/observatory.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Observatory/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Persistence/README.md
+++ b/src/Altair/Persistence/README.md
@@ -1,0 +1,21 @@
+# Univeros Persistence
+
+> Thin Repository + UnitOfWork contract over Cycle ORM v2, wired through Altair's Container
+
+## Installation
+
+```bash
+composer require univeros/persistence
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/persistence.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Persistence/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Profiling/README.md
+++ b/src/Altair/Profiling/README.md
@@ -1,0 +1,21 @@
+# Univeros Profiling
+
+> bin/altair profile — framework-native sampling profiler. Answers "where does my code spend time?" via excimer (or xdebug) sampling, builds a weighted call tree + hotspot table + flamegraph SVG, and diffs two profiles to flag regressions. Deterministic JSON for agents and CI
+
+## Installation
+
+```bash
+composer require univeros/profiling
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/profiling.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Profiling/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Sanitation/README.md
+++ b/src/Altair/Sanitation/README.md
@@ -1,0 +1,21 @@
+# Univeros Sanitation
+
+> The Altair Sanitation package
+
+## Installation
+
+```bash
+composer require univeros/sanitation
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/sanitation.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Sanitation/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Scaffold/README.md
+++ b/src/Altair/Scaffold/README.md
@@ -1,0 +1,21 @@
+# Univeros Scaffold
+
+> Spec-to-API code generator: YAML spec in, Action/Input/Responder + OpenAPI + tests out
+
+## Installation
+
+```bash
+composer require univeros/scaffold
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/scaffold.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Scaffold/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Security/README.md
+++ b/src/Altair/Security/README.md
@@ -1,0 +1,21 @@
+# Univeros Security
+
+> The Altair Security package
+
+## Installation
+
+```bash
+composer require univeros/security
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/security.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Security/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Session/README.md
+++ b/src/Altair/Session/README.md
@@ -1,0 +1,21 @@
+# Univeros Session
+
+> The Altair Session package
+
+## Installation
+
+```bash
+composer require univeros/session
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/session.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Session/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Structure/README.md
+++ b/src/Altair/Structure/README.md
@@ -1,0 +1,21 @@
+# Univeros Structure
+
+> The Altair Structure package
+
+## Installation
+
+```bash
+composer require univeros/structure
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/structure.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Structure/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Suggest/README.md
+++ b/src/Altair/Suggest/README.md
@@ -1,0 +1,21 @@
+# Univeros Suggest
+
+> bin/altair suggest — walks the introspection surface and proposes refactors: dead bindings, fat constructors, dead events, routes without specs, orphan middleware. Deterministic JSON for agents and CI
+
+## Installation
+
+```bash
+composer require univeros/suggest
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/suggest.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Suggest/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/TestReporter/README.md
+++ b/src/Altair/TestReporter/README.md
@@ -1,0 +1,21 @@
+# Univeros Test Reporter
+
+> AI-native PHPUnit reporter: structured JSON output mapped to the production source under test
+
+## Installation
+
+```bash
+composer require univeros/test-reporter
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/test-reporter.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/TestReporter/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Tinker/README.md
+++ b/src/Altair/Tinker/README.md
@@ -1,0 +1,21 @@
+# Univeros Tinker
+
+> bin/altair tinker — an interactive PsySH REPL with the DI container in scope and a doctor-style preamble of what's wired. A local debugging tool for developers, not an agent surface
+
+## Installation
+
+```bash
+composer require univeros/tinker
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/tinker.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Tinker/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Validation/README.md
+++ b/src/Altair/Validation/README.md
@@ -1,0 +1,21 @@
+# Univeros Validation
+
+> The Altair Validation package
+
+## Installation
+
+```bash
+composer require univeros/validation
+```
+
+## Documentation
+
+The full guide for this package lives in the [Univeros documentation](https://github.com/univeros/docs/blob/master/packages/validation.md).
+
+## Contributing
+
+This repository is a **read-only mirror** of `src/Altair/Validation/` in [univeros/framework](https://github.com/univeros/framework). All issues, pull requests, and discussion belong there — changes pushed here will be overwritten by the next split.
+
+## License
+
+The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary

Mirrors the Laravel three-repo layout (`laravel/laravel` + `laravel/framework` + `laravel/docs`) by adding two non-package entries to the split pipeline, and gives every sub-package split its own GitHub landing page.

- **`docs/`** → [univeros/docs](https://github.com/univeros/docs) (the public documentation surface)
- **`src/Altair/Bootstrap/resources/skeleton/`** → [univeros/univeros](https://github.com/univeros/univeros) (the `composer create-project` starter)
- **35 per-package READMEs** under `src/Altair/<Pkg>/README.md`, modeled on [laravel/tinker](https://github.com/laravel/tinker)

The framework repo remains the single source of truth — docs PRs, starter changes, and package READMEs all live in this monorepo and get split-published. This preserves the "code and docs co-evolve in one PR" workflow while presenting the externally-pinned three-repo structure consumers expect, and gives every `github.com/univeros/<pkg>` repo a real homepage instead of a bare composer.json.

## Changes

- `split.yml`: 2 new matrix entries (`docs`, `univeros`), dropdown updated, drift guard narrowed to enforce only `src/Altair/<single-segment>` paths so the two extras are exempt without weakening package-coverage.
- README.md: new top-level "Repositories" section explaining the three top-level repos.
- `docs/packages/split-publish.md`: runbook updated for the two extras (`gh repo create univeros/docs` step, "All repositories" PAT scope guidance, dispatch examples for `docs` / `univeros`).
- 52 markdown cross-links across `docs/` rewritten from `../../X` to absolute `https://github.com/univeros/framework/blob/master/X` URLs. Without this, links like `../../tests/...` would render broken in `univeros/docs` (whose root sits one directory deeper).
- **35 new `src/Altair/<Pkg>/README.md` files** — title, one-line description (from each package's `composer.json`), install command, link to the canonical guide at `univeros/docs`, and an explicit "read-only mirror, open PRs against univeros/framework" notice.

## Test plan

- [x] Local drift-guard simulation: `find src/Altair -mindepth 2 -maxdepth 2 -name composer.json` matches the 35 `src/Altair/*` paths in the matrix; the two extras (`docs`, `univeros`) are excluded.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/split.yml'))"` passes.
- [x] `grep -rE '\]\(\.\./\.\./' docs/` returns 0 (no remaining relative cross-links).
- [x] 35 READMEs render — titles use the package's display name (Univeros Cache, Univeros MCP, Univeros Migration Intelligence), descriptions pulled cleanly from composer.json, "read-only mirror" pointer per package.
- [ ] After merge: operator runs `gh repo create univeros/docs`, then `gh workflow run split.yml` and verifies 38 jobs pass (1 matrix + 35 packages + docs + univeros).
- [ ] Real run pushes content to `univeros/docs` and `univeros/univeros` for the first time.
- [ ] Each `github.com/univeros/<pkg>` now shows a useful README on the landing page.
- [ ] `composer create-project univeros/univeros myapp` materialises a runnable starter.

## Refs

- Closes the layout question alongside #73 (starter) and #15 (docs umbrella).