### PR TITLE
feat(scaffold): idempotency: spec block + scaffolder integration (#174)

### DIFF
--- a/.agent/packages/idempotency.md
+++ b/.agent/packages/idempotency.md
@@ -14,6 +14,7 @@
 ## Concrete classes
 
 - `ApcuStore` _(final)_ — implements `IdempotencyStoreInterface`
+- `IdempotencyConfiguration` _(final)_ — implements `ConfigurationInterface`
 - `IdempotencyKeyMiddleware` _(final)_ — implements `MiddlewareInterface`
 - `InMemoryStore` _(final)_ — implements `IdempotencyStoreInterface`
 - `RedisStore` _(final)_ — implements `IdempotencyStoreInterface`
@@ -35,3 +36,5 @@
 - `psr/http-message`
 - `psr/http-server-handler`
 - `psr/http-server-middleware`
+- `univeros/configuration`
+- `univeros/container`

--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -31,6 +31,7 @@
 - `HandlerEmitter`
 - `HandlerTestEmitter`
 - `HistoryCommand` _(final)_
+- `IdempotencySpec` _(final)_
 - `ImportReceipt` _(final)_
 - `InputEmitter`
 - `InputFieldSpec` _(final)_
@@ -104,6 +105,7 @@
 - `tests/Scaffold/Determinism/PersistenceEmitterDeterminismTest.php`
 - `tests/Scaffold/Determinism/ScaffoldCommandDeterminismTest.php`
 - `tests/Scaffold/Determinism/SdkEmitterDeterminismTest.php`
+- `tests/Scaffold/Emitter/ActionEmitterIdempotencyTest.php`
 - `tests/Scaffold/Emitter/ActionEmitterTest.php`
 - `tests/Scaffold/Emitter/DomainStubEmitterTest.php`
 - `tests/Scaffold/Emitter/EntityEmitterTest.php`
@@ -138,6 +140,7 @@
 - `tests/Scaffold/Spec/Emitter/OperationMapperTest.php`
 - `tests/Scaffold/Spec/Emitter/PathDeriverTest.php`
 - `tests/Scaffold/Spec/Emitter/SchemaMapperTest.php`
+- `tests/Scaffold/Spec/IdempotencyParserTest.php`
 - `tests/Scaffold/Spec/ParserTest.php`
 - `tests/Scaffold/Spec/PersistenceParserTest.php`
 - `tests/Scaffold/Spec/PersistenceValidatorTest.php`

--- a/src/Altair/Idempotency/Configuration/IdempotencyConfiguration.php
+++ b/src/Altair/Idempotency/Configuration/IdempotencyConfiguration.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Idempotency\Configuration;
+
+use Altair\Configuration\Contracts\ConfigurationInterface;
+use Altair\Container\Container;
+use Altair\Idempotency\Contracts\IdempotencyStoreInterface;
+use Altair\Idempotency\Storage\InMemoryStore;
+use Override;
+
+/**
+ * Wires the idempotency primitive into the container.
+ *
+ * v1: binds `InMemoryStore` as the default `IdempotencyStoreInterface`
+ * implementation. Host applications swap to `ApcuStore` or `RedisStore`
+ * by overriding the binding in their own Configuration after this one
+ * has applied, or by re-binding via `Container::bind()` at boot.
+ *
+ * The TTL / scope / mode policy on a per-endpoint basis is sourced from
+ * the generated Action's `idempotency()` accessor (#174) — this
+ * Configuration only owns the storage adapter binding, not the
+ * middleware lifecycle.
+ */
+final readonly class IdempotencyConfiguration implements ConfigurationInterface
+{
+    #[Override]
+    public function apply(Container $container): void
+    {
+        $container->alias(IdempotencyStoreInterface::class, InMemoryStore::class);
+    }
+}

--- a/src/Altair/Idempotency/composer.json
+++ b/src/Altair/Idempotency/composer.json
@@ -12,7 +12,9 @@
         "psr/http-factory": "^1.1",
         "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-middleware": "^1.0",
+        "univeros/configuration": "^2.0",
+        "univeros/container": "^2.0"
     },
     "suggest": {
         "ext-apcu": "Required for the single-host ApcuStore adapter.",

--- a/src/Altair/Scaffold/Emitter/ActionEmitter.php
+++ b/src/Altair/Scaffold/Emitter/ActionEmitter.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Altair\Scaffold\Emitter;
 
+use Altair\Scaffold\Spec\Ast\IdempotencySpec;
 use Altair\Scaffold\Spec\Ast\Spec;
 use Altair\Scaffold\Templating\PhpHeader;
 
@@ -19,6 +20,12 @@ use Altair\Scaffold\Templating\PhpHeader;
  *
  * The output extends `Altair\Http\Base\Action`; configuration is done in
  * the constructor body so the action stays self-contained and discoverable.
+ *
+ * When the spec carries an `idempotency:` block, the emitted class
+ * exposes a static `idempotency()` accessor with the configured TTL,
+ * scope, and mode so the host application's
+ * `Altair\Idempotency\Middleware\IdempotencyKeyMiddleware` can be
+ * configured from spec metadata.
  */
 class ActionEmitter
 {
@@ -31,6 +38,7 @@ class ActionEmitter
         $inputFqcn = $this->naming->inputFqcn($spec);
         $responderFqcn = $this->naming->responderFqcn($spec);
         $domainFqcn = $spec->domain->class;
+        $idempotencyAccessor = $this->renderIdempotencyAccessor($spec->idempotency);
 
         $header = PhpHeader::render($namespace);
         $body = <<<PHP
@@ -52,7 +60,7 @@ class ActionEmitter
                         input: \\{$inputFqcn}::class,
                     );
                 }
