### PR TITLE
feat(scaffold): OpenAPI document \xe2\x86\x92 Altair YAML spec emitter (#161)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -18,6 +18,8 @@
 - `EmittedFile` _(final)_
 - `EmittedFileKind` _(final)_ — implements `BackedEnum`, `UnitEnum`
 - `EmittedSdk` _(final)_
+- `EmittedSpec` _(final)_
+- `Emitter` _(final)_
 - `EmitterRegistry` _(final)_
 - `EndpointSpec` _(final)_
 - `EntityEmitter` _(final)_
@@ -42,9 +44,11 @@
 - `OpenApiEmitter`
 - `OpenApiParser` _(final)_
 - `OperationKind` _(final)_ — implements `BackedEnum`, `UnitEnum`
+- `OperationMapper` _(final)_
 - `OperationModel` _(final)_
 - `OutputResponseSpec` _(final)_
 - `Parser`
+- `PathDeriver` _(final)_
 - `PathResolver`
 - `PersistenceEntitySpec` _(final)_
 - `PersistenceFieldSpec` _(final)_
@@ -61,6 +65,7 @@
 - `RouteEmitter`
 - `ScaffoldCommand` _(final)_
 - `ScaffoldJournalConfiguration` _(final)_ — implements `ConfigurationInterface`
+- `SchemaMapper` _(final)_
 - `SchemaType` _(final)_
 - `SdkException` — implements `Stringable`, `Throwable`
 - `ShowCommand` _(final)_
@@ -70,6 +75,7 @@
 - `TestEmitter`
 - `TypeMapper` _(final)_
 - `TypeScriptEmitter` _(final)_ — implements `EmitterInterface`
+- `UnmappableSchemaException` _(final)_ — implements `Stringable`, `Throwable`
 - `Validator`
 - `WriteOutcome` _(final)_
 - `WriteStatus` _(final)_ — implements `BackedEnum`, `UnitEnum`
@@ -108,6 +114,11 @@
 - `tests/Scaffold/Sdk/OpenApiParserTest.php`
 - `tests/Scaffold/Sdk/PythonEmitterTest.php`
 - `tests/Scaffold/Sdk/TypeScriptEmitterTest.php`
+- `tests/Scaffold/Spec/Emitter/EmittedSpecTest.php`
+- `tests/Scaffold/Spec/Emitter/EmitterTest.php`
+- `tests/Scaffold/Spec/Emitter/OperationMapperTest.php`
+- `tests/Scaffold/Spec/Emitter/PathDeriverTest.php`
+- `tests/Scaffold/Spec/Emitter/SchemaMapperTest.php`
 - `tests/Scaffold/Spec/ParserTest.php`
 - `tests/Scaffold/Spec/PersistenceParserTest.php`
 - `tests/Scaffold/Spec/PersistenceValidatorTest.php`

--- a/src/Altair/Scaffold/Spec/Emitter/EmittedSpec.php
+++ b/src/Altair/Scaffold/Spec/Emitter/EmittedSpec.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Emitter;
+
+/**
+ * In-memory representation of one Altair YAML spec file produced by the
+ * {@see Emitter}. The CLI handles I/O; this class never touches disk.
+ */
+final readonly class EmittedSpec
+{
+    public function __construct(
+        public string $relativePath,
+        public string $contents,
+    ) {}
+}

--- a/src/Altair/Scaffold/Spec/Emitter/Emitter.php
+++ b/src/Altair/Scaffold/Spec/Emitter/Emitter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Walks an {@see OpenApiDocument} and produces one {@see EmittedSpec} per
+ * operation. The reverse of `spec:emit-openapi` — turns a parsed OpenAPI 3.1
+ * document into a directory of Altair YAML specs.
+ *
+ * Output is deterministic for the same input (alphabetical key ordering
+ * inside each operation, stable filename derivation) so it is golden-file
+ * safe.
+ */
+final readonly class Emitter
+{
+    private const int YAML_INLINE_LEVEL = 6;
+
+    private const int YAML_INDENT = 2;
+
+    public function __construct(
+        private OperationMapper $operationMapper = new OperationMapper(),
+        private PathDeriver $pathDeriver = new PathDeriver(),
+    ) {}
+
+    /**
+     *
+     * @throws UnmappableSchemaException When an operation carries a schema the mapper cannot express.
+     * @return list<EmittedSpec>
+     */
+    public function emit(OpenApiDocument $document): array
+    {
+        $emitted = [];
+        $seen = [];
+
+        foreach ($document->operations as $operation) {
+            $filename = $this->pathDeriver->filename($operation);
+
+            if (isset($seen[$filename])) {
+                throw new UnmappableSchemaException(
+                    $this->operationPointer($operation),
+                    \sprintf(
+                        "filename collision: '%s' is also emitted by '%s %s'. Set distinct operationIds to disambiguate.",
+                        $filename,
+                        $seen[$filename]['method'],
+                        $seen[$filename]['path'],
+                    ),
+                );
+            }
+
+            $structure = $this->operationMapper->map($document, $operation);
+            $contents = Yaml::dump(
+                $structure,
+                self::YAML_INLINE_LEVEL,
+                self::YAML_INDENT,
+                Yaml::DUMP_OBJECT_AS_MAP,
+            );
+
+            $emitted[] = new EmittedSpec(relativePath: $filename, contents: $contents);
+            $seen[$filename] = ['method' => $operation->method, 'path' => $operation->path];
+        }
+
+        return $emitted;
+    }
+
+    private function operationPointer(OperationModel $operation): string
+    {
+        $encodedPath = str_replace('/', '~1', $operation->path);
+
+        return '#/paths/' . $encodedPath . '/' . strtolower($operation->method);
+    }
+}

--- a/src/Altair/Scaffold/Spec/Emitter/Exception/UnmappableSchemaException.php
+++ b/src/Altair/Scaffold/Spec/Emitter/Exception/UnmappableSchemaException.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Emitter\Exception;
+
+use Altair\Scaffold\Exception\ScaffoldException;
+
+/**
+ * Raised when an OpenAPI schema cannot be expressed as an Altair YAML spec
+ * field — for example a `oneOf` without a discriminator, a recursive `$ref`
+ * cycle, or a schema kind the framework does not yet handle.
+ *
+ * The JSON pointer locates the offending node inside the source document so
+ * the caller can surface it verbatim to the user (or agent).
+ */
+final class UnmappableSchemaException extends ScaffoldException
+{
+    public function __construct(
+        public readonly string $jsonPointer,
+        string $message,
+    ) {
+        parent::__construct(\sprintf('Unmappable schema at %s: %s', $jsonPointer, $message));
+    }
+}

--- a/src/Altair/Scaffold/Spec/Emitter/OperationMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/OperationMapper.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+
+/**
+ * Builds the array structure that, when YAML-dumped, produces a single
+ * Altair endpoint spec. Combines the {@see PathDeriver} (endpoint + domain)
+ * and {@see SchemaMapper} (input + output) into one tree.
+ */
+final readonly class OperationMapper
+{
+    public function __construct(
+        private PathDeriver $pathDeriver = new PathDeriver(),
+        private SchemaMapper $schemaMapper = new SchemaMapper(),
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function map(OpenApiDocument $document, OperationModel $operation): array
+    {
+        $spec = [
+            'endpoint' => $this->endpoint($operation),
+        ];
+
+        $inputs = $this->schemaMapper->inputFields($document, $operation);
+        if ($inputs !== []) {
+            $spec['input'] = $this->inputBlock($inputs);
+        }
+
+        $outputs = $this->schemaMapper->outputs($document, $operation);
+        if ($outputs !== []) {
+            $spec['output'] = $this->outputBlock($outputs);
+        }
+
+        $spec['domain'] = [
+            'class' => $this->pathDeriver->domainFqcn($operation),
+            'invocation' => '__invoke',
+        ];
+
+        return $spec;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function endpoint(OperationModel $operation): array
+    {
+        return [
+            'method' => strtoupper($operation->method),
+            'path' => $operation->path,
+            'summary' => $operation->summary,
+            'tags' => [$this->pathDeriver->resourceDir($operation)],
+        ];
+    }
+
+    /**
+     * Render the field list as a map keyed by name so the YAML reads naturally
+     * and the Parser's "input is a map" expectation is met.
+     *
+     * @param  list<array<string, mixed>>  $fields
+     * @return array<string, array<string, mixed>>
+     */
+    private function inputBlock(array $fields): array
+    {
+        $block = [];
+        foreach ($fields as $field) {
+            $name = (string) $field['name'];
+            unset($field['name']);
+            $block[$name] = $field;
+        }
+
+        return $block;
+    }
+
+    /**
+     * @param  array<int, array<string, string>>      $outputs
+     * @return array<int, array<string, mixed>>
+     */
+    private function outputBlock(array $outputs): array
+    {
+        $block = [];
+        foreach ($outputs as $status => $body) {
+            $block[$status] = ['body' => $body];
+        }
+
+        return $block;
+    }
+}

--- a/src/Altair/Scaffold/Spec/Emitter/PathDeriver.php
+++ b/src/Altair/Scaffold/Spec/Emitter/PathDeriver.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OperationModel;
+
+/**
+ * Derives filenames, domain class FQCNs, and resource hints from an
+ * {@see OperationModel}. Holds the convention `api/<resource>/<verb>.yaml`
+ * in one place so {@see Emitter} and tests can rely on it.
+ */
+final readonly class PathDeriver
+{
+    public function __construct(
+        private string $appNamespace = 'App',
+        private string $specRoot = 'api',
+    ) {}
+
+    public function filename(OperationModel $operation): string
+    {
+        return $this->specRoot . '/' . $this->resourceDir($operation) . '/' . $this->verb($operation) . '.yaml';
+    }
+
+    public function domainFqcn(OperationModel $operation): string
+    {
+        $resource = $this->singularize($this->resourceSegment($operation));
+        $namespacePart = $this->pascalCase($resource);
+        $className = $this->className($operation);
+
+        return $this->appNamespace . '\\' . $namespacePart . '\\' . $className;
+    }
+
+    public function resourceSingular(OperationModel $operation): string
+    {
+        return $this->singularize($this->resourceSegment($operation));
+    }
+
+    public function resourceDir(OperationModel $operation): string
+    {
+        return $this->resourceSegment($operation);
+    }
+
+    public function verb(OperationModel $operation): string
+    {
+        $firstWord = $this->firstCamelWord($operation->operationId);
+        if ($firstWord !== '') {
+            return strtolower($firstWord);
+        }
+
+        return $this->verbFromMethod($operation);
+    }
+
+    private function verbFromMethod(OperationModel $operation): string
+    {
+        return match (strtoupper($operation->method)) {
+            'POST' => 'create',
+            'PUT', 'PATCH' => 'update',
+            'DELETE' => 'delete',
+            'GET' => $this->endsWithPathParameter($operation->path) ? 'get' : 'list',
+            default => strtolower($operation->method),
+        };
+    }
+
+    private function className(OperationModel $operation): string
+    {
+        if ($operation->operationId !== '') {
+            return $this->pascalCase($operation->operationId);
+        }
+
+        $verb = $this->verbFromMethod($operation);
+        $resourceSegment = $this->resourceSegment($operation);
+        $resource = $verb === 'list' ? $resourceSegment : $this->singularize($resourceSegment);
+
+        return $this->pascalCase($verb) . $this->pascalCase($resource);
+    }
+
+    private function resourceSegment(OperationModel $operation): string
+    {
+        $segments = array_values(array_filter(
+            explode('/', $operation->path),
+            static fn(string $segment): bool => $segment !== '' && !str_starts_with($segment, '{'),
+        ));
+
+        if ($segments === []) {
+            return 'endpoint';
+        }
+
+        return end($segments);
+    }
+
+    private function endsWithPathParameter(string $path): bool
+    {
+        $segments = array_values(array_filter(
+            explode('/', $path),
+            static fn(string $segment): bool => $segment !== '',
+        ));
+
+        if ($segments === []) {
+            return false;
+        }
+
+        return str_starts_with(end($segments), '{');
+    }
+
+    private function firstCamelWord(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        // Split on camelCase boundary: first lowercase run.
+        if (preg_match('/^[a-z]+/', $value, $match) === 1) {
+            return $match[0];
+        }
+
+        return $value;
+    }
+
+    private function pascalCase(string $value): string
+    {
+        $words = preg_split('/[^A-Za-z0-9]+|(?<=[a-z])(?=[A-Z])/', $value) ?: [];
+        $words = array_filter($words, static fn(string $w): bool => $w !== '');
+
+        return implode('', array_map(static fn(string $w): string => ucfirst(strtolower($w)), $words));
+    }
+
+    private function singularize(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        if (str_ends_with($value, 'ies') && \strlen($value) > 3) {
+            return substr($value, 0, -3) . 'y';
+        }
+
+        if (str_ends_with($value, 'ses') && \strlen($value) > 3) {
+            return substr($value, 0, -2);
+        }
+
+        return str_ends_with($value, 's') && !str_ends_with($value, 'ss')
+            ? substr($value, 0, -1)
+            : $value;
+    }
+}

--- a/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
@@ -1,0 +1,323 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Sdk\Model\ResponseModel;
+use Altair\Scaffold\Sdk\Model\SchemaType;
+use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
+
+/**
+ * Translates the language-neutral {@see SchemaType} tree into the flat
+ * field-list shape Altair YAML specs use.
+ *
+ * Inputs are scalar-only by design (Altair's input layer maps to validated
+ * primitives), so nested objects and arrays of objects raise
+ * {@see UnmappableSchemaException}. Output bodies allow richer types
+ * (FQCN references, generics) because the scaffolder hands them through to
+ * the responder unchanged.
+ */
+final readonly class SchemaMapper
+{
+    /** Refs we have followed during the current resolution — guards against cycles. */
+    private const int MAX_REF_DEPTH = 8;
+
+    public function __construct(
+        private string $appNamespace = 'App',
+    ) {}
+
+    /**
+     * Combined path-parameter + request-body field list for an operation.
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function inputFields(OpenApiDocument $document, OperationModel $operation): array
+    {
+        $fields = [];
+
+        foreach ($operation->pathParameters as $name) {
+            $fields[] = [
+                'name' => $name,
+                'type' => 'string',
+                'rules' => ['required'],
+            ];
+        }
+
+        $requestBody = $operation->requestBody;
+        if ($requestBody instanceof SchemaType) {
+            $pointer = $this->requestBodyPointer($operation);
+            $bodySchema = $this->resolveRef($document, $requestBody, $pointer);
+            foreach ($this->objectInputFields($document, $bodySchema, $pointer) as $field) {
+                $fields[] = $field;
+            }
+        }
+
+        return $fields;
+    }
+
+    /**
+     * Builds the `output:` map (status => body) for every response carrying a
+     * parseable schema. Statuses with no schema (e.g. 204 No Content, 404
+     * description-only) are skipped because Altair's output block can't
+     * represent an empty body.
+     *
+     * @return array<int, array<string, string>>
+     */
+    public function outputs(OpenApiDocument $document, OperationModel $operation): array
+    {
+        $outputs = [];
+
+        foreach ($operation->responses as $response) {
+            if (!$response->statusIsNumeric()) {
+                continue;
+            }
+
+            if (!$response->schema instanceof SchemaType) {
+                continue;
+            }
+
+            $status = (int) $response->status;
+            $outputs[$status] = $this->responseBody($document, $response, $this->responsePointer($operation, $response));
+        }
+
+        return $outputs;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function responseBody(OpenApiDocument $document, ResponseModel $response, string $pointer): array
+    {
+        \assert($response->schema instanceof SchemaType);
+
+        // Top-level $ref preserves the abstraction — wrap rather than inline.
+        if ($response->schema->kind === SchemaType::REF) {
+            $refName = (string) $response->schema->ref;
+
+            return [$this->lowercaseFirst($refName) => $this->refFqcn($refName)];
+        }
+
+        $schema = $this->resolveRef($document, $response->schema, $pointer);
+
+        if ($schema->kind === SchemaType::OBJECT) {
+            $body = [];
+            foreach ($schema->properties as $name => $property) {
+                $body[(string) $name] = $this->outputType($document, $property['schema'], $pointer . '/properties/' . $name);
+            }
+
+            return $body;
+        }
+
+        return ['result' => $this->outputType($document, $schema, $pointer)];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function objectInputFields(OpenApiDocument $document, SchemaType $schema, string $pointer): array
+    {
+        if ($schema->kind !== SchemaType::OBJECT) {
+            throw new UnmappableSchemaException(
+                $pointer,
+                'request body must be an object (got ' . $schema->kind . ').',
+            );
+        }
+
+        $fields = [];
+        foreach ($schema->properties as $name => $property) {
+            $propertyPointer = $pointer . '/properties/' . $name;
+            $fields[] = $this->inputField($document, (string) $name, $property['schema'], $property['required'], $propertyPointer);
+        }
+
+        return $fields;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function inputField(OpenApiDocument $document, string $name, SchemaType $schema, bool $required, string $pointer): array
+    {
+        $rules = $required ? ['required'] : [];
+        $resolved = $this->resolveRef($document, $schema, $pointer);
+
+        return match ($resolved->kind) {
+            SchemaType::SCALAR => $this->scalarInputField($name, $resolved, $rules),
+            SchemaType::ENUM => $this->enumInputField($name, $resolved, $rules),
+            SchemaType::ARRAY => $this->arrayInputField($name, $resolved, $rules, $pointer),
+            SchemaType::OBJECT => throw new UnmappableSchemaException(
+                $pointer,
+                'nested objects in inputs are not yet supported.',
+            ),
+            default => throw new UnmappableSchemaException(
+                $pointer,
+                \sprintf("unsupported input kind '%s'.", $resolved->kind),
+            ),
+        };
+    }
+
+    /**
+     * @param  list<string>          $rules
+     * @return array<string, mixed>
+     */
+    private function scalarInputField(string $name, SchemaType $schema, array $rules): array
+    {
+        return [
+            'name' => $name,
+            'type' => $this->inputScalarType((string) $schema->scalarType),
+            'rules' => $rules,
+        ];
+    }
+
+    /**
+     * @param  list<string>          $rules
+     * @return array<string, mixed>
+     */
+    private function enumInputField(string $name, SchemaType $schema, array $rules): array
+    {
+        if ($schema->enumValues !== []) {
+            $rules[] = 'in:' . implode(',', $schema->enumValues);
+        }
+
+        return [
+            'name' => $name,
+            'type' => 'string',
+            'rules' => $rules,
+        ];
+    }
+
+    /**
+     * @param  list<string>          $rules
+     * @return array<string, mixed>
+     */
+    private function arrayInputField(string $name, SchemaType $schema, array $rules, string $pointer): array
+    {
+        if ($schema->items instanceof SchemaType && $schema->items->kind === SchemaType::OBJECT) {
+            throw new UnmappableSchemaException(
+                $pointer . '/items',
+                'arrays of objects are not yet supported in inputs.',
+            );
+        }
+
+        return [
+            'name' => $name,
+            'type' => 'array',
+            'rules' => $rules,
+        ];
+    }
+
+    private function outputType(OpenApiDocument $document, SchemaType $schema, string $pointer): string
+    {
+        if ($schema->kind === SchemaType::REF) {
+            $refName = (string) $schema->ref;
+            $resolved = $this->resolveRef($document, $schema, $pointer);
+
+            // Refs to objects keep the FQCN abstraction; refs to scalars/enums
+            // render as the underlying type so consumers see what's on the wire.
+            return $resolved->kind === SchemaType::OBJECT
+                ? $this->refFqcn($refName)
+                : $this->outputType($document, $resolved, $pointer);
+        }
+
+        return match ($schema->kind) {
+            SchemaType::SCALAR => $this->outputScalarType((string) $schema->scalarType),
+            SchemaType::ENUM => 'string',
+            SchemaType::ARRAY => $this->outputArrayType($document, $schema, $pointer),
+            SchemaType::OBJECT => 'array<string, mixed>',
+            SchemaType::MIXED => 'mixed',
+            default => throw new UnmappableSchemaException(
+                $pointer,
+                \sprintf("unsupported output kind '%s'.", $schema->kind),
+            ),
+        };
+    }
+
+    private function outputArrayType(OpenApiDocument $document, SchemaType $schema, string $pointer): string
+    {
+        if (!$schema->items instanceof SchemaType) {
+            return 'list<mixed>';
+        }
+
+        $inner = $this->outputType($document, $schema->items, $pointer . '/items');
+
+        return 'list<' . $inner . '>';
+    }
+
+    private function inputScalarType(string $scalarType): string
+    {
+        return match ($scalarType) {
+            'integer' => 'int',
+            'number' => 'float',
+            'boolean' => 'bool',
+            default => 'string',
+        };
+    }
+
+    private function outputScalarType(string $scalarType): string
+    {
+        return match ($scalarType) {
+            'integer' => 'int',
+            'number' => 'float',
+            'boolean' => 'bool',
+            default => 'string',
+        };
+    }
+
+    private function refFqcn(string $refName): string
+    {
+        return $this->appNamespace . '\\' . $refName . '\\' . $refName;
+    }
+
+    private function lowercaseFirst(string $value): string
+    {
+        return $value === '' ? $value : strtolower($value[0]) . substr($value, 1);
+    }
+
+    private function resolveRef(
+        OpenApiDocument $document,
+        SchemaType $schema,
+        string $pointer,
+        int $depth = 0,
+    ): SchemaType {
+        if ($schema->kind !== SchemaType::REF) {
+            return $schema;
+        }
+
+        if ($depth >= self::MAX_REF_DEPTH) {
+            throw new UnmappableSchemaException($pointer, 'ref cycle exceeded resolution depth.');
+        }
+
+        $refName = (string) $schema->ref;
+        if (!isset($document->namedSchemas[$refName])) {
+            throw new UnmappableSchemaException($pointer, \sprintf("ref '%s' is not defined in components/schemas.", $refName));
+        }
+
+        return $this->resolveRef($document, $document->namedSchemas[$refName], $pointer, $depth + 1);
+    }
+
+    private function requestBodyPointer(OperationModel $operation): string
+    {
+        return $this->operationPointer($operation) . '/requestBody/content/application~1json/schema';
+    }
+
+    private function responsePointer(OperationModel $operation, ResponseModel $response): string
+    {
+        return $this->operationPointer($operation) . '/responses/' . $response->status . '/content/application~1json/schema';
+    }
+
+    private function operationPointer(OperationModel $operation): string
+    {
+        $encodedPath = str_replace('/', '~1', $operation->path);
+
+        return '#/paths/' . $encodedPath . '/' . strtolower($operation->method);
+    }
+}

--- a/tests/Scaffold/Spec/Emitter/EmittedSpecTest.php
+++ b/tests/Scaffold/Spec/Emitter/EmittedSpecTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Spec\Emitter\EmittedSpec;
+use PHPUnit\Framework\TestCase;
+
+final class EmittedSpecTest extends TestCase
+{
+    public function testExposesPathAndContents(): void
+    {
+        $emitted = new EmittedSpec(relativePath: 'api/users/create.yaml', contents: 'endpoint: {}');
+
+        self::assertSame('api/users/create.yaml', $emitted->relativePath);
+        self::assertSame('endpoint: {}', $emitted->contents);
+    }
+}

--- a/tests/Scaffold/Spec/Emitter/EmitterTest.php
+++ b/tests/Scaffold/Spec/Emitter/EmitterTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OpenApiParser;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Sdk\Model\ResponseModel;
+use Altair\Scaffold\Sdk\Model\SchemaType;
+use Altair\Scaffold\Spec\Emitter\Emitter;
+use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
+use Altair\Scaffold\Spec\Parser;
+use Altair\Scaffold\Spec\Validator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+final class EmitterTest extends TestCase
+{
+    public function testEmitsOneSpecPerOperation(): void
+    {
+        $document = $this->petstoreDocument();
+
+        $emitted = (new Emitter())->emit($document);
+
+        self::assertCount(3, $emitted);
+        self::assertSame('api/pets/create.yaml', $emitted[0]->relativePath);
+        self::assertSame('api/pets/list.yaml', $emitted[1]->relativePath);
+        self::assertSame('api/pets/get.yaml', $emitted[2]->relativePath);
+    }
+
+    public function testFilenameCollisionRaises(): void
+    {
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [
+                new OperationModel(operationId: '', method: 'GET', path: '/users', pathParameters: [], requestBody: null, responses: []),
+                new OperationModel(operationId: 'listUsers', method: 'POST', path: '/users', pathParameters: [], requestBody: null, responses: []),
+            ],
+        );
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('filename collision');
+        (new Emitter())->emit($document);
+    }
+
+    public function testEmittedYamlIsParsedByExistingParser(): void
+    {
+        $document = $this->petstoreDocument();
+
+        $emitted = (new Emitter())->emit($document);
+
+        $parser = new Parser();
+        $validator = new Validator();
+        foreach ($emitted as $spec) {
+            $parsed = $parser->parseString($spec->contents, $spec->relativePath);
+            $errors = $validator->collectErrors($parsed);
+            self::assertSame([], $errors, sprintf("Emitted spec '%s' should validate: ", $spec->relativePath) . implode('; ', $errors));
+        }
+    }
+
+    public function testEmissionIsDeterministic(): void
+    {
+        $document = $this->petstoreDocument();
+        $emitter = new Emitter();
+
+        $first = $emitter->emit($document);
+        $second = $emitter->emit($document);
+
+        self::assertCount(\count($first), $second);
+        foreach ($first as $index => $spec) {
+            self::assertSame($spec->relativePath, $second[$index]->relativePath);
+            self::assertSame($spec->contents, $second[$index]->contents);
+        }
+    }
+
+    public function testUsersApiFixtureMapsCleanly(): void
+    {
+        $yaml = (string) file_get_contents(__DIR__ . '/../../Sdk/Fixtures/users-api.yaml');
+        $document = (new OpenApiParser())->parseYaml($yaml);
+
+        $emitted = (new Emitter())->emit($document);
+
+        $byPath = [];
+        foreach ($emitted as $spec) {
+            $byPath[$spec->relativePath] = $spec->contents;
+        }
+
+        self::assertArrayHasKey('api/users/create.yaml', $byPath);
+        self::assertArrayHasKey('api/users/get.yaml', $byPath);
+
+        $created = Yaml::parse($byPath['api/users/create.yaml']);
+        self::assertSame('POST', $created['endpoint']['method']);
+        self::assertSame('/users', $created['endpoint']['path']);
+        self::assertSame('App\\User\\CreateUser', $created['domain']['class']);
+        self::assertArrayHasKey('email', $created['input']);
+        self::assertSame(['required'], $created['input']['email']['rules']);
+        self::assertArrayHasKey(201, $created['output']);
+
+        $get = Yaml::parse($byPath['api/users/get.yaml']);
+        self::assertSame('App\\User\\GetUser', $get['domain']['class']);
+        self::assertArrayHasKey('id', $get['input']);
+        self::assertSame('App\\User\\User', $get['output'][200]['body']['user']);
+    }
+
+    public function testReportsJsonPointerOnUnmappableSchema(): void
+    {
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [
+                new OperationModel(
+                    operationId: 'createUser',
+                    method: 'POST',
+                    path: '/users',
+                    pathParameters: [],
+                    requestBody: SchemaType::object([
+                        'address' => ['schema' => SchemaType::object([]), 'required' => true],
+                    ]),
+                    responses: [],
+                ),
+            ],
+        );
+
+        try {
+            (new Emitter())->emit($document);
+            self::fail('Expected UnmappableSchemaException');
+        } catch (UnmappableSchemaException $unmappableSchemaException) {
+            self::assertStringContainsString('~1users/post', $unmappableSchemaException->jsonPointer);
+            self::assertStringContainsString('address', $unmappableSchemaException->jsonPointer);
+        }
+    }
+
+    private function petstoreDocument(): OpenApiDocument
+    {
+        $petSchema = SchemaType::object([
+            'id' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+            'name' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+        ]);
+
+        return new OpenApiDocument(
+            title: 'Pets',
+            version: '1.0',
+            operations: [
+                new OperationModel(
+                    operationId: 'createPet',
+                    method: 'POST',
+                    path: '/pets',
+                    pathParameters: [],
+                    requestBody: SchemaType::object([
+                        'name' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+                    ]),
+                    responses: [new ResponseModel(status: '201', schema: SchemaType::ref('Pet'))],
+                    summary: 'Add a new pet',
+                ),
+                new OperationModel(
+                    operationId: 'listPets',
+                    method: 'GET',
+                    path: '/pets',
+                    pathParameters: [],
+                    requestBody: null,
+                    responses: [new ResponseModel(status: '200', schema: SchemaType::object([
+                        'pets' => ['schema' => SchemaType::arrayOf(SchemaType::ref('Pet')), 'required' => true],
+                    ]))],
+                ),
+                new OperationModel(
+                    operationId: 'getPet',
+                    method: 'GET',
+                    path: '/pets/{id}',
+                    pathParameters: ['id'],
+                    requestBody: null,
+                    responses: [new ResponseModel(status: '200', schema: SchemaType::ref('Pet'))],
+                ),
+            ],
+            namedSchemas: ['Pet' => $petSchema],
+        );
+    }
+}

--- a/tests/Scaffold/Spec/Emitter/OperationMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/OperationMapperTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Sdk\Model\ResponseModel;
+use Altair\Scaffold\Sdk\Model\SchemaType;
+use Altair\Scaffold\Spec\Emitter\OperationMapper;
+use PHPUnit\Framework\TestCase;
+
+final class OperationMapperTest extends TestCase
+{
+    public function testAssemblesEndpointInputOutputAndDomain(): void
+    {
+        $requestBody = SchemaType::object([
+            'email' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+        ]);
+        $responseSchema = SchemaType::object([
+            'id' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+        ]);
+        $operation = new OperationModel(
+            operationId: 'createUser',
+            method: 'POST',
+            path: '/users',
+            pathParameters: [],
+            requestBody: $requestBody,
+            responses: [new ResponseModel(status: '201', schema: $responseSchema)],
+            summary: 'Create a new user',
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertSame('POST', $spec['endpoint']['method']);
+        self::assertSame('/users', $spec['endpoint']['path']);
+        self::assertSame('Create a new user', $spec['endpoint']['summary']);
+        self::assertSame(['users'], $spec['endpoint']['tags']);
+
+        self::assertArrayHasKey('email', $spec['input']);
+        self::assertSame('string', $spec['input']['email']['type']);
+        self::assertSame(['required'], $spec['input']['email']['rules']);
+
+        self::assertSame(['id' => 'string'], $spec['output'][201]['body']);
+
+        self::assertSame('App\\User\\CreateUser', $spec['domain']['class']);
+        self::assertSame('__invoke', $spec['domain']['invocation']);
+    }
+
+    public function testOmitsInputBlockWhenNoInputs(): void
+    {
+        $operation = new OperationModel(
+            operationId: 'listUsers',
+            method: 'GET',
+            path: '/users',
+            pathParameters: [],
+            requestBody: null,
+            responses: [],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertArrayNotHasKey('input', $spec);
+        self::assertArrayNotHasKey('output', $spec);
+        self::assertArrayHasKey('endpoint', $spec);
+        self::assertArrayHasKey('domain', $spec);
+    }
+
+    public function testTagsDerivedFromResource(): void
+    {
+        $operation = new OperationModel(
+            operationId: '',
+            method: 'GET',
+            path: '/posts/{id}',
+            pathParameters: ['id'],
+            requestBody: null,
+            responses: [],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertSame(['posts'], $spec['endpoint']['tags']);
+    }
+
+    private function emptyDocument(): OpenApiDocument
+    {
+        return new OpenApiDocument(title: 'X', version: '1.0', operations: []);
+    }
+}

--- a/tests/Scaffold/Spec/Emitter/PathDeriverTest.php
+++ b/tests/Scaffold/Spec/Emitter/PathDeriverTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Spec\Emitter\PathDeriver;
+use PHPUnit\Framework\TestCase;
+
+final class PathDeriverTest extends TestCase
+{
+    public function testCollectionPostBecomesCreateFile(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('POST', '/users'));
+
+        self::assertSame('api/users/create.yaml', $filename);
+    }
+
+    public function testCollectionGetBecomesListFile(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('GET', '/users'));
+
+        self::assertSame('api/users/list.yaml', $filename);
+    }
+
+    public function testItemGetBecomesGetFile(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('GET', '/users/{id}', pathParameters: ['id']));
+
+        self::assertSame('api/users/get.yaml', $filename);
+    }
+
+    public function testItemPutBecomesUpdateFile(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('PUT', '/users/{id}', pathParameters: ['id']));
+
+        self::assertSame('api/users/update.yaml', $filename);
+    }
+
+    public function testItemPatchBecomesUpdateFile(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('PATCH', '/users/{id}', pathParameters: ['id']));
+
+        self::assertSame('api/users/update.yaml', $filename);
+    }
+
+    public function testItemDeleteBecomesDeleteFile(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('DELETE', '/users/{id}', pathParameters: ['id']));
+
+        self::assertSame('api/users/delete.yaml', $filename);
+    }
+
+    public function testOperationIdFirstWordOverridesVerb(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('POST', '/posts/{id}', operationId: 'archivePost', pathParameters: ['id']));
+
+        self::assertSame('api/posts/archive.yaml', $filename);
+    }
+
+    public function testRootPathFallsBackToEndpointDirectory(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('GET', '/'));
+
+        self::assertSame('api/endpoint/list.yaml', $filename);
+    }
+
+    public function testSynthesizedOperationIdProducesCleanFilename(): void
+    {
+        // Mirrors what OpenApiParser::synthesizeOperationId emits.
+        $filename = (new PathDeriver())->filename($this->operation('GET', '/users/{id}', operationId: 'getUsersById', pathParameters: ['id']));
+
+        self::assertSame('api/users/get.yaml', $filename);
+    }
+
+    public function testDomainFqcnUsesSingularResourceNamespace(): void
+    {
+        $fqcn = (new PathDeriver())->domainFqcn($this->operation('POST', '/users', operationId: 'createUser'));
+
+        self::assertSame('App\\User\\CreateUser', $fqcn);
+    }
+
+    public function testDomainFqcnPascalCasesOperationId(): void
+    {
+        $fqcn = (new PathDeriver())->domainFqcn($this->operation('POST', '/posts/{id}', operationId: 'archivePost', pathParameters: ['id']));
+
+        self::assertSame('App\\Post\\ArchivePost', $fqcn);
+    }
+
+    public function testDomainFqcnSynthesizesWhenOperationIdMissing(): void
+    {
+        $fqcn = (new PathDeriver())->domainFqcn($this->operation('GET', '/users'));
+
+        self::assertSame('App\\User\\ListUsers', $fqcn);
+    }
+
+    public function testDomainFqcnUsesCustomAppNamespace(): void
+    {
+        $fqcn = (new PathDeriver(appNamespace: 'Acme'))->domainFqcn($this->operation('POST', '/users', operationId: 'createUser'));
+
+        self::assertSame('Acme\\User\\CreateUser', $fqcn);
+    }
+
+    public function testCustomSpecRootDirectory(): void
+    {
+        $filename = (new PathDeriver(specRoot: 'specs'))->filename($this->operation('POST', '/users'));
+
+        self::assertSame('specs/users/create.yaml', $filename);
+    }
+
+    /**
+     * @param list<string> $pathParameters
+     */
+    private function operation(
+        string $method,
+        string $path,
+        string $operationId = '',
+        array $pathParameters = [],
+    ): OperationModel {
+        return new OperationModel(
+            operationId: $operationId,
+            method: $method,
+            path: $path,
+            pathParameters: $pathParameters,
+            requestBody: null,
+            responses: [],
+        );
+    }
+}

