### PR TITLE
feat(scaffold): x-altair-* OpenAPI extensions for round-trippable spec fields (#163)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -88,6 +88,7 @@
 ## Tests as documentation
 
 - `tests/Scaffold/Cli/ImportReceiptTest.php`
+- `tests/Scaffold/Cli/OpenApiImportExtensionsTest.php`
 - `tests/Scaffold/Cli/OpenApiImportRunnerTest.php`
 - `tests/Scaffold/Cli/OpenApiImportScaffoldTest.php`
 - `tests/Scaffold/Cli/PersistenceInferrerTest.php`
@@ -106,6 +107,7 @@
 - `tests/Scaffold/Emitter/MessageEmitterTest.php`
 - `tests/Scaffold/Emitter/MigrationEmitterTest.php`
 - `tests/Scaffold/Emitter/NamingTest.php`
+- `tests/Scaffold/Emitter/OpenApiEmitterExtensionsTest.php`
 - `tests/Scaffold/Emitter/OpenApiEmitterTest.php`
 - `tests/Scaffold/Emitter/RepositoryEmitterTest.php`
 - `tests/Scaffold/Emitter/ResponderEmitterTest.php`
@@ -120,11 +122,13 @@
 - `tests/Scaffold/Sdk/CompileIntegrationTest.php`
 - `tests/Scaffold/Sdk/EmitSdkCommandTest.php`
 - `tests/Scaffold/Sdk/EmitterRegistryTest.php`
+- `tests/Scaffold/Sdk/OpenApiParserExtensionsTest.php`
 - `tests/Scaffold/Sdk/OpenApiParserTest.php`
 - `tests/Scaffold/Sdk/PythonEmitterTest.php`
 - `tests/Scaffold/Sdk/TypeScriptEmitterTest.php`
 - `tests/Scaffold/Spec/Emitter/EmittedSpecTest.php`
 - `tests/Scaffold/Spec/Emitter/EmitterTest.php`
+- `tests/Scaffold/Spec/Emitter/OperationMapperExtensionsTest.php`
 - `tests/Scaffold/Spec/Emitter/OperationMapperTest.php`
 - `tests/Scaffold/Spec/Emitter/PathDeriverTest.php`
 - `tests/Scaffold/Spec/Emitter/SchemaMapperTest.php`

--- a/docs/openapi/extensions.md
+++ b/docs/openapi/extensions.md
@@ -1,0 +1,165 @@
+# `x-altair-*` OpenAPI extensions
+
+> The set of OpenAPI 3.1 specification extensions Univeros uses to carry
+> framework-specific concerns that the base spec cannot express. Forward
+> emit (`spec:emit-openapi`) writes them; reverse import
+> (`openapi:import`) reads them back. The round-trip preserves
+> persistence, queue, and domain identity that would otherwise be lost.
+
+**Schemas:** [`docs/openapi/extensions/`](./extensions/)
+**Issue:** [#163](https://github.com/univeros/framework/issues/163) ·
+epic [#160](https://github.com/univeros/framework/issues/160)
+
+## Why an extension family
+
+OpenAPI 3.1 describes the wire shape — what the request looks like, what
+each response looks like, what each status means. It deliberately does
+not describe how that shape is satisfied: which class handles the
+request, which entity persists it, which message gets dispatched after.
+
+For Univeros those are first-class spec fields. If a round trip through
+OpenAPI silently dropped them, the only safe import workflow would be
+"import then hand-rewrite," and the import path stops being useful for
+adoption. `x-altair-*` is the OpenAPI-idiomatic way out: unknown `x-*`
+keys are explicitly permitted by the spec and ignored by tooling that
+doesn't recognise them, so adding ours doesn't break the document for
+non-Univeros consumers.
+
+## The v1 keys
+
+All keys live at the **operation** level (under
+`paths.<path>.<method>`).
+
+| Key | Round-trips | Schema |
+|---|---|---|
+| `x-altair-domain` | Yes — `spec.domain.{class, invocation}` | [x-altair-domain.schema.json](./extensions/x-altair-domain.schema.json) |
+| `x-altair-persistence` | Yes — `spec.persistence` | [x-altair-persistence.schema.json](./extensions/x-altair-persistence.schema.json) |
+| `x-altair-queue` | Yes — `spec.queue` | [x-altair-queue.schema.json](./extensions/x-altair-queue.schema.json) |
+| `x-altair-idempotency` | Carried through; runtime ships later | [x-altair-idempotency.schema.json](./extensions/x-altair-idempotency.schema.json) |
+| `x-altair-webhook` | Carried through; runtime ships later | [x-altair-webhook.schema.json](./extensions/x-altair-webhook.schema.json) |
+| `x-altair-input-location` | Carried through; needs parameters-parser support | [x-altair-input-location.schema.json](./extensions/x-altair-input-location.schema.json) |
+
+"Carried through" means the parser preserves the key on the
+`OperationModel` so a downstream emitter can read it. The reverse
+importer doesn't yet do anything with it because the corresponding
+runtime piece hasn't landed; the schema is published now so authoring
+tooling can lint a document that uses it.
+
+## Round-trip example
+
+A hand-authored Altair YAML spec:
+
+```yaml
+endpoint:
+  method: POST
+  path: /users
+  summary: Create a user
+  tags: [users]
+input:
+  email:
+    type: string
+    rules: [required]
+domain:
+  class: App\User\CreateUser
+  invocation: __invoke
+persistence:
+  entity:
+    class: App\User\User
+    table: users
+    fields:
+      id: { type: uuid, primary: true }
+      email: { type: string, unique: true }
+  repository: App\User\UserRepository
+queue:
+  on_create:
+    message: App\Messages\SendWelcomeEmail
+    fields: { email: string }
+    transport: redis
+```
+
+`spec:emit-openapi` produces the corresponding OpenAPI 3.1 fragment with
+the `x-altair-*` blocks attached:
+
+```yaml
+paths:
+  /users:
+    post:
+      summary: Create a user
+      tags: [users]
+      x-altair-domain:
+        class: App\User\CreateUser
+        invocation: __invoke
+      x-altair-persistence:
+        entity:
+          class: App\User\User
+          table: users
+          fields:
+            id: { type: uuid, primary: true }
+            email: { type: string, unique: true }
+        repository: App\User\UserRepository
+      x-altair-queue:
+        - name: on_create
+          message: App\Messages\SendWelcomeEmail
+          fields: { email: string }
+          transport: redis
+      requestBody:
+        ...
+      responses:
+        ...
+```
+
+`openapi:import` reads those blocks and reconstructs the original spec:
+`domain.class` matches (not the path-derived
+`App\Users\CreateUsers`), the `persistence:` block is recovered
+verbatim, and the `queue:` block comes back as a name-keyed map (the
+extension is a list because OpenAPI's YAML serialisation reads more
+naturally that way; the Altair spec uses a map because the dispatch
+name is a stable identifier).
+
+## Forward compatibility
+
+Unknown `x-altair-*` keys are not an error. The parser captures any key
+that starts with `x-altair-` onto `OperationModel::$extensions`; on the
+reverse path, anything the runner does not know how to interpret
+surfaces in `ImportReceipt::$warnings` so v1 imports never silently
+drop a key a future Univeros release will rely on.
+
+The warning is informational: the receipt's `ok` field stays `true` and
+the import still succeeds. Agents can branch on the warning to refuse
+imports that depend on yet-unsupported behaviour, or note the gap and
+proceed.
+
+## Validating the extensions
+
+The schemas in [`docs/openapi/extensions/`](./extensions/) are Draft
+2020-12 JSON Schemas. They can be used in two ways:
+
+1. **At authoring time.** Editor tooling that supports
+   `$schema`-referencing extensions can validate `x-altair-*` blocks
+   inline as the document is edited.
+2. **At CI time.** A linter step in the OpenAPI document's repository
+   can validate each `x-altair-*` block against the matching schema and
+   fail the build on drift — the same gate the round-trip test
+   ([#164](https://github.com/univeros/framework/issues/164)) provides
+   from the framework side.
+
+## What does not round-trip yet
+
+- **`x-altair-input-location`**. The Altair flat `input:` block can
+  represent path / query / header / body inputs uniformly, but the
+  `OpenApiParser` does not currently parse `parameters[]` schemas, so
+  the location annotation has nowhere to land on the reverse path. The
+  forward emitter does not yet write this key either — both halves
+  land together when the parser gains `parameters[]` support.
+- **`x-altair-idempotency`** / **`x-altair-webhook`**. The framework
+  pieces these refer to (idempotency middleware, the webhook
+  receiver / dispatcher) ship under separate issues. The keys are
+  reserved and the schemas are published so the wire format stays
+  stable across releases.
+
+## See also
+
+- [docs/openapi/import.md](./import.md) — the importer that consumes these keys
+- [#162](https://github.com/univeros/framework/issues/162) — the CLI itself
+- [#161](https://github.com/univeros/framework/issues/161) — the spec emitter (library)
+- [#164](https://github.com/univeros/framework/issues/164) — round-trip drift gate

--- a/docs/openapi/extensions/x-altair-domain.schema.json
+++ b/docs/openapi/extensions/x-altair-domain.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://univeros.io/openapi/extensions/x-altair-domain.schema.json",
+    "title": "x-altair-domain",
+    "description": "Carries the FQCN of the domain service that handles this operation, so that openapi:import recovers the original spec's domain.class instead of synthesising one from the path + operationId.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["class"],
+    "properties": {
+        "class": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)+$",
+            "description": "Fully-qualified PHP class name of the domain service, e.g. App\\User\\CreateUser."
+        },
+        "invocation": {
+            "type": "string",
+            "default": "__invoke",
+            "description": "Method on the domain class to invoke; defaults to __invoke."
+        }
+    }
+}

--- a/docs/openapi/extensions/x-altair-idempotency.schema.json
+++ b/docs/openapi/extensions/x-altair-idempotency.schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://univeros.io/openapi/extensions/x-altair-idempotency.schema.json",
+    "title": "x-altair-idempotency",
+    "description": "Reserved key for the idempotency primitive arriving with the dedicated framework work. Emitted by spec:emit-openapi when the spec carries an idempotency block; imported as-is on the reverse path. This release does not yet wire the runtime.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["ttl"],
+    "properties": {
+        "ttl": {
+            "type": "string",
+            "description": "Duration the framework should remember the Idempotency-Key for, e.g. 24h, 7d.",
+            "pattern": "^[0-9]+(ms|s|m|h|d)$"
+        },
+        "scope": {
+            "type": "string",
+            "description": "Logical bucket the key is scoped to (e.g. tenant, user, global). Application-defined.",
+            "default": "tenant"
+        }
+    }
+}

--- a/docs/openapi/extensions/x-altair-input-location.schema.json
+++ b/docs/openapi/extensions/x-altair-input-location.schema.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://univeros.io/openapi/extensions/x-altair-input-location.schema.json",
+    "title": "x-altair-input-location",
+    "description": "Per-input-field annotation that records where the value came from on the wire (path, query, header) so an imported spec preserves the location even though Altair's input: block stores all inputs flat. Reserved key — OpenApiParser does not yet read parameters[] schemas, so the round-trip is incomplete in this release; the schema is published so authoring tooling can lint a doc that uses it.",
+    "type": "object",
+    "additionalProperties": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["in"],
+        "properties": {
+            "in": {
+                "type": "string",
+                "enum": ["path", "query", "header", "body"]
+            },
+            "name": {
+                "type": "string",
+                "description": "Override the field name as it appears on the wire (e.g. snake_case ↔ camelCase mapping)."
+            }
+        }
+    }
+}

--- a/docs/openapi/extensions/x-altair-persistence.schema.json
+++ b/docs/openapi/extensions/x-altair-persistence.schema.json
@@ -1,0 +1,58 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://univeros.io/openapi/extensions/x-altair-persistence.schema.json",
+    "title": "x-altair-persistence",
+    "description": "Mirrors the Altair spec's persistence: block at the operation level so the imported entity + table + fields survive a round trip through OpenAPI 3.1.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["entity"],
+    "properties": {
+        "entity": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["class", "table", "fields"],
+            "properties": {
+                "class": {
+                    "type": "string",
+                    "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)+$"
+                },
+                "table": {
+                    "type": "string",
+                    "minLength": 1
+                },
+                "fields": {
+                    "type": "object",
+                    "minProperties": 1,
+                    "additionalProperties": {
+                        "type": "object",
+                        "required": ["type"],
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": [
+                                    "uuid", "string", "text", "int", "integer",
+                                    "bigint", "smallint", "float", "decimal",
+                                    "bool", "boolean", "datetime", "date", "time",
+                                    "json", "enum"
+                                ]
+                            },
+                            "primary": { "type": "boolean" },
+                            "nullable": { "type": "boolean" },
+                            "unique": { "type": "boolean" },
+                            "default": {},
+                            "of": {
+                                "type": "string",
+                                "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)+$",
+                                "description": "FQCN of the PHP enum for type=enum fields."
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "repository": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)+$"
+        }
+    }
+}

--- a/docs/openapi/extensions/x-altair-queue.schema.json
+++ b/docs/openapi/extensions/x-altair-queue.schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://univeros.io/openapi/extensions/x-altair-queue.schema.json",
+    "title": "x-altair-queue",
+    "description": "Mirrors the Altair spec's queue: block, capturing one or more message dispatches per operation. Each entry is the same shape the Symfony Messenger handler factory consumes downstream.",
+    "type": "array",
+    "minItems": 1,
+    "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["name", "message", "fields"],
+        "properties": {
+            "name": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Dispatch handle, e.g. on_create. Keys the message back to the queue: map after import."
+            },
+            "message": {
+                "type": "string",
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)+$",
+                "description": "FQCN of the Message DTO to dispatch."
+            },
+            "fields": {
+                "type": "object",
+                "description": "Field name => PHP-ish type (string|int|float|bool) or FQCN.",
+                "additionalProperties": {
+                    "type": "string"
+                }
+            },
+            "transport": {
+                "type": "string",
+                "description": "Symfony Messenger transport name; null = bus default routing."
+            }
+        }
+    }
+}