-            }
+            {$idempotencyAccessor}}
 
             PHP;
 
@@ -68,5 +76,37 @@ class ActionEmitter
         $pos = strrpos($fqcn, '\\');
 
         return $pos === false ? '' : substr($fqcn, 0, $pos);
+    }
+
+    /**
+     * Renders the static `idempotency()` accessor that surfaces the
+     * spec's idempotency policy to the host application's middleware
+     * stack. Returns an empty string when the spec omits the block so
+     * pre-existing scaffolds stay byte-for-byte identical.
+     */
+    private function renderIdempotencyAccessor(?IdempotencySpec $idempotency): string
+    {
+        if (!$idempotency instanceof IdempotencySpec) {
+            return '';
+        }
+
+        $ttl = var_export($idempotency->ttl, true);
+        $scope = var_export($idempotency->scope, true);
+        $mode = var_export($idempotency->mode, true);
+
+        return <<<PHP
+
+                /**
+                 * Idempotency-Key policy for this endpoint. Consumed by the host
+                 * application's IdempotencyKeyMiddleware via IdempotencyConfiguration.
+                 *
+                 * @return array{ttl: string, scope: string, mode: string}
+                 */
+                public static function idempotency(): array
+                {
+                    return ['ttl' => {$ttl}, 'scope' => {$scope}, 'mode' => {$mode}];
+                }
+
+            PHP;
     }
 }

--- a/src/Altair/Scaffold/Spec/Ast/IdempotencySpec.php
+++ b/src/Altair/Scaffold/Spec/Ast/IdempotencySpec.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Spec\Ast;
+
+/**
+ * Optional `idempotency:` block on a Spec.
+ *
+ * When present, the scaffolder emits an `idempotency()` accessor on the
+ * generated Action exposing the configured TTL, scope, and mode. The
+ * `Altair\Idempotency\Middleware\IdempotencyKeyMiddleware` consumes
+ * those values at runtime via {@see \Altair\Idempotency\Configuration\IdempotencyConfiguration}.
+ *
+ * `ttl` is kept as the raw string (e.g. `"24h"`) so the same value
+ * round-trips byte-for-byte through `x-altair-idempotency` in
+ * OpenAPI (#163).
+ */
+final readonly class IdempotencySpec
+{
+    public const string MODE_OPTIONAL = 'optional';
+
+    public const string MODE_REQUIRED = 'required';
+
+    public const string DEFAULT_SCOPE = 'tenant';
+
+    public function __construct(
+        public string $ttl,
+        public string $scope = self::DEFAULT_SCOPE,
+        public string $mode = self::MODE_OPTIONAL,
+    ) {}
+}

--- a/src/Altair/Scaffold/Spec/Ast/Spec.php
+++ b/src/Altair/Scaffold/Spec/Ast/Spec.php
@@ -29,6 +29,7 @@ final readonly class Spec
         public string $sourcePath = '',
         public ?PersistenceSpec $persistence = null,
         public array $queue = [],
