### PR TITLE
docs(brand): mirror Laravel's laravel/laravel + laravel/framework README split

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-<h1 align="center">Univeros</h1>
+<h1 align="center">Univeros Framework</h1>
 
 <p align="center">
-  <em>A PHP framework whose primitives — generators, mutations, introspection — are built so an AI agent can drive it.</em>
+  <em>The source code of the Univeros framework. Namespace: <code>Altair\*</code>. Ships as <code>composer require univeros/framework</code>.</em>
 </p>
 
 <p align="center">
@@ -13,239 +13,15 @@
 
 ---
 
-## What is Univeros?
+> **Note:** this repository contains the core code of Univeros. If you want to build an application using Univeros, visit the main [**univeros/univeros**](https://github.com/univeros/univeros) repository.
 
-Univeros is a PHP 8.3+ framework for building APIs. Its codebase is namespaced `Altair\*` and ships as 35 composable packages (`univeros/http`, `univeros/scaffold`, `univeros/persistence`, …) plus a meta-package, `univeros/framework`, that bundles them all.
+## About Univeros
 
-It looks familiar at first — PSR-7/15 HTTP stack, a DI container, an ORM bridge over Cycle, a message bus over Symfony Messenger, immutable value objects, single-pass middleware. The unusual part is the layer above that: a CLI surface (`bin/altair`) whose every command emits **deterministic JSON** an AI agent can branch on, and a set of primitives — **scaffolding from a YAML spec, a rewindable journal of mutations, an append-only event log, a symbol-usage index, a doctor, a refactor adviser** — designed so an agent can be productive in the codebase without a human in the loop.
+Univeros is a PHP 8.3+ framework for building APIs. Its codebase lives under the `Altair\*` namespace — the engineering name, the way `Illuminate\*` is the engineering name for Laravel's components. The brand consumers see is **Univeros**; `Altair\*` is the plumbing.
 
-This README is the front door to what makes that work and how to use it.
+It looks familiar at first — PSR-7/15 HTTP stack, a DI container, a Cycle ORM bridge, a Symfony Messenger bridge, immutable value objects, single-pass middleware. The unusual part is the layer above that: a CLI surface (`bin/altair`) whose every command emits deterministic JSON an AI agent can branch on, and a set of primitives — **spec-driven scaffolding, a rewindable journal, an append-only event log, a symbol-usage index, a doctor, a refactor adviser, an MCP server** — designed so an agent can be productive without a human in the loop.
 
----
-
-## Why it exists
-
-Most frameworks were designed for a developer who reads documentation and infers patterns, greps for examples and mimics them, remembers project conventions between sessions, and catches their own mistakes by re-reading code.
-
-An AI agent does none of those things reliably. It needs:
-
-1. **Conventions emitted as machine-readable manifests** — not inferred from prose docs.
-2. **Generators that are deterministic** — so output can be verified, not just executed.
-3. **A clean way to undo a failed iteration** — not "hope you committed before that".
-4. **Mutation history that persists across context windows** — so "what did I just do?" is answerable in any session.
-
-Univeros provides those four things as first-class primitives. That is the reason it exists.
-
----
-
-## Quick start
-
-```bash
-composer create-project univeros/univeros myapp
-cd myapp
-php -S localhost:8080 -t public
-curl localhost:8080/ping
-# → {"status":"ok"}
-```
-
-You now have a runnable Altair API with a passing test, a health endpoint, the spec-driven toolchain wired, and the Altair agent skill staged at `.ai/skills/altair/SKILL.md` so any agent (Claude Code, Cursor, ChatGPT desktop) that lands in the project gets the project-specific operating manual on first load.
-
-To add an endpoint, write the spec — don't hand-write the boilerplate:
-
-```yaml
-# api/users/create.yaml
-endpoint:
-  name: CreateUser
-  method: POST
-  path: /users
-input:
-  email: { type: string, format: email, required: true }
-  name:  { type: string, required: true }
-responder:
-  success: 201
-persistence:
-  entity: User
-  table: users
-  columns:
-    id:    { type: uuid, primary: true }
-    email: { type: string, unique: true }
-    name:  { type: string }
-```
-
-Then scaffold:
-
-```bash
-bin/altair spec:scaffold api/users/create.yaml
-# Writes: Action, Input, Responder, domain stub, PHPUnit test,
-#         route entry, OpenAPI fragment, Cycle entity, migration, repository.
-```
-
-Every emitted file is byte-stable. Re-run on the same spec and not a byte changes — `bin/altair spec:lint` is a CI drift gate, and the SDK emitters ship their own `--check` mode.
-
----
-
-## What makes it work for agents
-
-These are the framework primitives that exist because agents need them. Each is a real `bin/altair` command with a `--format=json` (or default JSON) output mode.
-
-### 1. Spec-driven, deterministic emitters
-
-Every code generator — scaffolder, OpenAPI emitter, TypeScript SDK emitter, Python SDK emitter, Cycle migration emitter — produces byte-stable output for the same input. CI gates verify this:
-
-```bash
-bin/altair spec:scaffold api/users/create.yaml          # emit
-bin/altair spec:emit-openapi --out docs/openapi.yaml    # merge OpenAPI fragments
-bin/altair spec:emit-sdk typescript --out=sdk.ts --check  # exit 1 on drift
-bin/altair spec:lint                                    # drift check after hand-edits
-```
-
-An agent that generates from a spec can re-generate and compare to verify it did not corrupt the output. Determinism is enforced by issue **#74** as a CI gate on every PR.
-
-### 2. Spec journal — rewind / replay
-
-Every successful `bin/altair spec:scaffold` writes a self-contained entry to `.altair/journal/<id>.json` capturing the spec, per-file SHAs, and `content_before` for modified files. Failed iterations become recoverable.
-
-```bash
-bin/altair journal:list -n 50            # newest 50 entries
-bin/altair journal:rewind                # undo the most recent scaffold
-bin/altair journal:rewind --to=<id>      # undo back to a point
-bin/altair journal:rewind --dry-run      # preview without writing
-bin/altair journal:replay <id>           # re-apply one entry
-```
-
-### 3. Append-only event log — cross-session memory
-
-Every mutating operation (scaffold, migration, rewind, replay, `cs:fix`, rector, worker consume, manifest generate) records a structured entry to `.altair/events.jsonl`:
-
-```bash
-bin/altair events:tail -n 50                  # newest 50 events
-bin/altair events:since-last-success          # what happened since the last OK event
-bin/altair events:stats                       # counts by kind/status + total duration
-bin/altair events:checkpoint:create feat/posts # bookmark current head
-bin/altair events:checkpoint:diff feat/posts  # everything since the bookmark
-```
-
-An agent opens a fresh session, reads the log, and knows what was attempted, what landed, and what failed — without re-deriving it from `git log`.
-
-### 4. Symbol-usage index — refactor with confidence
-
-`bin/altair index` walks every PHP file with `nikic/php-parser` and stores symbols + usages in SQLite (`.altair/index.db`). It understands the framework's higher-level constructs too — spec endpoints, persistence entities — so refactor queries surface the YAML that drives a class, not just the PHP that references it.
-
-```bash
-bin/altair index:build                                       # ~1.8s on a 1490-file repo (8k symbols, 21k usages)
-bin/altair index:find-usages "App\User\User"
-bin/altair index:implements "Altair\Http\Contracts\MiddlewareInterface"
-bin/altair index:callers-of "App\User\UserRepository::findById"
-bin/altair index:impact "App\Order\Order"                    # blast radius of changing this
-bin/altair index:unused                                      # dead symbols
-bin/altair index:orphans                                     # files with no incoming references
-```
-
-Incremental rebuilds (content-hashed per file) keep queries millisecond-fast on a moving session.
-
-### 5. Doctor — agent-actionable health checks
-
-`bin/altair doctor` runs PHP / extension / composer checks, CS / PHPStan / test gates, container probes, and database probes. The JSON shape includes an `agent_action` per failure, telling the agent exactly what to do next — not just *what is wrong*, but *what to run next to fix it*.
-
-```bash
-bin/altair doctor --format=json
-bin/altair doctor --fix              # opt-in autofix for the subset that's safe
-bin/altair doctor --only=database    # filter by check group
-```
-
-### 6. Suggest — refactor adviser
-
-`bin/altair suggest` walks the introspection surface and flags dead container bindings, fat constructors, dead event listeners, routes without specs, orphan middleware. Each finding ships with file, line, rationale, and (where safe) an autofix.
-
-```bash
-bin/altair suggest --format=json
-bin/altair suggest --rule=dead-bindings
-```
-
-### 7. Eval — sandboxed scratchpad
-
-`bin/altair eval '<php>'` runs a snippet inside the project's container in a guarded subprocess (`disable_functions`, `open_basedir`, memory + wall-clock kill) and returns a structured JSON result.
-
-```bash
-bin/altair eval 'return $container->get(App\User\UserRepository::class)->count();'
-```
-
-The agent's "let me check" primitive. `--unsafe` lifts the sandbox and is audit-logged to `events.jsonl`.
-
-### 8. MCP server — drive Altair from any agent
-
-`bin/altair mcp:serve` exposes 42 framework operations as Model Context Protocol tools over stdio or HTTP. Any MCP-capable agent (Claude Code, ChatGPT desktop, Cursor) can drive an Altair project natively — introspect routes, run doctor, scaffold endpoints, rewind journal entries, query the index — without shell access.
-
-```bash
-bin/altair mcp:serve            # stdio
-bin/altair mcp:serve --http     # HTTP for remote agents
-bin/altair mcp:tools            # list exposed tools
-```
-
-For shell-capable agents working in a local checkout, the framework also ships an Altair skill at `.ai/skills/altair/SKILL.md` (and `.claude/skills/altair/SKILL.md`) in every project — onboarding without prompting.
-
-### 9. Introspection — read the booted app as JSON
-
-`bin/altair` ships read-only inspectors for everything the container resolves: bindings, routes, listeners, middleware, manifests, specs, masked config. Each emits deterministic JSON for agents and a scannable view for humans.
-
-### 10. Test reporter — failures mapped back to source
-
-`Altair\TestReporter\AltairExtension` is a PHPUnit 11 extension that emits a structured JSON report at the end of every run — failures mapped back to the production class under test (via `#[CoversClass]`, `@covers`, or a namespace heuristic), structured diffs for `assertSame` / `assertEquals`, one-word `result` for agents to branch on.
-
-### 11. Migration intelligence — safe schema changes
-
-`bin/altair db:migration-plan` proposes a Cycle migration from a spec/entity diff, with read-only safety checks: NOT NULL backfill paths, unique-constraint dupes, FK orphans, type-cast risk, large-table warnings, two-phase rename / type-change plans. Deterministic JSON output for agents and CI.
-
----
-
-## What you get on the human side
-
-Concrete decisions worth highlighting if you're evaluating from a developer angle, not an agent angle:
-
-- **PHP 8.3+**, `declare(strict_types=1)` on every file (995/995 source files compliant), native types over PHPDoc.
-- **PSR-7 / 15 / 14 / 6 / 16** where applicable.
-- **Single-pass middleware** — no `$next($req, $res)` double-pass leftovers from the 2015 era.
-- **Immutable value objects** — `withFoo()` instead of `setFoo()`. See `Altair\Cookie\Cookie` as the reference.
-- **Cycle ORM v2** behind framework-owned `RepositoryInterface` / `UnitOfWorkInterface` / `EntityManagerInterface` contracts — ORM imports stay out of HTTP/domain code.
-- **Symfony Messenger** behind a thin `MessageBusInterface` bridge, attribute-driven handler discovery (`#[AsHandler]`), built-in `bin/altair worker` commands.
-- **Attribute-driven CLI** — write a `#[Command]` invokable, decorate its `__invoke()` params with `#[Argument]`/`#[Option]`, and `bin/altair` discovers and autowires it.
-- **OpenTelemetry-format observability** without an OTel SDK dependency: PSR-15 middleware emits OTLP-JSON spans, the JSONL log captures them locally, the OTLP exporter forwards to any OTel Collector.
-- **Sampling profiler** (`bin/altair profile:*`, ext-excimer) — weighted call tree, hotspot table, flamegraph SVG, `profile:compare` regression gate for CI.
-- **Many small files** — 200-400 LOC typical, 800 LOC hard cap. Cohesion over containerisation.
-
----
-
-## Architecture in three layers
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│  HTTP                                                        │
-│  Http · Middleware · Cookie · Session · Sanitation           │
-│  Validation · Courier · Security                             │
-├──────────────────────────────────────────────────────────────┤
-│  Application core                                            │
-│  Container · Configuration · Happen · Common · Structure     │
-│  Data · Cache · Filesystem · Messaging · Persistence         │
-├──────────────────────────────────────────────────────────────┤
-│  Agent and tooling surface                                   │
-│  Scaffold · AgentSpec · Cli · Introspection · Doctor         │
-│  Suggest · Index · Eval · Profiling · Observability          │
-│  Migration Intelligence · Events · TestReporter              │
-│  Mcp · Bootstrap · Tinker · Observatory                      │
-└──────────────────────────────────────────────────────────────┘
-```
-
-All three layers ship as the bundled `univeros/framework`, or as 35 independently installable packages — see [Sub-packages](#sub-packages) below.
-
----
-
-## Repositories
-
-Univeros is split across three top-level repositories — `univeros/univeros`, `univeros/framework`, `univeros/docs` — plus a read-only mirror per sub-package.
-
-- **[univeros/univeros](https://github.com/univeros/univeros)** — the create-project starter. `composer create-project univeros/univeros myapp` lays down a runnable Altair API.
-- **[univeros/framework](https://github.com/univeros/framework)** — this repo. The library you depend on (`composer require univeros/framework`).
-- **[univeros/docs](https://github.com/univeros/docs)** — read-only mirror of the [docs/](docs/) tree from this monorepo. Open issues and PRs against `univeros/framework`; the docs repo is the published surface only.
+For the pitch, agent affordances walkthrough, and architecture diagram, see [**univeros/univeros**](https://github.com/univeros/univeros). For per-package guides, see [**univeros/docs**](https://github.com/univeros/docs).
 
 ## Sub-packages
 
@@ -255,7 +31,7 @@ The framework is composed of 35 standalone PHP packages under [src/Altair/](src/
 composer require univeros/framework
 ```
 
-…or compose individual packages. A few representative ones:
+…or compose individual packages:
 
 ```bash
 composer require univeros/http          # PSR-7 + PSR-15 stack, single-pass middleware
@@ -265,30 +41,19 @@ composer require univeros/messaging     # MessageBus bridge over Symfony Messeng
 composer require univeros/events        # Append-only mutation event log for agents
 ```
 
-Per-package documentation lives under [docs/packages/](docs/packages/). The complete published list:
+The complete published list: `agent-spec`, `bootstrap`, `cache`, `cli`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `doctor`, `eval`, `events`, `filesystem`, `happen`, `http`, `index`, `introspection`, `mcp`, `messaging`, `middleware`, `migration-intelligence`, `observability`, `observatory`, `persistence`, `profiling`, `sanitation`, `scaffold`, `security`, `session`, `structure`, `suggest`, `test-reporter`, `tinker`, `validation`.
 
-`agent-spec`, `bootstrap`, `cache`, `cli`, `common`, `configuration`, `container`, `cookie`, `courier`, `data`, `doctor`, `eval`, `events`, `filesystem`, `happen`, `http`, `index`, `introspection`, `mcp`, `messaging`, `middleware`, `migration-intelligence`, `observability`, `observatory`, `persistence`, `profiling`, `sanitation`, `scaffold`, `security`, `session`, `structure`, `suggest`, `test-reporter`, `tinker`, `validation`.
+Splits are produced automatically by [.github/workflows/split.yml](.github/workflows/split.yml) — see [docs/packages/split-publish.md](docs/packages/split-publish.md) for the operator runbook. All changes belong in this monorepo; the split repos are read-only mirrors.
 
-Splits are produced automatically by [.github/workflows/split.yml](.github/workflows/split.yml) — see [docs/packages/split-publish.md](docs/packages/split-publish.md) for the operator runbook. All changes belong in this monorepo; every split repo (including `univeros/univeros` and `univeros/docs`) is a read-only mirror.
+## Repositories
 
----
-
-## Documentation
-
-Per-package guides live in [docs/packages/](docs/packages/) — every page stands alone and is kept in lockstep with the source via the same PR that changes the code. Recommended starting points:
-
-- [docs/README.md](docs/README.md) — full index, grouped by HTTP stack / application core / data / infrastructure / tooling
-- [docs/packages/scaffold.md](docs/packages/scaffold.md) — the spec-driven core
-- [docs/packages/events.md](docs/packages/events.md) — the agent memory model
-- [docs/packages/index.md](docs/packages/index.md) — the refactor index
-- [docs/packages/mcp.md](docs/packages/mcp.md) — driving Altair from any agent over MCP
-- [docs/packages/agent-spec.md](docs/packages/agent-spec.md) — the `.agent/` manifest emitter
-
----
+- **[univeros/univeros](https://github.com/univeros/univeros)** — `composer create-project` starter and the main entry point for application developers.
+- **[univeros/framework](https://github.com/univeros/framework)** — this repo. The library source.
+- **[univeros/docs](https://github.com/univeros/docs)** — per-package documentation.
 
 ## Contributing
 
-Bug reports and pull requests are welcome against [`univeros/framework`](https://github.com/univeros/framework). The 35 sub-package repos under `github.com/univeros/*` are read-only mirrors maintained automatically by [.github/workflows/split.yml](.github/workflows/split.yml) — PRs against them will be ignored and overwritten on the next split.
+Issues and pull requests are welcome on this repository — it's the source of truth. The 35 sub-package repos under `github.com/univeros/*` are read-only mirrors; PRs against them will be ignored and overwritten on the next split.
 
 Before submitting:
 
@@ -301,8 +66,8 @@ CI mirrors the same gates plus the determinism drift check.
 
 ## Security
 
-If you discover a security vulnerability, please email **antonio@lonelymonkey.co** instead of opening a public issue. All security vulnerabilities will be promptly addressed.
+If you discover a security vulnerability, please email **antonio@lonelymonkey.co** instead of opening a public issue.
 
 ## License
 
-The Univeros framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+Univeros is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/src/Altair/Bootstrap/resources/skeleton/README.md
+++ b/src/Altair/Bootstrap/resources/skeleton/README.md
@@ -1,95 +1,262 @@
-# Your new Univeros app
+<h1 align="center">Univeros</h1>
 
-A runnable [Univeros](https://github.com/univeros/framework) API generated from the official starter — one working endpoint (`GET /ping`), one passing test, the spec-driven toolchain wired, and the Altair agent skill staged at `.ai/skills/altair/SKILL.md` and `.claude/skills/altair/SKILL.md` so any MCP-capable agent that opens the project is onboarded on first load.
+<p align="center">
+  <em>A PHP framework whose primitives — generators, mutations, introspection — are built so an AI agent can drive it.</em>
+</p>
 
-> **Landed here from GitHub?** This repo is the starter template — create a new app from it with:
-> ```bash
-> composer create-project univeros/univeros myapp
-> ```
-> The repo is a read-only mirror of `src/Altair/Bootstrap/resources/skeleton/` in [univeros/framework](https://github.com/univeros/framework). Open issues and PRs there.
+<p align="center">
+  <a href="https://github.com/univeros/framework/actions/workflows/ci.yml"><img src="https://github.com/univeros/framework/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
+  <img src="https://img.shields.io/badge/php-%3E%3D8.3-777BB4.svg" alt="PHP 8.3+">
+  <img src="https://img.shields.io/badge/packages-35-success.svg" alt="35 packages">
+</p>
 
-## Requirements
+---
 
-- PHP 8.3+
-- Composer
+## What is Univeros?
 
-## Getting started
+Univeros is a PHP 8.3+ framework for building APIs. The library codebase lives under the `Altair\*` namespace and ships as 35 composable packages (`univeros/http`, `univeros/scaffold`, `univeros/persistence`, …) plus a meta-package, `univeros/framework`, that bundles them all.
+
+It looks familiar at first — PSR-7/15 HTTP stack, a DI container, a Cycle ORM bridge, a Symfony Messenger bridge, immutable value objects, single-pass middleware. The unusual part is the layer above that: a CLI surface (`bin/altair`) whose every command emits **deterministic JSON** an AI agent can branch on, and a set of primitives — **spec-driven scaffolding, a rewindable journal of mutations, an append-only event log, a symbol-usage index, a doctor, a refactor adviser** — designed so an agent can be productive in the codebase without a human in the loop.
+
+This README is the front door to what makes that work and how to use it.
+
+---
+
+## Why it exists
+
+Most frameworks were designed for a developer who reads documentation and infers patterns, greps for examples and mimics them, remembers project conventions between sessions, and catches their own mistakes by re-reading code.
+
+An AI agent does none of those things reliably. It needs:
+
+1. **Conventions emitted as machine-readable manifests** — not inferred from prose docs.
+2. **Generators that are deterministic** — so output can be verified, not just executed.
+3. **A clean way to undo a failed iteration** — not "hope you committed before that".
+4. **Mutation history that persists across context windows** — so "what did I just do?" is answerable in any session.
+
+Univeros provides those four things as first-class primitives. That is the reason it exists.
+
+---
+
+## Quick start
 
 ```bash
+composer create-project univeros/univeros myapp
+cd myapp
 composer serve            # php -S localhost:8080 -t public
 curl localhost:8080/ping  # {"message":"ok","timestamp":"..."}
 composer test
 ```
 
-## Building endpoints
+You now have a runnable Univeros API with a passing test, a health endpoint, the spec-driven toolchain wired, and the Altair agent skill staged at `.ai/skills/altair/SKILL.md` and `.claude/skills/altair/SKILL.md` so any agent (Claude Code, Cursor, ChatGPT desktop) that lands in the project gets the project-specific operating manual on first load.
 
-Endpoints are spec-driven — don't hand-write the boilerplate. Write a YAML spec under `api/`, then scaffold:
+To add an endpoint, write the spec — don't hand-write the boilerplate:
+
+```yaml
+# api/users/create.yaml
+endpoint:
+  name: CreateUser
+  method: POST
+  path: /users
+input:
+  email: { type: string, format: email, required: true }
+  name:  { type: string, required: true }
+responder:
+  success: 201
+persistence:
+  entity: User
+  table: users
+  columns:
+    id:    { type: uuid, primary: true }
+    email: { type: string, unique: true }
+    name:  { type: string }
+```
+
+Then scaffold:
 
 ```bash
-vendor/bin/altair spec:scaffold api/your-endpoint.yaml
+vendor/bin/altair spec:scaffold api/users/create.yaml
 # Writes: Action, Input, Responder, domain stub, PHPUnit test,
-#         route entry, OpenAPI fragment. (Add a `persistence:` block
-#         to also emit a Cycle entity + migration + repository.)
+#         route entry, OpenAPI fragment, Cycle entity, migration, repository.
 ```
 
-Implement the generated domain's `__invoke()` — the one piece left as a TODO — and your endpoint is live. See `api/ping.yaml` + `app/Health/Ping.php` for the reference shape.
+Every emitted file is byte-stable. Re-run on the same spec and not a byte changes — `bin/altair spec:lint` is a CI drift gate, and the SDK emitters ship their own `--check` mode.
 
-Useful commands (all via `vendor/bin/altair`):
+---
+
+## What makes it work for agents
+
+These are the framework primitives that exist because agents need them. Each is a real `bin/altair` command with a `--format=json` (or default JSON) output mode.
+
+### 1. Spec-driven, deterministic emitters
+
+Every code generator — scaffolder, OpenAPI emitter, TypeScript SDK emitter, Python SDK emitter, Cycle migration emitter — produces byte-stable output for the same input. CI gates verify this:
 
 ```bash
-vendor/bin/altair spec:scaffold api/         # scaffold every spec
-vendor/bin/altair spec:emit-openapi          # merge OpenAPI fragments
-vendor/bin/altair spec:lint                  # spec-vs-code drift gate
-vendor/bin/altair doctor                     # health checks (JSON or human)
-vendor/bin/altair journal:rewind             # undo the last scaffold
-vendor/bin/altair events:since-last-success  # what changed since the last OK
-vendor/bin/altair index:find-usages Foo\\Bar # symbol-usage index
-vendor/bin/altair mcp:serve                  # drive this project from an MCP client
+vendor/bin/altair spec:scaffold api/users/create.yaml          # emit
+vendor/bin/altair spec:emit-openapi --out docs/openapi.yaml    # merge OpenAPI fragments
+vendor/bin/altair spec:emit-sdk typescript --out=sdk.ts --check  # exit 1 on drift
+vendor/bin/altair spec:lint                                    # drift check after hand-edits
 ```
 
-## Layout
+An agent that generates from a spec can re-generate and compare to verify it did not corrupt the output. Determinism is enforced by issue **#74** as a CI gate on every PR.
 
-```
-app/                    your application code (App\ namespace)
-api/                    YAML endpoint specs
-config/                 container, configuration chain, routes
-public/                 front controller (index.php)
-tests/                  PHPUnit tests
-docs/openapi/           emitted OpenAPI fragments
-database/migrations/    Cycle migrations (when persistence: is used)
-.ai/skills/altair/      Altair skill for any MCP-capable agent
-.claude/skills/altair/  Claude Code variant of the same skill
-.altair/                local-only: event log, journal, symbol index (gitignored)
-```
+### 2. Spec journal — rewind / replay
 
-## Driving it from an AI agent
+Every successful `bin/altair spec:scaffold` writes a self-contained entry to `.altair/journal/<id>.json` capturing the spec, per-file SHAs, and `content_before` for modified files. Failed iterations become recoverable.
 
-This project ships two flavours of agent affordance, depending on whether the agent has shell access:
-
-**Shell-capable agents** (Claude Code, Cursor, Copilot Workspace) auto-load the Altair skill at `.ai/skills/altair/SKILL.md` (and `.claude/skills/altair/SKILL.md` for Claude Code specifically). The skill gives the agent project-specific operating instructions on first load — what `bin/altair` ships, when to scaffold vs. hand-edit, how the event log works.
-
-**Shell-less / MCP-only agents** (ChatGPT desktop, Claude desktop, third-party MCP hosts) connect via the framework's MCP server. Point your MCP client at this project:
-
-```json
-{
-  "mcpServers": {
-    "altair": {
-      "command": "php",
-      "args": ["vendor/bin/altair", "mcp:serve"],
-      "env": { "APP_ENV": "dev" }
-    }
-  }
-}
+```bash
+vendor/bin/altair journal:list -n 50            # newest 50 entries
+vendor/bin/altair journal:rewind                # undo the most recent scaffold
+vendor/bin/altair journal:rewind --to=<id>      # undo back to a point
+vendor/bin/altair journal:rewind --dry-run      # preview without writing
+vendor/bin/altair journal:replay <id>           # re-apply one entry
 ```
 
-The server exposes 42 framework tools — scaffold, doctor, journal, events, index, suggest, eval — so the agent can drive the project without a shell.
+### 3. Append-only event log — cross-session memory
 
-## Learn more
+Every mutating operation (scaffold, migration, rewind, replay, `cs:fix`, rector, worker consume, manifest generate) records a structured entry to `.altair/events.jsonl`:
 
-- **[univeros/framework](https://github.com/univeros/framework)** — the library this depends on, source for `bin/altair`, contributing guidelines
-- **[univeros/docs](https://github.com/univeros/docs)** — per-package guides
-- **[docs/openapi/](docs/openapi/)** — the OpenAPI fragments emitted from your specs
+```bash
+vendor/bin/altair events:tail -n 50                  # newest 50 events
+vendor/bin/altair events:since-last-success          # what happened since the last OK event
+vendor/bin/altair events:stats                       # counts by kind/status + total duration
+vendor/bin/altair events:checkpoint:create feat/posts # bookmark current head
+vendor/bin/altair events:checkpoint:diff feat/posts  # everything since the bookmark
+```
+
+An agent opens a fresh session, reads the log, and knows what was attempted, what landed, and what failed — without re-deriving it from `git log`.
+
+### 4. Symbol-usage index — refactor with confidence
+
+`bin/altair index` walks every PHP file with `nikic/php-parser` and stores symbols + usages in SQLite (`.altair/index.db`). It understands the framework's higher-level constructs too — spec endpoints, persistence entities — so refactor queries surface the YAML that drives a class, not just the PHP that references it.
+
+```bash
+vendor/bin/altair index:build                                  # ~1.8s on a 1490-file repo (8k symbols, 21k usages)
+vendor/bin/altair index:find-usages "App\User\User"
+vendor/bin/altair index:implements "Altair\Http\Contracts\MiddlewareInterface"
+vendor/bin/altair index:callers-of "App\User\UserRepository::findById"
+vendor/bin/altair index:impact "App\Order\Order"               # blast radius of changing this
+vendor/bin/altair index:unused                                 # dead symbols
+vendor/bin/altair index:orphans                                # files with no incoming references
+```
+
+Incremental rebuilds (content-hashed per file) keep queries millisecond-fast on a moving session.
+
+### 5. Doctor — agent-actionable health checks
+
+`bin/altair doctor` runs PHP / extension / composer checks, CS / PHPStan / test gates, container probes, and database probes. The JSON shape includes an `agent_action` per failure, telling the agent exactly what to do next — not just *what is wrong*, but *what to run next to fix it*.
+
+```bash
+vendor/bin/altair doctor --format=json
+vendor/bin/altair doctor --fix              # opt-in autofix for the subset that's safe
+vendor/bin/altair doctor --only=database    # filter by check group
+```
+
+### 6. Suggest — refactor adviser
+
+`bin/altair suggest` walks the introspection surface and flags dead container bindings, fat constructors, dead event listeners, routes without specs, orphan middleware. Each finding ships with file, line, rationale, and (where safe) an autofix.
+
+```bash
+vendor/bin/altair suggest --format=json
+vendor/bin/altair suggest --rule=dead-bindings
+```
+
+### 7. Eval — sandboxed scratchpad
+
+`bin/altair eval '<php>'` runs a snippet inside the project's container in a guarded subprocess (`disable_functions`, `open_basedir`, memory + wall-clock kill) and returns a structured JSON result.
+
+```bash
+vendor/bin/altair eval 'return $container->get(App\User\UserRepository::class)->count();'
+```
+
+The agent's "let me check" primitive. `--unsafe` lifts the sandbox and is audit-logged to `events.jsonl`.
+
+### 8. MCP server — drive Univeros from any agent
+
+`bin/altair mcp:serve` exposes 42 framework operations as Model Context Protocol tools over stdio or HTTP. Any MCP-capable agent (Claude Code, ChatGPT desktop, Cursor) can drive a Univeros project natively — introspect routes, run doctor, scaffold endpoints, rewind journal entries, query the index — without shell access.
+
+```bash
+vendor/bin/altair mcp:serve            # stdio
+vendor/bin/altair mcp:serve --http     # HTTP for remote agents
+vendor/bin/altair mcp:tools            # list exposed tools
+```
+
+For shell-capable agents working in a local checkout, the framework also ships the Altair skill at `.ai/skills/altair/SKILL.md` (and `.claude/skills/altair/SKILL.md`) — onboarding without prompting.
+
+### 9. Introspection — read the booted app as JSON
+
+`bin/altair` ships read-only inspectors for everything the container resolves: bindings, routes, listeners, middleware, manifests, specs, masked config. Each emits deterministic JSON for agents and a scannable view for humans.
+
+### 10. Test reporter — failures mapped back to source
+
+`Altair\TestReporter\AltairExtension` is a PHPUnit 11 extension that emits a structured JSON report at the end of every run — failures mapped back to the production class under test (via `#[CoversClass]`, `@covers`, or a namespace heuristic), structured diffs for `assertSame` / `assertEquals`, one-word `result` for agents to branch on.
+
+### 11. Migration intelligence — safe schema changes
+
+`bin/altair db:migration-plan` proposes a Cycle migration from a spec/entity diff, with read-only safety checks: NOT NULL backfill paths, unique-constraint dupes, FK orphans, type-cast risk, large-table warnings, two-phase rename / type-change plans. Deterministic JSON output for agents and CI.
+
+---
+
+## What you get on the human side
+
+Concrete decisions worth highlighting if you're evaluating from a developer angle, not an agent angle:
+
+- **PHP 8.3+**, `declare(strict_types=1)` on every file (995/995 source files compliant), native types over PHPDoc.
+- **PSR-7 / 15 / 14 / 6 / 16** where applicable.
+- **Single-pass middleware** — no `$next($req, $res)` double-pass leftovers from the 2015 era.
+- **Immutable value objects** — `withFoo()` instead of `setFoo()`. See `Altair\Cookie\Cookie` as the reference.
+- **Cycle ORM v2** behind framework-owned `RepositoryInterface` / `UnitOfWorkInterface` / `EntityManagerInterface` contracts — ORM imports stay out of HTTP/domain code.
+- **Symfony Messenger** behind a thin `MessageBusInterface` bridge, attribute-driven handler discovery (`#[AsHandler]`), built-in `vendor/bin/altair worker` commands.
+- **Attribute-driven CLI** — write a `#[Command]` invokable, decorate its `__invoke()` params with `#[Argument]`/`#[Option]`, and `bin/altair` discovers and autowires it.
+- **OpenTelemetry-format observability** without an OTel SDK dependency: PSR-15 middleware emits OTLP-JSON spans, the JSONL log captures them locally, the OTLP exporter forwards to any OTel Collector.
+- **Sampling profiler** (`vendor/bin/altair profile:*`, ext-excimer) — weighted call tree, hotspot table, flamegraph SVG, `profile:compare` regression gate for CI.
+- **Many small files** — 200-400 LOC typical, 800 LOC hard cap. Cohesion over containerisation.
+
+---
+
+## Architecture in three layers
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  HTTP                                                        │
+│  Http · Middleware · Cookie · Session · Sanitation           │
+│  Validation · Courier · Security                             │
+├──────────────────────────────────────────────────────────────┤
+│  Application core                                            │
+│  Container · Configuration · Happen · Common · Structure     │
+│  Data · Cache · Filesystem · Messaging · Persistence         │
+├──────────────────────────────────────────────────────────────┤
+│  Agent and tooling surface                                   │
+│  Scaffold · AgentSpec · Cli · Introspection · Doctor         │
+│  Suggest · Index · Eval · Profiling · Observability          │
+│  Migration Intelligence · Events · TestReporter              │
+│  Mcp · Bootstrap · Tinker · Observatory                      │
+└──────────────────────────────────────────────────────────────┘
+```
+
+All three layers ship as the bundled `univeros/framework`, or as 35 independently installable packages.
+
+---
+
+## Where everything lives
+
+- **[univeros/univeros](https://github.com/univeros/univeros)** — this repo. The `composer create-project` starter.
+- **[univeros/framework](https://github.com/univeros/framework)** — the library source code (`Altair\*` namespace, ships as `composer require univeros/framework`). All issues and pull requests belong here.
+- **[univeros/docs](https://github.com/univeros/docs)** — per-package guides.
+
+> This repository is a read-only mirror of `src/Altair/Bootstrap/resources/skeleton/` in [univeros/framework](https://github.com/univeros/framework). Open issues and pull requests there.
+
+---
+
+## Contributing
+
+Bug reports and pull requests against [univeros/framework](https://github.com/univeros/framework). The 35 sub-package repos under `github.com/univeros/*` are read-only mirrors maintained automatically by the framework's split workflow.
+
+## Security
+
+If you discover a security vulnerability, please email **antonio@lonelymonkey.co** instead of opening a public issue. All security vulnerabilities will be promptly addressed.
 
 ## License
 
-This starter is licensed under the [MIT license](https://opensource.org/licenses/MIT). The application code you write on top of it is yours.
+Univeros is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary

**Brand architecture:** Univeros is to Altair what Laravel is to Illuminate. Univeros is the consumer-facing brand; \`Altair\\\\*\` is the engineering namespace. The README split should reflect that.

Closes the inverted-README issue from the previous round — the 264-line technical landing page that was on \`univeros/framework\` was on the wrong repo for its purpose. Visitors evaluating Univeros for the first time landed on the codebase rather than the brand entry point.

## Changes

### \`src/Altair/Bootstrap/resources/skeleton/README.md\` → published as github.com/univeros/univeros

Now carries the **full Univeros marketing pitch** — agent-era thesis, 11 agent primitives walkthrough, three-layer architecture diagram, sub-packages list. This is:

- The consumer entry point on GitHub (mirrors \`laravel/laravel\`)
- The README that ships at the root of every \`composer create-project univeros/univeros myapp\` checkout

### \`README.md\` (this repo) → published as github.com/univeros/framework

Now a **Laravel-laravel/framework-style slim README** (~75 lines):

- \"Note: this repository contains the core code of Univeros. If you want to build an application using Univeros, visit the main univeros/univeros repository.\"
- Brief \"About Univeros\" paragraph drawing the Altair-Illuminate parallel explicitly
- Sub-packages list (since this is where the source lives)
- Contributing + Security + License

### About-section descriptions swapped

- **univeros/univeros** → *\"A PHP 8.3 framework with agent-native primitives: deterministic generators, rewindable journal, append-only event log, MCP server. composer create-project univeros/univeros myapp.\"*
- **univeros/framework** → *\"The source code of the Univeros framework (Altair\\\\* namespace). To build a Univeros application, visit github.com/univeros/univeros.\"*

## Test plan

- [x] Both READMEs render correctly on GitHub
- [x] Cross-links resolve (univeros/univeros ↔ univeros/framework ↔ univeros/docs)
- [x] CI passes (documentation-only change)
- [ ] After merge: run split workflow so \`univeros/univeros\`'s landing page picks up the marketing pitch