--- a/docs/openapi/extensions/x-altair-webhook.schema.json
+++ b/docs/openapi/extensions/x-altair-webhook.schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://univeros.io/openapi/extensions/x-altair-webhook.schema.json",
+    "title": "x-altair-webhook",
+    "description": "Reserved key for the webhook primitive arriving with the dedicated framework work. Marks an operation as an inbound (in) or outbound (out) webhook endpoint and carries the verification settings the framework will need at runtime. This release does not yet wire the runtime.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["direction", "signing"],
+    "properties": {
+        "direction": {
+            "type": "string",
+            "enum": ["in", "out"]
+        },
+        "signing": {
+            "type": "string",
+            "description": "Signing scheme expected on inbound requests / applied to outbound dispatches.",
+            "enum": ["hmac-sha256", "hmac-sha512", "ed25519"]
+        },
+        "header": {
+            "type": "string",
+            "description": "Header name carrying the signature (inbound). Defaults to X-Signature."
+        },
+        "dedupe_ttl": {
+            "type": "string",
+            "pattern": "^[0-9]+(ms|s|m|h|d)$",
+            "description": "How long to remember the request ID for replay protection."
+        }
+    }
+}

--- a/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
@@ -62,6 +62,21 @@ final readonly class OpenApiImportRunner
 
     private const int YAML_INDENT = 2;
 