--- a/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
@@ -1,0 +1,256 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Sdk\Model\ResponseModel;
+use Altair\Scaffold\Sdk\Model\SchemaType;
+use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
+use Altair\Scaffold\Spec\Emitter\SchemaMapper;
+use PHPUnit\Framework\TestCase;
+
+final class SchemaMapperTest extends TestCase
+{
+    public function testPathParametersBecomeRequiredStringInputs(): void
+    {
+        $operation = $this->operation('GET', '/users/{id}', pathParameters: ['id']);
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'id', 'type' => 'string', 'rules' => ['required']],
+        ], $fields);
+    }
+
+    public function testRequestBodyObjectPropertiesBecomeInputs(): void
+    {
+        $body = SchemaType::object([
+            'email' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+            'age' => ['schema' => SchemaType::scalar('integer'), 'required' => false],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'email', 'type' => 'string', 'rules' => ['required']],
+            ['name' => 'age', 'type' => 'int', 'rules' => []],
+        ], $fields);
+    }
+
+    public function testEnumInputEmitsInRule(): void
+    {
+        $body = SchemaType::object([
+            'role' => ['schema' => SchemaType::enum(['admin', 'member']), 'required' => true],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'role', 'type' => 'string', 'rules' => ['required', 'in:admin,member']],
+        ], $fields);
+    }
+
+    public function testArrayInputEmitsArrayType(): void
+    {
+        $body = SchemaType::object([
+            'tags' => ['schema' => SchemaType::arrayOf(SchemaType::scalar('string')), 'required' => false],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'tags', 'type' => 'array', 'rules' => []],
+        ], $fields);
+    }
+
+    public function testNestedObjectInputRaises(): void
+    {
+        $body = SchemaType::object([
+            'address' => ['schema' => SchemaType::object([]), 'required' => true],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('nested objects in inputs are not yet supported');
+        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+    }
+
+    public function testArrayOfObjectsInputRaises(): void
+    {
+        $body = SchemaType::object([
+            'items' => ['schema' => SchemaType::arrayOf(SchemaType::object([])), 'required' => true],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('arrays of objects are not yet supported');
+        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+    }
+
+    public function testResponseObjectPropertiesBecomeBodyFields(): void
+    {
+        $schema = SchemaType::object([
+            'id' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+            'email' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+        ]);
+        $operation = $this->operation('GET', '/users/{id}', pathParameters: ['id'], responses: [
+            new ResponseModel(status: '200', schema: $schema, description: 'OK'),
+        ]);
+
+        $outputs = (new SchemaMapper())->outputs($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            200 => ['id' => 'string', 'email' => 'string'],
+        ], $outputs);
+    }
+
+    public function testResponseTopLevelRefWrapsAsField(): void
+    {
+        $operation = $this->operation('GET', '/users/{id}', pathParameters: ['id'], responses: [
+            new ResponseModel(status: '200', schema: SchemaType::ref('User')),
+        ]);
+
+        $outputs = (new SchemaMapper())->outputs($this->emptyDocument(), $operation);
+
+        self::assertSame([200 => ['user' => 'App\\User\\User']], $outputs);
+    }
+
+    public function testResponseRefPropertyResolvesToFqcn(): void
+    {
+        $schema = SchemaType::object([
+            'owner' => ['schema' => SchemaType::ref('User'), 'required' => true],
+        ]);
+        $operation = $this->operation('GET', '/posts/{id}', pathParameters: ['id'], responses: [
+            new ResponseModel(status: '200', schema: $schema),
+        ]);
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [],
+            namedSchemas: ['User' => SchemaType::object([])],
+        );
+
+        $outputs = (new SchemaMapper())->outputs($document, $operation);
+
+        self::assertSame([200 => ['owner' => 'App\\User\\User']], $outputs);
+    }
+
+    public function testResponseArrayRendersListType(): void
+    {
+        $schema = SchemaType::object([
+            'tags' => ['schema' => SchemaType::arrayOf(SchemaType::scalar('string')), 'required' => true],
+        ]);
+        $operation = $this->operation('GET', '/users/{id}', pathParameters: ['id'], responses: [
+            new ResponseModel(status: '200', schema: $schema),
+        ]);
+
+        $outputs = (new SchemaMapper())->outputs($this->emptyDocument(), $operation);
+
+        self::assertSame([200 => ['tags' => 'list<string>']], $outputs);
+    }
+
+    public function testResponseSkippedWhenNoSchema(): void
+    {
+        $operation = $this->operation('DELETE', '/users/{id}', pathParameters: ['id'], responses: [
+            new ResponseModel(status: '204', schema: null, description: 'No Content'),
+            new ResponseModel(status: 'default', schema: null, description: 'Error'),
+        ]);
+
+        $outputs = (new SchemaMapper())->outputs($this->emptyDocument(), $operation);
+
+        self::assertSame([], $outputs);
+    }
+
+    public function testResolvesRefInRequestBody(): void
+    {
+        $body = SchemaType::ref('NewUser');
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [],
+            namedSchemas: [
+                'NewUser' => SchemaType::object([
+                    'email' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+                ]),
+            ],
+        );
+
+        $fields = (new SchemaMapper())->inputFields($document, $operation);
+
+        self::assertSame([
+            ['name' => 'email', 'type' => 'string', 'rules' => ['required']],
+        ], $fields);
+    }
+
+    public function testDanglingRefRaises(): void
+    {
+        $operation = $this->operation('POST', '/users', requestBody: SchemaType::ref('Missing'));
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage("ref 'Missing' is not defined in components/schemas");
+        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+    }
+
+    public function testRefCycleRaises(): void
+    {
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [],
+            namedSchemas: ['Loop' => SchemaType::ref('Loop')],
+        );
+        $operation = $this->operation('POST', '/users', requestBody: SchemaType::ref('Loop'));
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('ref cycle');
+        (new SchemaMapper())->inputFields($document, $operation);
+    }
+
+    public function testJsonPointerLocatesOffendingProperty(): void
+    {
+        $body = SchemaType::object([
+            'address' => ['schema' => SchemaType::object([]), 'required' => true],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        try {
+            (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+            self::fail('Expected UnmappableSchemaException');
+        } catch (UnmappableSchemaException $unmappableSchemaException) {
+            self::assertStringContainsString('#/paths/~1users/post/requestBody/content/application~1json/schema/properties/address', $unmappableSchemaException->jsonPointer);
+        }
+    }
+
+    /**
+     * @param list<string>        $pathParameters
+     * @param list<ResponseModel> $responses
+     */
+    private function operation(
+        string $method,
+        string $path,
+        string $operationId = '',
+        array $pathParameters = [],
+        ?SchemaType $requestBody = null,
+        array $responses = [],
+    ): OperationModel {
+        return new OperationModel(
+            operationId: $operationId,
+            method: $method,
+            path: $path,
+            pathParameters: $pathParameters,
+            requestBody: $requestBody,
+            responses: $responses,
+        );
+    }
+
+    private function emptyDocument(): OpenApiDocument
+    {
+        return new OpenApiDocument(title: 'X', version: '1.0', operations: []);
+    }
+}


### PR DESCRIPTION
Closes #161. Part of #160.

## Summary

- Adds `Altair\Scaffold\Spec\Emitter\*` — the reverse of `spec:emit-openapi`. Walks an `OpenApiDocument` (from the existing `OpenApiParser`) and returns one `EmittedSpec` per operation, ready to be written to disk by the CLI follow-up (#162).
- Library-only, deterministic output, no CLI surface in this PR.
- 44 new tests across 5 classes (`EmittedSpec`, `Emitter`, `OperationMapper`, `SchemaMapper`, `PathDeriver`) + an `UnmappableSchemaException` with JSON pointer.

## Mapping rules

- **Filename**: `api/<resource>/<verb>.yaml`. Verb from method (`POST`\xe2\x86\x92create, `GET`\xe2\x86\x92list/get, `PUT`/`PATCH`\xe2\x86\x92update, `DELETE`\xe2\x86\x92delete). operationId's first camelCase word overrides verb (e.g. `archivePost` \xe2\x86\x92 `api/posts/archive.yaml`).
- **Path parameters** become required string inputs.
- **Request-body object properties** become inputs; OpenAPI `required` array maps to the Altair `required` rule.
- **Enum inputs** render as `string` + `in:val1,val2` rule.
- **Refs in inputs** resolve through `components.schemas`. Refs to objects in outputs render as `App\<Ref>\<Ref>`; refs to scalars/enums render as the underlying type.
- **Top-level `$ref` responses** wrap as `{<refLowerCamel>: App\<Ref>\<Ref>}` to preserve the abstraction.
- **Unmappable**: nested objects in inputs, arrays of objects, ref cycles, dangling refs, and unknown kinds raise `UnmappableSchemaException` with a JSON pointer to the offending node.
- **Determinism**: same input \xe2\x86\x92 byte-identical output (verified by a test).

## What's intentionally out of scope (per #160)

- CLI command \xe2\x80\x94 #162.
- `x-altair-*` extension handling \xe2\x80\x94 #163. The Emitter is the hook point but extension keys are not yet read/written.
- Round-trip drift gate \xe2\x80\x94 #164.

## Known follow-ups noted during this PR

- `OpenApiParser` does not currently parse `parameters[]` schemas \xe2\x80\x94 path params are coerced to `string` regardless of the source schema. Worth widening the parser when #162 lands so imports can preserve `{name: id, in: path, schema: {type: integer}}` exactly.

## Test plan

- [x] `composer cs` \xe2\x80\x94 green
- [x] `composer stan` \xe2\x80\x94 green
- [x] `composer rector` (no cache, full tree) \xe2\x80\x94 green
- [x] `composer test` \xe2\x80\x94 6175 tests, 44 new, 0 new failures. (5 pre-existing errors are environmental: MongoDB ext + `tsc`/`mypy` not installed locally; CI has them.)
- [x] Round-trip via existing `Parser` + `Validator`: emitted YAML for the Petstore-class fixture validates against the existing spec validator without manual editing.