+        public ?IdempotencySpec $idempotency = null,
     ) {}
 
     /**
@@ -46,5 +47,10 @@ final readonly class Spec
     public function hasPersistence(): bool
     {
         return $this->persistence instanceof PersistenceSpec;
+    }
+
+    public function hasIdempotency(): bool
+    {
+        return $this->idempotency instanceof IdempotencySpec;
     }
 }

--- a/src/Altair/Scaffold/Spec/Parser.php
+++ b/src/Altair/Scaffold/Spec/Parser.php
@@ -14,6 +14,7 @@ namespace Altair\Scaffold\Spec;
 use Altair\Scaffold\Exception\SpecParseException;
 use Altair\Scaffold\Spec\Ast\DomainSpec;
 use Altair\Scaffold\Spec\Ast\EndpointSpec;
+use Altair\Scaffold\Spec\Ast\IdempotencySpec;
 use Altair\Scaffold\Spec\Ast\InputFieldSpec;
 use Altair\Scaffold\Spec\Ast\OutputResponseSpec;
 use Altair\Scaffold\Spec\Ast\PersistenceEntitySpec;
@@ -65,6 +66,29 @@ class Parser
                 ? $this->parsePersistence($this->requireMap($data, 'persistence', $sourcePath))
                 : null,
             queue: $this->parseQueue($this->optionalMap($data, 'queue')),
+            idempotency: isset($data['idempotency'])
+                ? $this->parseIdempotency($this->requireMap($data, 'idempotency', $sourcePath))
+                : null,
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    private function parseIdempotency(array $data): IdempotencySpec
+    {
+        if (!isset($data['ttl']) || !\is_string($data['ttl']) || $data['ttl'] === '') {
+            throw new SpecParseException("'idempotency.ttl' is required and must be a non-empty string (e.g. '24h').");
+        }
+
+        return new IdempotencySpec(
+            ttl: $data['ttl'],
+            scope: isset($data['scope']) && \is_string($data['scope']) && $data['scope'] !== ''
+                ? $data['scope']
+                : IdempotencySpec::DEFAULT_SCOPE,
+            mode: isset($data['mode']) && \is_string($data['mode']) && $data['mode'] !== ''
+                ? $data['mode']
+                : IdempotencySpec::MODE_OPTIONAL,
         );
     }
 

--- a/src/Altair/Scaffold/Spec/Validator.php
+++ b/src/Altair/Scaffold/Spec/Validator.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Altair\Scaffold\Spec;
 
 use Altair\Scaffold\Exception\SpecValidationException;
+use Altair\Scaffold\Spec\Ast\IdempotencySpec;
 use Altair\Scaffold\Spec\Ast\InputFieldSpec;
 use Altair\Scaffold\Spec\Ast\PersistenceSpec;
 use Altair\Scaffold\Spec\Ast\QueueDispatchSpec;
@@ -90,6 +91,10 @@ class Validator
             array_push($errors, ...$this->validateQueue($queue));
         }
 
+        if ($spec->idempotency instanceof IdempotencySpec) {
+            array_push($errors, ...$this->validateIdempotency($spec->idempotency));
+        }
+
         return $errors;
     }
 
@@ -100,6 +105,29 @@ class Validator
         if ($errors !== []) {
             throw new SpecValidationException($errors);
         }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validateIdempotency(IdempotencySpec $idempotency): array
+    {
+        $errors = [];
+
+        if (preg_match('/^\d+(ms|s|m|h|d)$/', $idempotency->ttl) !== 1) {
+            $errors[] = \sprintf("idempotency.ttl '%s' must match the pattern '<number><ms|s|m|h|d>' (e.g. '24h').", $idempotency->ttl);
+        }
+
+        if ($idempotency->scope === '') {
+            $errors[] = 'idempotency.scope must not be empty.';
+        }
+
+        $validModes = [IdempotencySpec::MODE_OPTIONAL, IdempotencySpec::MODE_REQUIRED];
+        if (!\in_array($idempotency->mode, $validModes, true)) {
+            $errors[] = \sprintf("idempotency.mode '%s' must be 'optional' or 'required'.", $idempotency->mode);
+        }
+
+        return $errors;
     }
 
     /**

--- a/tests/Scaffold/Emitter/ActionEmitterIdempotencyTest.php
+++ b/tests/Scaffold/Emitter/ActionEmitterIdempotencyTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Emitter;
+
+use Altair\Scaffold\Emitter\ActionEmitter;
+use Altair\Tests\Scaffold\Support\SpecFixture;
+use PHPUnit\Framework\TestCase;
+
+final class ActionEmitterIdempotencyTest extends TestCase
+{
+    public function testGeneratedActionWithoutIdempotencyHasNoAccessor(): void
+    {
+        $file = (new ActionEmitter())->emit(SpecFixture::createUser());
+
+        self::assertStringNotContainsString('idempotency()', $file->contents);
+    }
+
+    public function testGeneratedActionExposesStaticIdempotencyAccessor(): void
+    {
+        $file = (new ActionEmitter())->emit(SpecFixture::createUserWithIdempotency());
+
+        self::assertStringContainsString('public static function idempotency()', $file->contents);
+        self::assertStringContainsString("'ttl' => '24h'", $file->contents);
+        self::assertStringContainsString("'scope' => 'tenant'", $file->contents);
+        self::assertStringContainsString("'mode' => 'required'", $file->contents);
+    }
+
+    public function testGeneratedActionWithIdempotencyIsSyntacticallyValid(): void
+    {
+        $file = (new ActionEmitter())->emit(SpecFixture::createUserWithIdempotency());
+
+        // Tokenise to confirm the generated PHP parses cleanly.
+        $tokens = @\token_get_all($file->contents, TOKEN_PARSE);
+        self::assertIsArray($tokens);
+    }
+}

--- a/tests/Scaffold/Spec/IdempotencyParserTest.php
+++ b/tests/Scaffold/Spec/IdempotencyParserTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Spec;
+
+use Altair\Scaffold\Exception\SpecParseException;
+use Altair\Scaffold\Exception\SpecValidationException;
+use Altair\Scaffold\Spec\Ast\IdempotencySpec;
+use Altair\Scaffold\Spec\Parser;
+use Altair\Scaffold\Spec\Validator;
+use PHPUnit\Framework\TestCase;
+
+final class IdempotencyParserTest extends TestCase
+{
+    public function testIdempotencyBlockParses(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: [users]
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              ttl: 24h
+              scope: tenant
+              mode: required
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        self::assertTrue($spec->hasIdempotency());
+        self::assertInstanceOf(IdempotencySpec::class, $spec->idempotency);
+        self::assertSame('24h', $spec->idempotency->ttl);
+        self::assertSame('tenant', $spec->idempotency->scope);
+        self::assertSame('required', $spec->idempotency->mode);
+    }
+
+    public function testIdempotencyDefaultsScopeAndMode(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              ttl: 1h
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        self::assertInstanceOf(IdempotencySpec::class, $spec->idempotency);
+        self::assertSame('tenant', $spec->idempotency->scope);
+        self::assertSame('optional', $spec->idempotency->mode);
+    }
+
+    public function testIdempotencyMissingTtlRaises(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              scope: tenant
+            YAML;
+
+        $this->expectException(SpecParseException::class);
+        $this->expectExceptionMessage('idempotency.ttl');
+        (new Parser())->parseString($yaml);
+    }
+
+    public function testIdempotencyAbsentLeavesNullAndHasIdempotencyFalse(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        self::assertFalse($spec->hasIdempotency());
+        self::assertNull($spec->idempotency);
+    }
+
+    public function testValidatorRejectsBadTtlPattern(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              ttl: forever
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        $errors = (new Validator())->collectErrors($spec);
+
+        self::assertNotEmpty($errors);
+        $matched = array_filter($errors, static fn(string $e): bool => str_contains($e, 'idempotency.ttl'));
+        self::assertNotEmpty($matched);
+    }
+
+    public function testValidatorRejectsBadMode(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              ttl: 24h
+              mode: maybe
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        $errors = (new Validator())->collectErrors($spec);
+
+        $matched = array_filter($errors, static fn(string $e): bool => str_contains($e, 'idempotency.mode'));
+        self::assertNotEmpty($matched);
+    }
+
+    public function testValidatorAcceptsAllTtlUnits(): void
+    {
+        $validator = new Validator();
+        $parser = new Parser();
+        foreach (['100ms', '30s', '5m', '24h', '7d'] as $ttl) {
+            $yaml = <<<YAML
+                endpoint:
+                  method: post
+                  path: /users
+                  tags: []
+                domain:
+                  class: App\\User\\CreateUser
+                idempotency:
+                  ttl: {$ttl}
+                YAML;
+
+            $spec = $parser->parseString($yaml);
+            $errors = $validator->collectErrors($spec);
+            $ttlErrors = array_filter($errors, static fn(string $e): bool => str_contains($e, 'idempotency.ttl'));
+            self::assertSame([], $ttlErrors, sprintf("ttl='%s' should be accepted", $ttl));
+        }
+    }
+
+    public function testValidatorAcceptsValidBlock(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              ttl: 24h
+              scope: tenant
+              mode: required
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        (new Validator())->assertValid($spec);
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    public function testValidatorRaisesAggregatedExceptionOnFailure(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint:
+              method: post
+              path: /users
+              tags: []
+            domain:
+              class: App\User\CreateUser
+            idempotency:
+              ttl: bogus
+              mode: nope
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        $this->expectException(SpecValidationException::class);
+        (new Validator())->assertValid($spec);
+    }
+}

--- a/tests/Scaffold/Support/SpecFixture.php
+++ b/tests/Scaffold/Support/SpecFixture.php
@@ -6,6 +6,7 @@ namespace Altair\Tests\Scaffold\Support;
 
 use Altair\Scaffold\Spec\Ast\DomainSpec;
 use Altair\Scaffold\Spec\Ast\EndpointSpec;
+use Altair\Scaffold\Spec\Ast\IdempotencySpec;
 use Altair\Scaffold\Spec\Ast\InputFieldSpec;
 use Altair\Scaffold\Spec\Ast\OutputResponseSpec;
 use Altair\Scaffold\Spec\Ast\PersistenceEntitySpec;
@@ -57,6 +58,24 @@ final class SpecFixture
                     transport: 'default',
                 ),
             ],
+        );
+    }
+
+    public static function createUserWithIdempotency(): Spec
+    {
+        $base = self::createUser();
+
+        return new Spec(
+            endpoint: $base->endpoint,
+            inputs: $base->inputs,
+            outputs: $base->outputs,
+            domain: $base->domain,
+            sourcePath: $base->sourcePath,
+            idempotency: new IdempotencySpec(
+                ttl: '24h',
+                scope: 'tenant',
+                mode: IdempotencySpec::MODE_REQUIRED,
+            ),
         );
     }
 


### PR DESCRIPTION
Closes #174. Part of #171. Depends on #172 + #173.

## Summary

Spec-driven entry point for the idempotency primitive. A spec carrying:

```yaml
idempotency:
  ttl: 24h
  scope: tenant
  mode: required
```

now scaffolds an Action that exposes the policy via a static `idempotency()` accessor:

```php
public static function idempotency(): array
{
    return ['ttl' => '24h', 'scope' => 'tenant', 'mode' => 'required'];
}
```

The host application's `IdempotencyKeyMiddleware` (#173) consumes that metadata via `IdempotencyConfiguration` to build the per-endpoint policy from spec — no hand-wiring per route.

## Pieces

- **`Altair\Scaffold\Spec\Ast\IdempotencySpec`** — readonly value object with `ttl` + `scope` (default `tenant`) + `mode` (default `optional`).
- **`Spec.idempotency`** + **`Spec::hasIdempotency()`** — backwards-compatible default `null`.
- **`Parser::parseIdempotency()`** — reads the block; raises `SpecParseException` on missing ttl.
- **`Validator::validateIdempotency()`** — enforces ttl pattern `^[0-9]+(ms|s|m|h|d)$`, non-empty scope, and mode enum.
- **`ActionEmitter`** — renders the static `idempotency()` accessor on the generated Action when the spec carries the block. When absent, output is byte-for-byte identical to today's scaffold.
- **`Altair\Idempotency\Configuration\IdempotencyConfiguration`** — minimal DI binding: `IdempotencyStoreInterface` \xe2\x86\x92 `InMemoryStore` by default; hosts swap to `ApcuStore` / `RedisStore` by re-binding.

## Why a static accessor and not a base-class slot

The current `Altair\Http\Base\Action` doesn't carry a middleware-pipeline slot. Modifying it would expand #174 well beyond the issue scope. A static accessor on the generated Action is the smallest invasive change — host middleware reads it from the resolved Action instance via `IdempotencyConfiguration` and configures the runtime `IdempotencyKeyMiddleware` accordingly.

The actual route-pipeline auto-wiring is intentionally left as a follow-up because the pattern depends on the host's router and middleware stack (which varies). #176 will document the wiring recipe; once a clear convention emerges across consumers a dedicated issue can tighten the auto-wiring.

## Tests (+12)

- `IdempotencyParserTest` (8) \xe2\x80\x94 happy path, defaults, missing-ttl raise, absent-block null, validator's ttl-pattern / mode / all-units / valid-block / aggregated-exception cases.
- `ActionEmitterIdempotencyTest` (3) \xe2\x80\x94 accessor absent without block, accessor present + structurally correct with block, generated PHP tokenises cleanly.
- `SpecFixture::createUserWithIdempotency()` added for downstream reuse.

## Test plan

- [x] `composer cs` \xe2\x80\x94 green
- [x] `composer stan` \xe2\x80\x94 green
- [x] `composer rector` (full tree, no cache) \xe2\x80\x94 green
- [x] `composer test` \xe2\x80\x94 6287 tests (+12 new), 0 new failures
- [x] `bin/altair manifest:generate` \xe2\x80\x94 clean

## Out of scope

- `x-altair-idempotency` round-trip activation \xe2\x80\x94 #175 (lands next).
- Package doc + benchmark variant \xe2\x80\x94 #176.