+    /**
+     * Operation-level `x-altair-*` keys this release understands. Anything
+     * outside this list still rides along verbatim — the parser captures
+     * any `x-altair-*` key — but surfaces in the receipt's `warnings[]`
+     * so v1 imports do not silently drop a key a future release relies on.
+     */
+    private const array KNOWN_OPERATION_EXTENSIONS = [
+        'x-altair-domain',
+        'x-altair-persistence',
+        'x-altair-queue',
+        'x-altair-idempotency',
+        'x-altair-webhook',
+        'x-altair-input-location',
+    ];
+
     public function __construct(
         private OpenApiParser $parser = new OpenApiParser(),
         private OperationMapper $operationMapper = new OperationMapper(),
@@ -101,7 +116,7 @@ final readonly class OpenApiImportRunner
         }
 
         if ($options->dryRun) {
-            return $this->dryRunReceipt($options, $planned);
+            return $this->dryRunReceipt($options, $planned, $document);
         }
 
         $collector = new SnapshotCollector($options->projectRoot);
@@ -110,7 +125,7 @@ final readonly class OpenApiImportRunner
         $writtenSpecs = $this->writeSpecs($planned, $writer, $collector, $options->force);
         $scaffoldFiles = [];
         $rolledBack = [];
-        $warnings = $this->initialWarnings($options);
+        $warnings = [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document)];
 
         if ($options->scaffold && $writtenSpecs !== []) {
             try {
@@ -266,9 +281,41 @@ final readonly class OpenApiImportRunner
         $warnings = [];
         if ($options->queue !== null) {
             $warnings[] = \sprintf(
-                "queue=%s recorded but inert: x-altair-queue extension support lands in #163; the flag is preserved for forward compatibility.",
+                "queue=%s flag recorded; x-altair-queue blocks in the OpenAPI source still round-trip into spec.queue regardless of the flag.",
                 $options->queue,
             );
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function unknownExtensionWarnings(OpenApiDocument $document): array
+    {
+        $warnings = [];
+        $seen = [];
+        foreach ($document->operations as $operation) {
+            foreach ($operation->extensions as $key => $_value) {
+                if (!\is_string($key)) {
+                    continue;
+                }
+
+                if (isset($seen[$key])) {
+                    continue;
+                }
+
+                if (\in_array($key, self::KNOWN_OPERATION_EXTENSIONS, true)) {
+                    continue;
+                }
+
+                $seen[$key] = true;
+                $warnings[] = \sprintf(
+                    "unknown extension '%s' carried through unchanged; not interpreted by this release.",
+                    $key,
+                );
+            }
         }
 
         return $warnings;
@@ -362,9 +409,9 @@ final readonly class OpenApiImportRunner
     }
 
     /**
-     * @param  list<EmittedFile> $planned
+     * @param list<EmittedFile> $planned
      */
-    private function dryRunReceipt(OpenApiImportOptions $options, array $planned): ImportReceipt
+    private function dryRunReceipt(OpenApiImportOptions $options, array $planned, OpenApiDocument $document): ImportReceipt
     {
         return new ImportReceipt(
             ok: true,
@@ -374,7 +421,7 @@ final readonly class OpenApiImportRunner
             scaffolded: [],
             rolledBack: [],
             unmapped: [],
-            warnings: $this->initialWarnings($options),
+            warnings: [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document)],
             journalId: null,
             eventId: null,
             error: null,

--- a/src/Altair/Scaffold/Emitter/OpenApiEmitter.php
+++ b/src/Altair/Scaffold/Emitter/OpenApiEmitter.php
@@ -12,6 +12,9 @@ declare(strict_types=1);
 namespace Altair\Scaffold\Emitter;
 
 use Altair\Scaffold\Spec\Ast\OutputResponseSpec;
+use Altair\Scaffold\Spec\Ast\PersistenceFieldSpec;
+use Altair\Scaffold\Spec\Ast\PersistenceSpec;
+use Altair\Scaffold\Spec\Ast\QueueDispatchSpec;
 use Altair\Scaffold\Spec\Ast\Spec;
 use Symfony\Component\Yaml\Yaml;
 
@@ -61,6 +64,10 @@ class OpenApiEmitter
             'summary' => $spec->endpoint->summary,
             'tags' => $spec->endpoint->tags,
         ];
+
+        foreach ($this->renderAltairExtensions($spec) as $key => $value) {
+            $operation[$key] = $value;
+        }
 
         if ($spec->inputs !== []) {
             $properties = [];
@@ -135,6 +142,110 @@ class OpenApiEmitter
         }
 
         return ['type' => 'object', 'properties' => $properties];
+    }
+
+    /**
+     * Round-trippable `x-altair-*` blocks carrying spec fields OpenAPI 3.1
+     * cannot natively express. Lets `openapi:import` recover the original
+     * `domain:`, `persistence:`, and `queue:` blocks byte-for-byte instead
+     * of having to re-infer them from the path + response shape.
+     *
+     * @return array<string, mixed>
+     */
+    private function renderAltairExtensions(Spec $spec): array
+    {
+        $extensions = [
+            'x-altair-domain' => [
+                'class' => $spec->domain->class,
+                'invocation' => $spec->domain->invocation,
+            ],
+        ];
+
+        if ($spec->persistence instanceof PersistenceSpec) {
+            $extensions['x-altair-persistence'] = $this->renderPersistence($spec->persistence);
+        }
+
+        if ($spec->queue !== []) {
+            $extensions['x-altair-queue'] = array_values(array_map(
+                $this->renderQueueDispatch(...),
+                $spec->queue,
+            ));
+        }
+
+        return $extensions;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function renderPersistence(PersistenceSpec $persistence): array
+    {
+        $fields = [];
+        foreach ($persistence->entity->fields as $field) {
+            $fields[$field->name] = $this->renderPersistenceField($field);
+        }
+
+        $block = [
+            'entity' => [
+                'class' => $persistence->entity->class,
+                'table' => $persistence->entity->table,
+                'fields' => $fields,
+            ],
+        ];
+
+        if ($persistence->repository !== '') {
+            $block['repository'] = $persistence->repository;
+        }
+
+        return $block;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function renderPersistenceField(PersistenceFieldSpec $field): array
+    {
+        $rendered = ['type' => $field->type];
+
+        if ($field->primary) {
+            $rendered['primary'] = true;
+        }
+
+        if ($field->nullable) {
+            $rendered['nullable'] = true;
+        }
+
+        if ($field->unique) {
+            $rendered['unique'] = true;
+        }
+
+        if ($field->hasDefault) {
+            $rendered['default'] = $field->default;
+        }
+
+        if ($field->of !== null) {
+            $rendered['of'] = $field->of;
+        }
+
+        return $rendered;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function renderQueueDispatch(QueueDispatchSpec $dispatch): array
+    {
+        $rendered = [
+            'name' => $dispatch->name,
+            'message' => $dispatch->message,
+            'fields' => $dispatch->fields,
+        ];
+
+        if ($dispatch->transport !== null) {
+            $rendered['transport'] = $dispatch->transport;
+        }
+
+        return $rendered;
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
+++ b/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
@@ -136,7 +136,30 @@ final readonly class OpenApiParser
             requestBody: $requestBody,
             responses: $responses,
             summary: isset($operation['summary']) && \is_string($operation['summary']) ? $operation['summary'] : '',
+            extensions: $this->extractExtensions($operation),
         );
+    }
+
+    /**
+     * `x-altair-*` keys carried at the operation level are preserved
+     * verbatim so the import path can round-trip framework-specific
+     * concerns (domain class, persistence, queue) that OpenAPI itself
+     * cannot express. Unknown extension keys still ride along so a v2
+     * extension can't be stripped by a v1 parser.
+     *
+     * @param  array<string, mixed> $operation
+     * @return array<string, mixed>
+     */
+    private function extractExtensions(array $operation): array
+    {
+        $extensions = [];
+        foreach ($operation as $key => $value) {
+            if (\is_string($key) && str_starts_with($key, 'x-altair-')) {
+                $extensions[$key] = $value;
+            }
+        }
+
+        return $extensions;
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/OperationModel.php
+++ b/src/Altair/Scaffold/Sdk/Model/OperationModel.php
@@ -24,6 +24,7 @@ final readonly class OperationModel
     /**
      * @param list<string>        $pathParameters Names of `{param}` path segments, in order.
      * @param list<ResponseModel> $responses
+     * @param array<string, mixed> $extensions    `x-altair-*` keys carried verbatim from the OpenAPI document.
      */
     public function __construct(
         public string $operationId,
@@ -33,6 +34,7 @@ final readonly class OperationModel
         public ?SchemaType $requestBody,
         public array $responses,
         public string $summary = '',
+        public array $extensions = [],
     ) {}
 
     public function hasRequestBody(): bool

--- a/src/Altair/Scaffold/Spec/Emitter/OperationMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/OperationMapper.php
@@ -45,12 +45,82 @@ final readonly class OperationMapper
             $spec['output'] = $this->outputBlock($outputs);
         }
 
-        $spec['domain'] = [
+        $spec['domain'] = $this->resolveDomain($operation);
+
+        $persistence = $this->extensionMap($operation, 'x-altair-persistence');
+        if ($persistence !== null) {
+            $spec['persistence'] = $persistence;
+        }
+
+        $queue = $this->extensionMap($operation, 'x-altair-queue');
+        if ($queue !== null) {
+            $spec['queue'] = $this->renderQueue($queue);
+        }
+
+        return $spec;
+    }
+
+    /**
+     * Pulls `x-altair-domain` when present so an imported endpoint keeps
+     * the FQCN its original spec carried. Falls back to {@see PathDeriver}
+     * when the extension is absent.
+     *
+     * @return array<string, string>
+     */
+    private function resolveDomain(OperationModel $operation): array
+    {
+        $extension = $operation->extensions['x-altair-domain'] ?? null;
+        if (\is_array($extension) && isset($extension['class']) && \is_string($extension['class']) && $extension['class'] !== '') {
+            $invocation = isset($extension['invocation']) && \is_string($extension['invocation']) && $extension['invocation'] !== ''
+                ? $extension['invocation']
+                : '__invoke';
+
+            return ['class' => $extension['class'], 'invocation' => $invocation];
+        }
+
+        return [
             'class' => $this->pathDeriver->domainFqcn($operation),
             'invocation' => '__invoke',
         ];
+    }
 
-        return $spec;
+    /**
+     * @return ?array<int|string, mixed>
+     */
+    private function extensionMap(OperationModel $operation, string $key): ?array
+    {
+        $value = $operation->extensions[$key] ?? null;
+
+        return \is_array($value) ? $value : null;
+    }
+
+    /**
+     * Turns the list form `x-altair-queue: [{name, message, ...}]` carried
+     * in the OpenAPI extension back into the map form
+     * `queue: { name: { message, ... } }` the Altair Parser expects.
+     *
+     * @param  array<int|string, mixed>      $value
+     * @return array<string, array<string, mixed>>
+     */
+    private function renderQueue(array $value): array
+    {
+        $result = [];
+        foreach ($value as $entry) {
+            if (!\is_array($entry)) {
+                continue;
+            }
+
+            $name = isset($entry['name']) && \is_string($entry['name']) ? $entry['name'] : null;
+            if ($name === null) {
+                continue;
+            }
+
+            $rendered = $entry;
+            unset($rendered['name']);
+            $result[$name] = $rendered;
+        }
+
+        return $result;
     }
 
     /**

--- a/tests/Scaffold/Cli/OpenApiImportExtensionsTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportExtensionsTest.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Cli;
+
+use Altair\Scaffold\Cli\OpenApiImportOptions;
+use Altair\Scaffold\Cli\OpenApiImportRunner;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * End-to-end coverage of the x-altair-* import path.
+ *
+ * Round-trip: build an Altair-shaped OpenAPI doc (matching what
+ * `spec:emit-openapi` produces) and assert that the imported YAML
+ * recovers the original domain / persistence / queue blocks rather than
+ * the path-derived defaults.
+ */
+final class OpenApiImportExtensionsTest extends TestCase
+{
+    private string $sandbox = '';
+
+    protected function setUp(): void
+    {
+        $this->sandbox = sys_get_temp_dir() . '/altair-extensions-' . bin2hex(random_bytes(4));
+        mkdir($this->sandbox, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->sandbox)) {
+            $this->removeRecursively($this->sandbox);
+        }
+    }
+
+    public function testXAltairDomainSurvivesImport(): void
+    {
+        $documentPath = $this->writeDocWithExtensions();
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok);
+        $spec = Yaml::parseFile($this->sandbox . '/api/users/create.yaml');
+        self::assertSame('Acme\\User\\HandleCreate', $spec['domain']['class']);
+        self::assertSame('handle', $spec['domain']['invocation']);
+    }
+
+    public function testXAltairPersistenceSurvivesImport(): void
+    {
+        $documentPath = $this->writeDocWithExtensions();
+
+        (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        $spec = Yaml::parseFile($this->sandbox . '/api/users/create.yaml');
+        self::assertArrayHasKey('persistence', $spec);
+        self::assertSame('Acme\\User\\User', $spec['persistence']['entity']['class']);
+        self::assertSame('user_records', $spec['persistence']['entity']['table']);
+        self::assertSame('uuid', $spec['persistence']['entity']['fields']['id']['type']);
+    }
+
+    public function testXAltairQueueSurvivesImportAsKeyedMap(): void
+    {
+        $documentPath = $this->writeDocWithExtensions();
+
+        (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        $spec = Yaml::parseFile($this->sandbox . '/api/users/create.yaml');
+        self::assertArrayHasKey('queue', $spec);
+        self::assertArrayHasKey('on_create', $spec['queue']);
+        self::assertSame('Acme\\Msg\\Welcome', $spec['queue']['on_create']['message']);
+    }
+
+    public function testUnknownExtensionSurfacesWarning(): void
+    {
+        $documentPath = $this->sandbox . '/openapi.yaml';
+        file_put_contents($documentPath, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: X, version: 1.0 }
+            paths:
+              /things:
+                get:
+                  operationId: listThings
+                  x-altair-future-feature: { hint: yes }
+                  responses:
+                    '200':
+                      description: OK
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              count: { type: integer }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertNotEmpty($receipt->warnings);
+        $matched = array_filter(
+            $receipt->warnings,
+            static fn(string $w): bool => str_contains($w, 'x-altair-future-feature'),
+        );
+        self::assertNotEmpty($matched, 'expected a warning for x-altair-future-feature, got: ' . implode('; ', $receipt->warnings));
+    }
+
+    public function testKnownExtensionsDoNotEmitUnknownWarning(): void
+    {
+        $documentPath = $this->writeDocWithExtensions();
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        $unknownWarnings = array_filter(
+            $receipt->warnings,
+            static fn(string $w): bool => str_contains($w, 'unknown extension'),
+        );
+
+        self::assertSame([], $unknownWarnings, 'Known extensions should not trigger unknown warnings; got: ' . implode('; ', $receipt->warnings));
+    }
+
+    private function writeDocWithExtensions(): string
+    {
+        $path = $this->sandbox . '/openapi.yaml';
+        file_put_contents($path, <<<'YAML'
+            openapi: 3.1.0
+            info:
+              title: Users API
+              version: 1.0.0
+            paths:
+              /users:
+                post:
+                  operationId: createUser
+                  summary: Create a user with non-standard hand-edits preserved
+                  x-altair-domain:
+                    class: Acme\User\HandleCreate
+                    invocation: handle
+                  x-altair-persistence:
+                    entity:
+                      class: Acme\User\User
+                      table: user_records
+                      fields:
+                        id: { type: uuid, primary: true }
+                        email: { type: string, unique: true }
+                    repository: Acme\User\UserRepository
+                  x-altair-queue:
+                    - name: on_create
+                      message: Acme\Msg\Welcome
+                      fields: { id: string, email: string }
+                      transport: redis
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [email]
+                          properties:
+                            email: { type: string }
+                  responses:
+                    '201':
+                      description: Created
+                      content:
+                        application/json:
+                          schema:
+                            type: object
+                            properties:
+                              id: { type: string }
+            YAML);
+
+        return $path;
+    }
+
+    private function removeRecursively(string $path): void
+    {
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+
+        foreach ($iterator as $node) {
+            if ($node->isDir()) {
+                @rmdir($node->getPathname());
+            } else {
+                @unlink($node->getPathname());
+            }
+        }
+
+        @rmdir($path);
+    }
+}

--- a/tests/Scaffold/Emitter/OpenApiEmitterExtensionsTest.php
+++ b/tests/Scaffold/Emitter/OpenApiEmitterExtensionsTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Emitter;
+
+use Altair\Scaffold\Emitter\OpenApiEmitter;
+use Altair\Tests\Scaffold\Support\SpecFixture;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Yaml\Yaml;
+
+final class OpenApiEmitterExtensionsTest extends TestCase
+{
+    public function testEmitsXAltairDomainBlock(): void
+    {
+        $file = (new OpenApiEmitter())->emit(SpecFixture::createUser());
+        $doc = Yaml::parse($file->contents);
+
+        $operation = $doc['paths']['/users']['post'];
+        self::assertArrayHasKey('x-altair-domain', $operation);
+        self::assertSame('App\\User\\CreateUser', $operation['x-altair-domain']['class']);
+        self::assertSame('__invoke', $operation['x-altair-domain']['invocation']);
+    }
+
+    public function testEmitsXAltairPersistenceBlock(): void
+    {
+        $file = (new OpenApiEmitter())->emit(SpecFixture::createUserWithPersistence());
+        $doc = Yaml::parse($file->contents);
+
+        $operation = $doc['paths']['/users']['post'];
+        self::assertArrayHasKey('x-altair-persistence', $operation);
+
+        $persistence = $operation['x-altair-persistence'];
+        self::assertSame('App\\User\\User', $persistence['entity']['class']);
+        self::assertSame('users', $persistence['entity']['table']);
+        self::assertSame('App\\User\\UserRepository', $persistence['repository']);
+
+        $fields = $persistence['entity']['fields'];
+        self::assertSame('uuid', $fields['id']['type']);
+        self::assertTrue($fields['id']['primary']);
+        self::assertSame('string', $fields['email']['type']);
+        self::assertTrue($fields['email']['unique']);
+        self::assertSame('datetime', $fields['created_at']['type']);
+        self::assertSame('now', $fields['created_at']['default']);
+    }
+
+    public function testEmitsXAltairQueueBlock(): void
+    {
+        $file = (new OpenApiEmitter())->emit(SpecFixture::createUserWithQueue());
+        $doc = Yaml::parse($file->contents);
+
+        $operation = $doc['paths']['/users']['post'];
+        self::assertArrayHasKey('x-altair-queue', $operation);
+
+        $queue = $operation['x-altair-queue'];
+        self::assertCount(1, $queue);
+        self::assertSame('on_create', $queue[0]['name']);
+        self::assertSame('App\\Messages\\SendWelcomeEmail', $queue[0]['message']);
+        self::assertSame('default', $queue[0]['transport']);
+        self::assertSame(['userId' => 'string', 'email' => 'string'], $queue[0]['fields']);
+    }
+
+    public function testOmitsBlocksWhenSpecHasNeither(): void
+    {
+        $file = (new OpenApiEmitter())->emit(SpecFixture::createUser());
+        $doc = Yaml::parse($file->contents);
+
+        $operation = $doc['paths']['/users']['post'];
+        self::assertArrayNotHasKey('x-altair-persistence', $operation);
+        self::assertArrayNotHasKey('x-altair-queue', $operation);
+    }
+}

--- a/tests/Scaffold/Sdk/OpenApiParserExtensionsTest.php
+++ b/tests/Scaffold/Sdk/OpenApiParserExtensionsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Sdk;
+
+use Altair\Scaffold\Sdk\Model\OpenApiParser;
+use PHPUnit\Framework\TestCase;
+
+final class OpenApiParserExtensionsTest extends TestCase
+{
+    public function testExtractsXAltairKeysOnOperation(): void
+    {
+        $document = (new OpenApiParser())->parseYaml(<<<'YAML'
+            openapi: 3.1.0
+            info: { title: X, version: 1.0 }
+            paths:
+              /users:
+                post:
+                  operationId: createUser
+                  x-altair-domain:
+                    class: App\User\CreateUser
+                    invocation: __invoke
+                  x-altair-persistence:
+                    entity:
+                      class: App\User\User
+                      table: users
+                      fields:
+                        id: { type: uuid, primary: true }
+                  x-other: ignored
+                  responses:
+                    '201': { description: ok }
+            YAML);
+
+        $operation = $document->operations[0];
+        self::assertArrayHasKey('x-altair-domain', $operation->extensions);
+        self::assertSame('App\\User\\CreateUser', $operation->extensions['x-altair-domain']['class']);
+        self::assertArrayHasKey('x-altair-persistence', $operation->extensions);
+        self::assertArrayNotHasKey('x-other', $operation->extensions);
+    }
+
+    public function testCarriesUnknownAltairExtensions(): void
+    {
+        $document = (new OpenApiParser())->parseYaml(<<<'YAML'
+            openapi: 3.1.0
+            info: { title: X, version: 1.0 }
+            paths:
+              /pings:
+                get:
+                  operationId: ping
+                  x-altair-future: { foo: bar }
+                  responses:
+                    '200': { description: ok }
+            YAML);
+
+        self::assertArrayHasKey('x-altair-future', $document->operations[0]->extensions);
+        self::assertSame(['foo' => 'bar'], $document->operations[0]->extensions['x-altair-future']);
+    }
+}

--- a/tests/Scaffold/Snapshots/create-user.openapi.yaml
+++ b/tests/Scaffold/Snapshots/create-user.openapi.yaml
@@ -8,6 +8,9 @@ paths:
       summary: 'Create a new user'
       tags:
         - users
+      x-altair-domain:
+        class: App\User\CreateUser
+        invocation: __invoke
       requestBody:
         required: true
         content:

--- a/tests/Scaffold/Spec/Emitter/OperationMapperExtensionsTest.php
+++ b/tests/Scaffold/Spec/Emitter/OperationMapperExtensionsTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec\Emitter;
+
+use Altair\Scaffold\Sdk\Model\OpenApiDocument;
+use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Spec\Emitter\OperationMapper;
+use PHPUnit\Framework\TestCase;
+
+final class OperationMapperExtensionsTest extends TestCase
+{
+    public function testXAltairDomainOverridesPathDerivedFqcn(): void
+    {
+        $operation = new OperationModel(
+            operationId: '',
+            method: 'POST',
+            path: '/users',
+            pathParameters: [],
+            requestBody: null,
+            responses: [],
+            extensions: [
+                'x-altair-domain' => ['class' => 'Acme\\Custom\\HandleCreate', 'invocation' => 'handle'],
+            ],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertSame('Acme\\Custom\\HandleCreate', $spec['domain']['class']);
+        self::assertSame('handle', $spec['domain']['invocation']);
+    }
+
+    public function testXAltairDomainInvocationDefaults(): void
+    {
+        $operation = new OperationModel(
+            operationId: '',
+            method: 'POST',
+            path: '/users',
+            pathParameters: [],
+            requestBody: null,
+            responses: [],
+            extensions: [
+                'x-altair-domain' => ['class' => 'Acme\\Custom\\X'],
+            ],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertSame('__invoke', $spec['domain']['invocation']);
+    }
+
+    public function testXAltairPersistenceBlockIsCopiedIntoSpec(): void
+    {
+        $persistence = [
+            'entity' => [
+                'class' => 'App\\User\\User',
+                'table' => 'users',
+                'fields' => ['id' => ['type' => 'uuid', 'primary' => true]],
+            ],
+            'repository' => 'App\\User\\UserRepository',
+        ];
+
+        $operation = new OperationModel(
+            operationId: '',
+            method: 'POST',
+            path: '/users',
+            pathParameters: [],
+            requestBody: null,
+            responses: [],
+            extensions: ['x-altair-persistence' => $persistence],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertSame($persistence, $spec['persistence']);
+    }
+
+    public function testXAltairQueueListIsRekeyedByName(): void
+    {
+        $queue = [
+            ['name' => 'on_create', 'message' => 'App\\Msg\\Foo', 'fields' => ['id' => 'string'], 'transport' => 'default'],
+            ['name' => 'on_create_email', 'message' => 'App\\Msg\\Bar', 'fields' => []],
+        ];
+
+        $operation = new OperationModel(
+            operationId: '',
+            method: 'POST',
+            path: '/users',
+            pathParameters: [],
+            requestBody: null,
+            responses: [],
+            extensions: ['x-altair-queue' => $queue],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertArrayHasKey('on_create', $spec['queue']);
+        self::assertSame('App\\Msg\\Foo', $spec['queue']['on_create']['message']);
+        self::assertSame('default', $spec['queue']['on_create']['transport']);
+        self::assertArrayHasKey('on_create_email', $spec['queue']);
+        self::assertArrayNotHasKey('name', $spec['queue']['on_create'], 'name should be a key, not a duplicated field');
+    }
+
+    public function testFallsBackToPathDeriverWhenExtensionAbsent(): void
+    {
+        $operation = new OperationModel(
+            operationId: 'createUser',
+            method: 'POST',
+            path: '/users',
+            pathParameters: [],
+            requestBody: null,
+            responses: [],
+        );
+
+        $spec = (new OperationMapper())->map($this->emptyDocument(), $operation);
+
+        self::assertSame('App\\User\\CreateUser', $spec['domain']['class']);
+    }
+
+    private function emptyDocument(): OpenApiDocument
+    {
+        return new OpenApiDocument(title: 'X', version: '1.0', operations: []);
+    }
+}


### PR DESCRIPTION
Closes #163. Part of #160.

## Summary

Defines the `x-altair-*` OpenAPI 3.1 extension family so the framework-specific spec fields the base spec cannot express survive a round trip through OpenAPI. `spec:emit-openapi` writes them on the forward path; `openapi:import` reads them on the reverse path. Closes the loop opened by #161 (emitter) and #162 (CLI).

## V1 key set

| Key | Round-trips | Schema |
|---|---|---|
| `x-altair-domain` | Yes \xe2\x80\x94 `spec.domain.{class, invocation}` | `docs/openapi/extensions/x-altair-domain.schema.json` |
| `x-altair-persistence` | Yes \xe2\x80\x94 `spec.persistence` | `docs/openapi/extensions/x-altair-persistence.schema.json` |
| `x-altair-queue` | Yes \xe2\x80\x94 `spec.queue` | `docs/openapi/extensions/x-altair-queue.schema.json` |
| `x-altair-idempotency` | Carried through; runtime ships later | `docs/openapi/extensions/x-altair-idempotency.schema.json` |
| `x-altair-webhook` | Carried through; runtime ships later | `docs/openapi/extensions/x-altair-webhook.schema.json` |
| `x-altair-input-location` | Carried through; needs `parameters[]` parser support | `docs/openapi/extensions/x-altair-input-location.schema.json` |

\"Carried through\" means the parser preserves the key on `OperationModel::$extensions` and the receipt warns when the runner sees it but doesn't yet act on it. The schema is published so authoring tooling can validate.

## Forward (spec:emit-openapi)

`OpenApiEmitter` now writes:

- `x-altair-domain` on every operation (the domain class is always set on a spec)
- `x-altair-persistence` when `spec.persistence` is non-null
- `x-altair-queue` (list form) when `spec.queue` is non-empty

The Petstore-class golden snapshot was regenerated to include the new `x-altair-domain` block.

## Reverse (openapi:import)

- `OperationModel` grew an `extensions: array<string, mixed>` field. Backwards-compatible default `[]`.
- `OpenApiParser` extracts every key starting with `x-altair-` from each operation onto that field. Unknown keys ride along verbatim (forward compat).
- `OperationMapper` reads `x-altair-domain` / `x-altair-persistence` / `x-altair-queue` when building the spec structure, preferring them over the path-derived defaults from `PathDeriver`.
- `OpenApiImportRunner` collects any `x-altair-*` key outside the v1 known set into `ImportReceipt::$warnings` so v1 imports never silently drop a key a future release will rely on.

## Round-trip example (from docs/openapi/extensions.md)

```yaml
# Altair spec
persistence:
  entity:
    class: App\\User\\User
    table: users
    fields:
      id: { type: uuid, primary: true }
```

emits:

```yaml
# OpenAPI fragment
x-altair-persistence:
  entity:
    class: App\\User\\User
    table: users
    fields:
      id: { type: uuid, primary: true }
```

which `openapi:import` recovers back into `spec.persistence` byte-for-byte (not the inferred persistence block the `--persistence=cycle` flag synthesises).

## Tests

- `OpenApiEmitterExtensionsTest` (4) \xe2\x80\x94 forward
- `OpenApiParserExtensionsTest` (2) \xe2\x80\x94 parser captures known + unknown `x-altair-*`
- `OperationMapperExtensionsTest` (5) \xe2\x80\x94 reverse mapping per extension
- `OpenApiImportExtensionsTest` (5) \xe2\x80\x94 end-to-end round trip + unknown-key warning + no-false-positive warnings on known keys
- Total: **+16 new tests**, all green; the existing snapshot regeneration brought the count to +1 in the OpenApiEmitter golden file.

## Test plan

- [x] `composer cs` \xe2\x80\x94 green
- [x] `composer stan` \xe2\x80\x94 green
- [x] `composer rector` (full tree, no cache) \xe2\x80\x94 green
- [x] `composer test` \xe2\x80\x94 6220 tests (+16 new), 0 new failures (5 pre-existing environmental errors unchanged)
- [x] `bin/altair manifest:generate` \xe2\x80\x94 clean
- [x] Real-CLI smoke: `openapi:import` on the Posts benchmark fixture \xe2\x80\x94 ok=true, warnings=[]

## Out of scope (per #160)

- Round-trip drift gate \xe2\x80\x94 #164 (lands next; the extensions defined here are what the gate will assert byte-stability of).