### PR TITLE
feat(http): production-safe, agent-native error handling wired by default

### DIFF
--- a/.agent/packages/events.md
+++ b/.agent/packages/events.md
@@ -24,6 +24,7 @@
 - `CompactCommand` _(final)_
 - `Event` _(final)_
 - `EventKind` _(final)_ — implements `BackedEnum`, `UnitEnum`
+- `EventRecordingLogger` _(final)_ — implements `LoggerInterface`
 - `EventStatus` _(final)_ — implements `BackedEnum`, `UnitEnum`
 - `EventsConfiguration` _(final)_ — implements `ConfigurationInterface`
 - `EventsSettings` _(final)_
@@ -47,6 +48,7 @@
 - `tests/Events/Cli/CommandsTest.php`
 - `tests/Events/Configuration/EventsConfigurationTest.php`
 - `tests/Events/Configuration/EventsSettingsTest.php`
+- `tests/Events/EventRecordingLoggerTest.php`
 - `tests/Events/EventTest.php`
 - `tests/Events/Integration/ConcurrentWriteTest.php`
 - `tests/Events/ReaderTest.php`

--- a/.agent/packages/http.md
+++ b/.agent/packages/http.md
@@ -17,6 +17,8 @@
 |  | `getFromServerRequestHeaderLine(ServerRequestInterface)` | `string\|null` |  |
 |  | `getFromServerRequestUriPath(ServerRequestInterface)` | `string\|null` |  |
 | `HttpAuthRuleInterface` | `__invoke(ServerRequestInterface)` | `bool` |  |
+| `HttpExceptionInterface` | `getHeaders()` | `array` |  |
+|  | `getStatusCode()` | `int` |  |
 | `HttpStatusCodeInterface` | _(marker)_ |  | constants: `HTTP_ACCEPTED`, `HTTP_ALREADY_REPORTED`, `HTTP_BAD_GATEWAY`, `HTTP_BAD_REQUEST`, `HTTP_CONFLICT`, `HTTP_CONTINUE`, `HTTP_CREATED`, `HTTP_EXPECTATION_FAILED`, `HTTP_FAILED_DEPENDENCY`, `HTTP_FORBIDDEN`, `HTTP_FOUND`, `HTTP_GATEWAY_TIMEOUT`, `HTTP_GONE`, `HTTP_IM_A_TEAPOT`, `HTTP_IM_USED`, `HTTP_INSUFFICIENT_STORAGE`, `HTTP_INTERNAL_SERVER_ERROR`, `HTTP_LENGTH_REQUIRED`, `HTTP_LOCKED`, `HTTP_LOOP_DETECTED`, `HTTP_MAX_RANGE`, `HTTP_METHOD_NOT_ALLOWED`, `HTTP_MIN_RANGE`, `HTTP_MISDIRECTED_REQUEST`, `HTTP_MOVED_PERMANENTLY`, `HTTP_MULTIPLE_CHOICES`, `HTTP_MULTI_STATUS`, `HTTP_NETWORK_AUTHENTICATION_REQUIRED`, `HTTP_NON_AUTHORITATIVE_INFORMATION`, `HTTP_NOT_ACCEPTABLE`, `HTTP_NOT_EXTENDED`, `HTTP_NOT_FOUND`, `HTTP_NOT_IMPLEMENTED`, `HTTP_NOT_MODIFIED`, `HTTP_NO_CONTENT`, `HTTP_OK`, `HTTP_PARTIAL_CONTENT`, `HTTP_PAYLOAD_TOO_LARGE`, `HTTP_PAYMENT_REQUIRED`, `HTTP_PERMANENT_REDIRECT`, `HTTP_PRECONDITION_FAILED`, `HTTP_PRECONDITION_REQUIRED`, `HTTP_PROCESSING`, `HTTP_PROXY_AUTHENTICATION_REQUIRED`, `HTTP_RANGE_NOT_SATISFIABLE`, `HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE`, `HTTP_REQUEST_TIMEOUT`, `HTTP_RESERVED`, `HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL`, `HTTP_RESET_CONTENT`, `HTTP_SEE_OTHER`, `HTTP_SERVICE_UNAVAILABLE`, `HTTP_SWITCHING_PROTOCOLS`, `HTTP_TEMPORARY_REDIRECT`, `HTTP_TOO_MANY_REQUESTS`, `HTTP_UNAUTHORIZED`, `HTTP_UNAVAILABLE_FOR_LEGAL_REASONS`, `HTTP_UNPROCESSABLE_ENTITY`, `HTTP_UNSUPPORTED_MEDIA_TYPE`, `HTTP_UPGRADE_REQUIRED`, `HTTP_URI_TOO_LONG`, `HTTP_USE_PROXY`, `HTTP_VARIANT_ALSO_NEGOTIATES`, `HTTP_VERSION_NOT_SUPPORTED`, `RESPONSE_CLASS_CLIENT_ERROR`, `RESPONSE_CLASS_INFORMATIONAL`, `RESPONSE_CLASS_REDIRECTION`, `RESPONSE_CLASS_SERVER_ERROR`, `RESPONSE_CLASS_SUCCESS` |
 | `HttpStatusInterface` | _(marker)_ |  | constants: `HTTP_ACCEPTED`, `HTTP_ALREADY_REPORTED`, `HTTP_BAD_GATEWAY`, `HTTP_BAD_REQUEST`, `HTTP_CONFLICT`, `HTTP_CONTINUE`, `HTTP_CREATED`, `HTTP_EXPECTATION_FAILED`, `HTTP_FAILED_DEPENDENCY`, `HTTP_FORBIDDEN`, `HTTP_FOUND`, `HTTP_GATEWAY_TIMEOUT`, `HTTP_GONE`, `HTTP_IM_A_TEAPOT`, `HTTP_IM_USED`, `HTTP_INSUFFICIENT_STORAGE`, `HTTP_INTERNAL_SERVER_ERROR`, `HTTP_LENGTH_REQUIRED`, `HTTP_LOCKED`, `HTTP_LOOP_DETECTED`, `HTTP_METHOD_NOT_ALLOWED`, `HTTP_MISDIRECTED_REQUEST`, `HTTP_MOVED_PERMANENTLY`, `HTTP_MULTIPLE_CHOICES`, `HTTP_MULTI_STATUS`, `HTTP_NETWORK_AUTHENTICATION_REQUIRED`, `HTTP_NON_AUTHORITATIVE_INFORMATION`, `HTTP_NOT_ACCEPTABLE`, `HTTP_NOT_EXTENDED`, `HTTP_NOT_FOUND`, `HTTP_NOT_IMPLEMENTED`, `HTTP_NOT_MODIFIED`, `HTTP_NO_CONTENT`, `HTTP_OK`, `HTTP_PARTIAL_CONTENT`, `HTTP_PAYLOAD_TOO_LARGE`, `HTTP_PAYMENT_REQUIRED`, `HTTP_PERMANENT_REDIRECT`, `HTTP_PRECONDITION_FAILED`, `HTTP_PRECONDITION_REQUIRED`, `HTTP_PROCESSING`, `HTTP_PROXY_AUTHENTICATION_REQUIRED`, `HTTP_RANGE_NOT_SATISFIABLE`, `HTTP_REQUEST_HEADER_FIELDS_TOO_LARGE`, `HTTP_REQUEST_TIMEOUT`, `HTTP_RESERVED_FOR_WEBDAV_ADVANCED_COLLECTIONS_EXPIRED_PROPOSAL`, `HTTP_RESET_CONTENT`, `HTTP_SEE_OTHER`, `HTTP_SERVICE_UNAVAILABLE`, `HTTP_SWITCHING_PROTOCOLS`, `HTTP_TEMPORARY_REDIRECT`, `HTTP_TOO_MANY_REQUESTS`, `HTTP_UNAUTHORIZED`, `HTTP_UNAVAILABLE_FOR_LEGAL_REASONS`, `HTTP_UNPROCESSABLE_ENTITY`, `HTTP_UNSUPPORTED_MEDIA_TYPE`, `HTTP_UPGRADE_REQUIRED`, `HTTP_URI_TOO_LONG`, `HTTP_USE_PROXY`, `HTTP_VARIANT_ALSO_NEGOTIATES`, `HTTP_VERSION_NOT_SUPPORTED` |
 | `IdentityProviderInterface` | `findOneBy(array)` | `array\|null` |  |
@@ -39,6 +41,7 @@
 |  | `withSettingsCollection(SettingsCollection)` | `PayloadInterface` |  |
 |  | `withStatus(int)` | `PayloadInterface` |  |
 |  | `withoutSetting(string)` | `PayloadInterface` |  |
+| `ProblemExtensionInterface` | `getProblemExtensions()` | `array` |  |
 | `ResponderInterface` | `__invoke(ServerRequestInterface, ResponseInterface, PayloadInterface)` | `ResponseInterface` |  |
 | `RouteInterface` | `getDomain()` | `mixed` |  |
 |  | `getInput()` | `mixed` |  |
@@ -114,6 +117,7 @@
 - `PhpViewFormatter` — implements `OutputFormatterInterface`
 - `PrivateCacheLimiter` — implements `CacheLimiterInterface`
 - `PrivateNoExpireCacheLimiter` — implements `CacheLimiterInterface`
+- `ProblemDetailsErrorHandler` _(final)_ — implements `ErrorHandlerInterface`
 - `PublicCacheLimiter` — implements `CacheLimiterInterface`
 - `QueryParamsTokenExtractor` — implements `TokenExtractorInterface`
 - `RateLimit` _(final)_
@@ -151,6 +155,7 @@
 
 - `tests/Http/Base/PayloadTest.php`
 - `tests/Http/Configuration/FastRouteConfigurationTest.php`
+- `tests/Http/Exception/HttpExceptionStatusTest.php`
 - `tests/Http/Formatter/JsonFormatterTest.php`
 - `tests/Http/Input/DtoInputHydratorTest.php`
 - `tests/Http/Jwt/LcobucciTokenGeneratorTest.php`
@@ -179,6 +184,7 @@
 - `tests/Http/Support/HttpCacheTest.php`
 - `tests/Http/Support/MimeTypeTest.php`
 - `tests/Http/Support/ModuleRoutesTest.php`
+- `tests/Http/Support/ProblemDetailsErrorHandlerTest.php`
 - `tests/Http/Support/QueryParamsTokenExtractorTest.php`
 - `tests/Http/Validator/DigestSignatureValidatorTest.php`
 - `tests/Http/Validator/RepositoryIdentityValidatorTest.php`

--- a/docs/packages/http.md
+++ b/docs/packages/http.md
@@ -363,7 +363,7 @@ You can change the list of inner responders by passing a custom `$responders` ar
 
 ### Built-in middleware
 
-**`ExceptionHandlerMiddleware`** wraps the rest of the pipeline in a try/catch. In capture mode (`$capture = true`) it converts any `Throwable` into an error response via the `ErrorHandlerInterface`. In non-capture mode it re-throws. It also intercepts 4xx/5xx responses from the pipeline and routes them through the error handler. Use `DefaultErrorHandler` for development; replace it with a custom implementation for production.
+**`ExceptionHandlerMiddleware`** wraps the rest of the pipeline in a try/catch. In capture mode (`$capture = true`) it converts any `Throwable` into an error response via the `ErrorHandlerInterface`. In non-capture mode it re-throws. It also intercepts 4xx/5xx responses from the pipeline and routes them through the error handler. A thrown exception that implements `HttpExceptionInterface` is rendered with **its own** status code and headers (so a thrown `HttpNotFoundException` is a 404, not a 500); any other `Throwable` becomes a 500. Pass an optional PSR-3 `LoggerInterface` and every 5xx is logged with the request method/path — wire it to `EventRecordingLogger` (Events package) to record `http_error` events. Use `ProblemDetailsErrorHandler` (RFC 7807) for both development and production; the legacy `DefaultErrorHandler` is dev-only.
 
 **`DispatcherMiddleware`** calls the FastRoute dispatcher with the request method and path. On `FOUND`, it sets the `Action` on the request attribute `ATTRIBUTE_ACTION` and adds route segment variables as individual attributes. On `NOT_FOUND` or `METHOD_NOT_ALLOWED`, it throws a typed `HttpException`.
 
@@ -410,20 +410,29 @@ All three authentication middleware enforce HTTPS by default. Requests over plai
 
 ### Error handling
 
-Position `ExceptionHandlerMiddleware` as the outermost middleware in the queue. It wraps the rest of the pipeline:
+The `bin/altair new` skeleton wires this for you — `ExceptionHandlerMiddleware` is the outermost entry in `public/index.php`, so a fresh app never leaks a raw PHP fatal. To wire it by hand, position it first in the queue:
 
 ```php
-// Capture mode: converts all Throwable to error responses.
 $queue->push(new ExceptionHandlerMiddleware(
     responseFactory: new ResponseFactory(),
-    handler: new MyProductionErrorHandler(),
+    handler: new ProblemDetailsErrorHandler(debug: $debug),
     capture: true,
+    logger: $errorLogger, // optional PSR-3 logger; null to disable
 ));
 ```
 
-The `ErrorHandlerInterface` receives the request (with the exception stored as `ATTRIBUTE_EXCEPTION`) and a pre-built response at the appropriate status code. `DefaultErrorHandler` content-negotiates the error format (HTML, JSON, XML, plain text, or an image) from the response's `Content-Type` header; it is suitable for development but uses `echo` internally and is not appropriate for production JSON APIs.
+**Status mapping.** Exceptions carry their own status via `HttpExceptionInterface::getStatusCode()` (and `getHeaders()` for things like the `Allow` header on a 405). The framework's `HttpException` hierarchy implements it — `HttpNotFoundException` is 404, `HttpMethodNotAllowedException` is 405 with an `Allow` header, `InputValidationException` is 422, the auth exceptions are 401/403. A bare `HttpBadRequestException` falls back to 400 and any non-HTTP `Throwable` to 500. In capture mode the middleware reads that status off the thrown exception, so a thrown 404 renders as 404. Userland exceptions can implement `HttpExceptionInterface` to opt a domain error into a specific status without subclassing the framework's exceptions.
 
-`HttpNotFoundException` and `HttpMethodNotAllowedException` carry HTTP status codes (404 and 405 respectively) and are thrown by `DispatcherMiddleware`. When `ExceptionHandlerMiddleware` is in capture mode, these are caught and forwarded to the error handler with the correct status.
+**`ProblemDetailsErrorHandler`** (recommended, dev and prod) renders an RFC 7807 `application/problem+json` document by default, negotiating down to a safe HTML page or plain text from the request's `Accept` header. It writes to the PSR-7 body (never `echo`) and escapes every interpolated value. It distinguishes environments via its `debug` flag:
+
+- **production** (`debug: false`): generic `detail` for 5xx, and never the exception class, message, or stack trace — no internal information leaks to the client.
+- **debug** (`debug: true`): the exception class, `file:line`, and stack trace are attached to the problem document.
+
+An exception implementing `ProblemExtensionInterface` contributes extra members to the document — `InputValidationException`, for example, adds `"errors": {"field": "message"}` to its 422 problem (reserved members `type`/`title`/`status`/`instance` can't be overwritten).
+
+**`DefaultErrorHandler`** is the legacy dev-only handler. It content-negotiates HTML/JSON/XML/plain-text/image from the response `Content-Type`, but uses `echo` internally and is not appropriate for production JSON APIs. Prefer `ProblemDetailsErrorHandler`.
+
+**Recording failures for agents.** Pass a PSR-3 `LoggerInterface` and the middleware logs every 5xx with the request method, path, and exception. Wire it to `Altair\Events\EventRecordingLogger` (bound by `EventsConfiguration` when the Events package is enabled) and each server-side failure becomes an `http_error` event in `.altair/events.jsonl`, queryable across sessions with `bin/altair events:filter --kind=http_error`. Client errors (4xx) are intentionally not recorded — they are expected and would only add noise. The skeleton picks the logger up automatically when Events is enabled.
 
 ---
 

--- a/src/Altair/Bootstrap/resources/skeleton/public/index.php
+++ b/src/Altair/Bootstrap/resources/skeleton/public/index.php
@@ -3,13 +3,17 @@
 declare(strict_types=1);
 
 use Altair\Container\Container;
+use Altair\Events\EventRecordingLogger;
 use Altair\Http\Middleware\ActionMiddleware;
 use Altair\Http\Middleware\DispatcherMiddleware;
+use Altair\Http\Middleware\ExceptionHandlerMiddleware;
 use Altair\Http\Support\ModuleRoutes;
+use Altair\Http\Support\ProblemDetailsErrorHandler;
 use FastRoute\RouteCollector;
 use Laminas\Diactoros\ResponseFactory;
 use Laminas\Diactoros\ServerRequestFactory;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Log\LoggerInterface;
 use Relay\Relay;
 
 use function FastRoute\simpleDispatcher;
@@ -31,7 +35,27 @@ $dispatcher = simpleDispatcher(static function (RouteCollector $collector) use (
     }
 });
 
+// Show full diagnostics locally; stay terse and leak-free in production.
+$debug = filter_var($_SERVER['APP_DEBUG'] ?? getenv('APP_DEBUG') ?: 'false', FILTER_VALIDATE_BOOL);
+
+// When the Events package is enabled (config/configurations.php), server-side
+// failures are recorded as `http_error` events — durable memory for agents.
+// `bin/altair events:filter --kind=http_error` to review them.
+$errorLogger = null;
+if ($container->has(EventRecordingLogger::class)) {
+    $candidate = $container->get(EventRecordingLogger::class);
+    $errorLogger = $candidate instanceof LoggerInterface ? $candidate : null;
+}
+
 $relay = new Relay([
+    // Outermost: turns any thrown exception into an RFC 7807 problem+json
+    // response (negotiating HTML/plain), with the exception's own status code.
+    new ExceptionHandlerMiddleware(
+        responseFactory: new ResponseFactory(),
+        handler: new ProblemDetailsErrorHandler(debug: $debug),
+        capture: true,
+        logger: $errorLogger,
+    ),
     new DispatcherMiddleware($dispatcher),
     new ActionMiddleware(
         static fn(string $class): object => $container->make($class),

--- a/src/Altair/Events/Configuration/EventsConfiguration.php
+++ b/src/Altair/Events/Configuration/EventsConfiguration.php
@@ -16,6 +16,7 @@ use Altair\Configuration\Support\Env;
 use Altair\Container\Container;
 use Altair\Events\Contracts\EventStorageInterface;
 use Altair\Events\Contracts\RecorderInterface;
+use Altair\Events\EventRecordingLogger;
 use Altair\Events\NullRecorder;
 use Altair\Events\Reader;
 use Altair\Events\Recorder;
@@ -89,6 +90,13 @@ final readonly class EventsConfiguration implements ConfigurationInterface
             ): RecorderInterface => $settings->enabled
                 ? new Recorder($storage, $scrubber)
                 : new NullRecorder(),
+        )->shared();
+
+        // PSR-3 bridge: lets the HTTP front controller record server-side
+        // failures as `http_error` events without depending on this package.
+        $container->factory(
+            EventRecordingLogger::class,
+            static fn(RecorderInterface $recorder): EventRecordingLogger => new EventRecordingLogger($recorder),
         )->shared();
     }
 }

--- a/src/Altair/Events/EventKind.php
+++ b/src/Altair/Events/EventKind.php
@@ -23,6 +23,7 @@ enum EventKind: string
 {
     case CsFix = 'cs_fix';
     case Eval = 'eval';
+    case HttpError = 'http_error';
     case IndexBuild = 'index_build';
     case ManifestGenerate = 'manifest_generate';
     case ManualEdit = 'manual_edit';

--- a/src/Altair/Events/EventRecordingLogger.php
+++ b/src/Altair/Events/EventRecordingLogger.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Events;
+
+use Altair\Events\Contracts\RecorderInterface;
+use Override;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use Stringable;
+use Throwable;
+
+/**
+ * A PSR-3 logger that turns serious log records into `http_error` events.
+ *
+ * This is the bridge that gives an agent durable, queryable memory of runtime
+ * failures (`bin/altair events:filter --kind=http_error`) without coupling the
+ * Http package to Events: the front controller hands the
+ * {@see \Altair\Http\Middleware\ExceptionHandlerMiddleware} any PSR-3 logger,
+ * and this implementation is the one that records.
+ *
+ * Only `error` and above are recorded; lighter levels are dropped so the log
+ * stays a signal of genuine server-side failures.
+ */
+final class EventRecordingLogger extends AbstractLogger
+{
+    /**
+     * @var array<string, true>
+     */
+    private const array RECORDED_LEVELS = [
+        LogLevel::EMERGENCY => true,
+        LogLevel::ALERT => true,
+        LogLevel::CRITICAL => true,
+        LogLevel::ERROR => true,
+    ];
+
+    public function __construct(
+        private readonly RecorderInterface $recorder,
+        private readonly Actor $actor = Actor::Script,
+    ) {}
+
+    /**
+     * @param mixed                $level
+     * @param array<string, mixed> $context
+     */
+    #[Override]
+    public function log($level, string|Stringable $message, array $context = []): void
+    {
+        if (!\is_string($level) || !isset(self::RECORDED_LEVELS[$level])) {
+            return;
+        }
+
+        $this->recorder->record(Event::create(
+            actor: $this->actor,
+            command: $this->commandFrom($context),
+            kind: EventKind::HttpError,
+            status: EventStatus::Fail,
+            durationMs: 0,
+            error: $this->errorFrom($message, $context),
+            extra: $this->extraFrom($context),
+        ));
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function commandFrom(array $context): string
+    {
+        $method = isset($context['method']) && \is_string($context['method']) ? $context['method'] : '';
+        $path = isset($context['path']) && \is_string($context['path']) ? $context['path'] : '';
+        $command = trim($method . ' ' . $path);
+
+        return $command !== '' ? $command : 'http.request';
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function errorFrom(string|Stringable $message, array $context): string
+    {
+        $error = trim((string) $message);
+        if ($error !== '') {
+            return $error;
+        }
+
+        if (($context['exception'] ?? null) instanceof Throwable) {
+            return $context['exception']::class;
+        }
+
+        return 'HTTP server error';
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>
+     */
+    private function extraFrom(array $context): array
+    {
+        $extra = [];
+
+        foreach (['method', 'path', 'status'] as $key) {
+            if (isset($context[$key]) && (\is_string($context[$key]) || \is_int($context[$key]))) {
+                $extra[$key] = $context[$key];
+            }
+        }
+
+        if (($context['exception'] ?? null) instanceof Throwable) {
+            $extra['exception'] = $context['exception']::class;
+        }
+
+        return $extra;
+    }
+}

--- a/src/Altair/Http/Contracts/HttpExceptionInterface.php
+++ b/src/Altair/Http/Contracts/HttpExceptionInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Http\Contracts;
+
+/**
+ * An exception that knows the HTTP status (and any headers) it should map to.
+ *
+ * The {@see \Altair\Http\Middleware\ExceptionHandlerMiddleware} reads these
+ * off a thrown exception so a 404 renders as 404 instead of collapsing to a
+ * generic 500. Userland exceptions can implement this to opt a domain error
+ * into a specific status without subclassing the framework's exceptions.
+ */
+interface HttpExceptionInterface
+{
+    /**
+     * The HTTP status code this exception maps to (a value in the 4xx/5xx range).
+     */
+    public function getStatusCode(): int;
+
+    /**
+     * Headers to merge onto the error response (e.g. `Allow` for a 405).
+     *
+     * @return array<string, string>
+     */
+    public function getHeaders(): array;
+}

--- a/src/Altair/Http/Contracts/ProblemExtensionInterface.php
+++ b/src/Altair/Http/Contracts/ProblemExtensionInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Http\Contracts;
+
+/**
+ * An exception that contributes extra members to an RFC 7807 problem document.
+ *
+ * The {@see \Altair\Http\Support\ProblemDetailsErrorHandler} merges the returned
+ * map onto the problem JSON (without letting it clobber the reserved members
+ * `type`, `title`, `status`, `instance`). A validation error, for example,
+ * returns `['errors' => ['field' => 'message']]`.
+ */
+interface ProblemExtensionInterface
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function getProblemExtensions(): array;
+}

--- a/src/Altair/Http/Exception/HttpBadRequestException.php
+++ b/src/Altair/Http/Exception/HttpBadRequestException.php
@@ -11,4 +11,18 @@ declare(strict_types=1);
 
 namespace Altair\Http\Exception;
 
-class HttpBadRequestException extends HttpException {}
+use Altair\Http\Contracts\HttpStatusCodeInterface;
+use Override;
+
+class HttpBadRequestException extends HttpException
+{
+    /**
+     * A bad-request and its subclasses are client errors: fall back to 400
+     * (not the base class's 500) when no explicit code was supplied.
+     */
+    #[Override]
+    protected function defaultStatusCode(): int
+    {
+        return HttpStatusCodeInterface::HTTP_BAD_REQUEST;
+    }
+}

--- a/src/Altair/Http/Exception/HttpException.php
+++ b/src/Altair/Http/Exception/HttpException.php
@@ -11,6 +11,44 @@ declare(strict_types=1);
 
 namespace Altair\Http\Exception;
 
+use Altair\Http\Contracts\HttpExceptionInterface;
+use Altair\Http\Contracts\HttpStatusCodeInterface;
 use Exception;
+use Override;
 
-class HttpException extends Exception {}
+class HttpException extends Exception implements HttpExceptionInterface
+{
+    /**
+     * The status this exception maps to: the carried code when it is a valid
+     * 4xx/5xx value, otherwise {@see self::defaultStatusCode()} (500 for the
+     * base class; subclasses narrow it — e.g. bad-request to 400).
+     */
+    #[Override]
+    public function getStatusCode(): int
+    {
+        $code = $this->getCode();
+
+        return \is_int($code)
+            && $code >= HttpStatusCodeInterface::HTTP_BAD_REQUEST
+            && $code <= HttpStatusCodeInterface::HTTP_MAX_RANGE
+                ? $code
+                : $this->defaultStatusCode();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    #[Override]
+    public function getHeaders(): array
+    {
+        return [];
+    }
+
+    /**
+     * Fallback status when no valid HTTP code was supplied to the constructor.
+     */
+    protected function defaultStatusCode(): int
+    {
+        return HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR;
+    }
+}

--- a/src/Altair/Http/Exception/HttpMethodNotAllowedException.php
+++ b/src/Altair/Http/Exception/HttpMethodNotAllowedException.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Altair\Http\Exception;
 
+use Override;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
 
@@ -26,6 +27,17 @@ class HttpMethodNotAllowedException extends HttpBadRequestException
         ?Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    #[Override]
+    public function getHeaders(): array
+    {
+        return $this->allowed === []
+            ? []
+            : ['Allow' => implode(',', $this->allowed)];
     }
 
     public function withResponse(ResponseInterface $response): ResponseInterface

--- a/src/Altair/Http/Exception/InputValidationException.php
+++ b/src/Altair/Http/Exception/InputValidationException.php
@@ -11,12 +11,16 @@ declare(strict_types=1);
 
 namespace Altair\Http\Exception;
 
+use Altair\Http\Contracts\HttpStatusCodeInterface;
+use Altair\Http\Contracts\ProblemExtensionInterface;
+use Override;
+
 /**
  * Thrown when request data cannot satisfy a typed input DTO — a required field
  * is missing. The HTTP action layer maps it to a 422 response carrying the
  * per-field errors.
  */
-final class InputValidationException extends HttpException
+final class InputValidationException extends HttpException implements ProblemExtensionInterface
 {
     /**
      * @param array<string, string> $errors per-field error messages
@@ -26,5 +30,20 @@ final class InputValidationException extends HttpException
         string $message = 'Input validation failed.',
     ) {
         parent::__construct($message);
+    }
+
+    /**
+     * @return array{errors: array<string, string>}
+     */
+    #[Override]
+    public function getProblemExtensions(): array
+    {
+        return ['errors' => $this->errors];
+    }
+
+    #[Override]
+    protected function defaultStatusCode(): int
+    {
+        return HttpStatusCodeInterface::HTTP_UNPROCESSABLE_ENTITY;
     }
 }

--- a/src/Altair/Http/Middleware/ExceptionHandlerMiddleware.php
+++ b/src/Altair/Http/Middleware/ExceptionHandlerMiddleware.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Altair\Http\Middleware;
 
 use Altair\Http\Contracts\ErrorHandlerInterface;
+use Altair\Http\Contracts\HttpExceptionInterface;
 use Altair\Http\Contracts\HttpStatusCodeInterface;
 use Altair\Http\Contracts\MiddlewareInterface;
 use Altair\Http\Contracts\StatusCodeValidatorInterface;
@@ -21,11 +22,18 @@ use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
 use Throwable;
 
 class ExceptionHandlerMiddleware implements MiddlewareInterface
 {
-    public function __construct(private readonly ResponseFactoryInterface $responseFactory, private readonly ErrorHandlerInterface $handler = new DefaultErrorHandler(), private readonly ?StatusCodeValidatorInterface $validator = null, private readonly bool $capture = false) {}
+    public function __construct(
+        private readonly ResponseFactoryInterface $responseFactory,
+        private readonly ErrorHandlerInterface $handler = new DefaultErrorHandler(),
+        private readonly ?StatusCodeValidatorInterface $validator = null,
+        private readonly bool $capture = false,
+        private readonly ?LoggerInterface $logger = null,
+    ) {}
 
     #[Override]
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
@@ -44,7 +52,10 @@ class ExceptionHandlerMiddleware implements MiddlewareInterface
                 throw $throwable;
             }
 
-            return $this->handleError($request, $throwable);
+            $status = $this->statusFor($throwable);
+            $this->logServerError($throwable, $request, $status);
+
+            return $this->handleError($request, $throwable, $status, $this->headersFor($throwable));
         } finally {
             while (ob_get_level() >= $level) {
                 ob_end_clean();
@@ -52,14 +63,64 @@ class ExceptionHandlerMiddleware implements MiddlewareInterface
         }
     }
 
+    /**
+     * @param array<string, string> $headers
+     */
     private function handleError(
         ServerRequestInterface $request,
         ?Throwable $exception,
         int $code = HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR,
+        array $headers = [],
     ): ResponseInterface {
         $request = $request->withAttribute(MiddlewareInterface::ATTRIBUTE_EXCEPTION, $exception);
 
-        return ($this->handler)($request, $this->responseFactory->createResponse($code));
+        $response = $this->responseFactory->createResponse($code);
+        foreach ($headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return ($this->handler)($request, $response);
+    }
+
+    /**
+     * The status a thrown exception maps to: its own when it declares one,
+     * otherwise a generic 500. This is what makes a thrown 404/405/422 render
+     * with the correct status instead of collapsing to 500.
+     */
+    private function statusFor(Throwable $throwable): int
+    {
+        return $throwable instanceof HttpExceptionInterface
+            ? $throwable->getStatusCode()
+            : HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function headersFor(Throwable $throwable): array
+    {
+        return $throwable instanceof HttpExceptionInterface
+            ? $throwable->getHeaders()
+            : [];
+    }
+
+    /**
+     * Server-side failures (5xx) are the ones worth remembering. Client errors
+     * (404/422/...) are expected and would only add noise, so they are skipped.
+     */
+    private function logServerError(Throwable $throwable, ServerRequestInterface $request, int $status): void
+    {
+        if (!$this->logger instanceof LoggerInterface
+            || $status < HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR) {
+            return;
+        }
+
+        $this->logger->error($throwable->getMessage(), [
+            'exception' => $throwable,
+            'method' => $request->getMethod(),
+            'path' => $request->getUri()->getPath(),
+            'status' => $status,
+        ]);
     }
 
     private function isError(int $code): bool

--- a/src/Altair/Http/Support/DefaultErrorHandler.php
+++ b/src/Altair/Http/Support/DefaultErrorHandler.php
@@ -94,6 +94,8 @@ class DefaultErrorHandler implements ErrorHandlerInterface
      */
     protected function svg(int $statusCode, string $message): void
     {
+        $message = $this->escape($message);
+
         echo <<<EOT
             <svg xmlns="http://www.w3.org/2000/svg" width="200" height="50" viewBox="0 0 200 50">
                 <text x="20" y="30" font-family="sans-serif" title="{$message}">
@@ -108,6 +110,8 @@ class DefaultErrorHandler implements ErrorHandlerInterface
      */
     protected function html(int $statusCode, string $message): void
     {
+        $message = $this->escape($message);
+
         echo <<<EOT
             <!DOCTYPE html>
             <html>
@@ -143,6 +147,8 @@ class DefaultErrorHandler implements ErrorHandlerInterface
      */
     protected function xml(int $statusCode, string $message): void
     {
+        $message = $this->escape($message);
+
         echo <<<EOT
             <?xml version="1.0" encoding="UTF-8"?>
             <error>
@@ -150,6 +156,16 @@ class DefaultErrorHandler implements ErrorHandlerInterface
                 <message>{$message}</message>
             </error>
             EOT;
+    }
+
+    /**
+     * Escape a message before interpolating it into markup, so a reflected
+     * value (e.g. the request path on a 404) cannot inject scripts or break
+     * out of the surrounding element/attribute.
+     */
+    protected function escape(string $message): string
+    {
+        return htmlspecialchars($message, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
     }
 
     /**

--- a/src/Altair/Http/Support/ProblemDetailsErrorHandler.php
+++ b/src/Altair/Http/Support/ProblemDetailsErrorHandler.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Http\Support;
+
+use Altair\Http\Contracts\ErrorHandlerInterface;
+use Altair\Http\Contracts\HttpStatusCodeInterface;
+use Altair\Http\Contracts\MiddlewareInterface;
+use Altair\Http\Contracts\ProblemExtensionInterface;
+use JsonException;
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Throwable;
+
+/**
+ * Production-grade, agent-native error renderer.
+ *
+ * Emits an RFC 7807 `application/problem+json` document by default (typed,
+ * machine-branchable), negotiating down to a safe HTML page or plain text
+ * when the client asks for them. Unlike the legacy {@see DefaultErrorHandler}
+ * it writes to the PSR-7 body (never `echo`), escapes every interpolated
+ * value, and distinguishes production from debug:
+ *
+ *  - production: generic detail for 5xx, never the exception class or trace
+ *  - debug:      exception class, file:line and stack trace attached
+ *
+ * The status code and any headers are expected to already be on the response
+ * (the {@see \Altair\Http\Middleware\ExceptionHandlerMiddleware} sets them from
+ * the thrown exception); this handler only renders a body for that status.
+ */
+final readonly class ProblemDetailsErrorHandler implements ErrorHandlerInterface
+{
+    private const string PROBLEM_TYPE = 'about:blank';
+
+    /**
+     * Reserved RFC 7807 members an exception's extensions must not overwrite.
+     */
+    private const array RESERVED_MEMBERS = ['type', 'title', 'status', 'instance'];
+
+    public function __construct(
+        private bool $debug = false,
+        private string $serverErrorDetail = 'An unexpected error occurred.',
+    ) {}
+
+    #[Override]
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+    {
+        $exception = $request->getAttribute(MiddlewareInterface::ATTRIBUTE_EXCEPTION);
+        $exception = $exception instanceof Throwable ? $exception : null;
+
+        $problem = $this->buildProblem($request, $response, $exception);
+
+        return match ($this->negotiate($request->getHeaderLine('Accept'))) {
+            'html' => $this->renderHtml($response, $problem),
+            'text' => $this->renderText($response, $problem),
+            default => $this->renderJson($response, $problem),
+        };
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildProblem(
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+        ?Throwable $exception,
+    ): array {
+        $status = $response->getStatusCode();
+        $reason = $response->getReasonPhrase();
+
+        $problem = [
+            'type' => self::PROBLEM_TYPE,
+            'title' => $reason !== '' ? $reason : 'Error',
+            'status' => $status,
+        ];
+
+        $detail = $this->detailFor($status, $exception);
+        if ($detail !== null) {
+            $problem['detail'] = $detail;
+        }
+
+        $path = $request->getUri()->getPath();
+        if ($path !== '') {
+            $problem['instance'] = $path;
+        }
+
+        if ($exception instanceof ProblemExtensionInterface) {
+            foreach ($exception->getProblemExtensions() as $key => $value) {
+                if (!\in_array($key, self::RESERVED_MEMBERS, true)) {
+                    $problem[$key] = $value;
+                }
+            }
+        }
+
+        if ($this->debug && $exception instanceof Throwable) {
+            $problem['exception'] = $exception::class;
+            $problem['file'] = $exception->getFile() . ':' . $exception->getLine();
+            $problem['trace'] = explode("\n", $exception->getTraceAsString());
+        }
+
+        return $problem;
+    }
+
+    /**
+     * Server errors never leak their internal message in production.
+     */
+    private function detailFor(int $status, ?Throwable $exception): ?string
+    {
+        if (!$exception instanceof Throwable) {
+            return null;
+        }
+
+        if ($status >= HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR && !$this->debug) {
+            return $this->serverErrorDetail;
+        }
+
+        $message = $exception->getMessage();
+
+        return $message !== '' ? $message : null;
+    }
+
+    private function negotiate(string $accept): string
+    {
+        $accept = strtolower($accept);
+
+        if ($accept === '' || str_contains($accept, '+json') || str_contains($accept, 'application/json')) {
+            return 'json';
+        }
+
+        if (str_contains($accept, 'text/html') || str_contains($accept, 'application/xhtml')) {
+            return 'html';
+        }
+
+        if (str_contains($accept, 'text/plain')) {
+            return 'text';
+        }
+
+        // `*/*` or anything unrecognised: this is an API-first framework.
+        return 'json';
+    }
+
+    /**
+     * @param array<string, mixed> $problem
+     */
+    private function renderJson(ResponseInterface $response, array $problem): ResponseInterface
+    {
+        $flags = JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | ($this->debug ? JSON_PRETTY_PRINT : 0);
+
+        try {
+            $body = json_encode($problem, JSON_THROW_ON_ERROR | $flags);
+        } catch (JsonException) {
+            $body = json_encode([
+                'type' => self::PROBLEM_TYPE,
+                'title' => $problem['title'] ?? 'Error',
+                'status' => $problem['status'] ?? HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR,
+            ]) ?: '{"type":"about:blank","title":"Error","status":500}';
+        }
+
+        $response->getBody()->write($body);
+
+        return $response->withHeader('Content-Type', 'application/problem+json');
+    }
+
+    /**
+     * @param array<string, mixed> $problem
+     */
+    private function renderHtml(ResponseInterface $response, array $problem): ResponseInterface
+    {
+        $status = (int) ($problem['status'] ?? HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR);
+        $title = $this->escape((string) ($problem['title'] ?? 'Error'));
+        $detail = isset($problem['detail']) ? '<p>' . $this->escape((string) $problem['detail']) . '</p>' : '';
+        $debug = $this->debug && isset($problem['exception'])
+            ? \sprintf(
+                "<pre>%s\n%s\n\n%s</pre>",
+                $this->escape((string) $problem['exception']),
+                $this->escape((string) ($problem['file'] ?? '')),
+                $this->escape(implode("\n", (array) ($problem['trace'] ?? []))),
+            )
+            : '';
+
+        $body = <<<HTML
+            <!doctype html>
+            <html lang="en">
+            <head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>{$status} {$title}</title>
+            <style>html{font-family:system-ui,sans-serif;margin:2rem;color:#1a1a1a}h1{font-size:1.5rem}pre{background:#f5f5f5;padding:1rem;overflow:auto;border-radius:6px}</style>
+            </head>
+            <body><h1>{$status} {$title}</h1>{$detail}{$debug}</body>
+            </html>
+            HTML;
+
+        $response->getBody()->write($body);
+
+        return $response->withHeader('Content-Type', 'text/html; charset=utf-8');
+    }
+
+    /**
+     * @param array<string, mixed> $problem
+     */
+    private function renderText(ResponseInterface $response, array $problem): ResponseInterface
+    {
+        $status = (int) ($problem['status'] ?? HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR);
+        $body = \sprintf('%d %s', $status, (string) ($problem['title'] ?? 'Error'));
+
+        if (isset($problem['detail'])) {
+            $detail = (string) $problem['detail'];
+            $body .= "\n\n" . $detail;
+        }
+
+        $response->getBody()->write($body);
+
+        return $response->withHeader('Content-Type', 'text/plain; charset=utf-8');
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML5, 'UTF-8');
+    }
+}

--- a/tests/Events/EventRecordingLoggerTest.php
+++ b/tests/Events/EventRecordingLoggerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Events;
+
+use Altair\Events\Contracts\RecorderInterface;
+use Altair\Events\Event;
+use Altair\Events\EventKind;
+use Altair\Events\EventRecordingLogger;
+use Altair\Events\EventStatus;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+final class EventRecordingLoggerTest extends TestCase
+{
+    public function testErrorLevelRecordsAnHttpErrorEvent(): void
+    {
+        $recorder = $this->recorder();
+        $logger = new EventRecordingLogger($recorder);
+
+        $logger->error('boom', [
+            'method' => 'POST',
+            'path' => '/orders',
+            'status' => 500,
+            'exception' => new RuntimeException('boom'),
+        ]);
+
+        $this->assertCount(1, $recorder->events);
+        $event = $recorder->events[0];
+        $this->assertSame(EventKind::HttpError, $event->kind);
+        $this->assertSame(EventStatus::Fail, $event->status);
+        $this->assertSame('POST /orders', $event->command);
+        $this->assertSame('boom', $event->error);
+        $this->assertSame('POST', $event->extra['method']);
+        $this->assertSame('/orders', $event->extra['path']);
+        $this->assertSame(500, $event->extra['status']);
+        $this->assertSame(RuntimeException::class, $event->extra['exception']);
+    }
+
+    public function testNonErrorLevelsAreIgnored(): void
+    {
+        $recorder = $this->recorder();
+        $logger = new EventRecordingLogger($recorder);
+
+        $logger->info('just fyi');
+        $logger->warning('careful');
+        $logger->notice('noted');
+        $logger->debug('trace');
+
+        $this->assertSame([], $recorder->events);
+    }
+
+    public function testCriticalAndAboveAreRecorded(): void
+    {
+        $recorder = $this->recorder();
+        $logger = new EventRecordingLogger($recorder);
+
+        $logger->critical('db down');
+        $logger->alert('page someone');
+        $logger->emergency('on fire');
+
+        $this->assertCount(3, $recorder->events);
+    }
+
+    public function testEmptyMessageFallsBackToExceptionClass(): void
+    {
+        $recorder = $this->recorder();
+        $logger = new EventRecordingLogger($recorder);
+
+        $logger->error('', ['exception' => new RuntimeException()]);
+
+        $this->assertSame(RuntimeException::class, $recorder->events[0]->error);
+        // No request context supplied: command still non-empty.
+        $this->assertSame('http.request', $recorder->events[0]->command);
+    }
+
+    /**
+     * @return RecorderInterface&object{events: list<Event>}
+     */
+    private function recorder(): RecorderInterface
+    {
+        return new class () implements RecorderInterface {
+            /** @var list<Event> */
+            public array $events = [];
+
+            public function record(Event $event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+    }
+}

--- a/tests/Http/Exception/HttpExceptionStatusTest.php
+++ b/tests/Http/Exception/HttpExceptionStatusTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Exception;
+
+use Altair\Http\Contracts\HttpExceptionInterface;
+use Altair\Http\Contracts\ProblemExtensionInterface;
+use Altair\Http\Exception\AuthorizationException;
+use Altair\Http\Exception\AuthorizationTokenException;
+use Altair\Http\Exception\HttpBadRequestException;
+use Altair\Http\Exception\HttpException;
+use Altair\Http\Exception\HttpMethodNotAllowedException;
+use Altair\Http\Exception\HttpNotFoundException;
+use Altair\Http\Exception\InputValidationException;
+use PHPUnit\Framework\TestCase;
+
+final class HttpExceptionStatusTest extends TestCase
+{
+    public function testHttpExceptionsAdvertiseTheirStatus(): void
+    {
+        $this->assertSame(404, (new HttpNotFoundException('/'))->getStatusCode());
+        $this->assertSame(405, (new HttpMethodNotAllowedException(['GET'], 'nope', 405))->getStatusCode());
+        $this->assertSame(401, (new AuthorizationException())->getStatusCode());
+        $this->assertSame(403, (new AuthorizationTokenException())->getStatusCode());
+        $this->assertSame(422, (new InputValidationException(['name' => 'required']))->getStatusCode());
+    }
+
+    public function testBareBadRequestFallsBackTo400NotServerError(): void
+    {
+        $this->assertSame(400, (new HttpBadRequestException('bad'))->getStatusCode());
+    }
+
+    public function testBareHttpExceptionFallsBackTo500(): void
+    {
+        $this->assertSame(500, (new HttpException('boom'))->getStatusCode());
+    }
+
+    public function testNonsenseCodeFallsBackToDefault(): void
+    {
+        // A code outside the HTTP error range must not leak through as a status.
+        $this->assertSame(500, (new HttpException('boom', 7))->getStatusCode());
+        $this->assertSame(400, (new HttpBadRequestException('boom', 7))->getStatusCode());
+    }
+
+    public function testMethodNotAllowedExposesAllowHeader(): void
+    {
+        $exception = new HttpMethodNotAllowedException(['GET', 'POST'], 'nope', 405);
+
+        $this->assertSame(['Allow' => 'GET,POST'], $exception->getHeaders());
+    }
+
+    public function testMethodNotAllowedWithoutAllowListHasNoHeaders(): void
+    {
+        $this->assertSame([], (new HttpMethodNotAllowedException([], 'nope', 405))->getHeaders());
+    }
+
+    public function testBaseExceptionHasNoHeaders(): void
+    {
+        $this->assertSame([], (new HttpNotFoundException('/'))->getHeaders());
+    }
+
+    public function testValidationExceptionContributesProblemExtensions(): void
+    {
+        $exception = new InputValidationException(['email' => 'invalid', 'age' => 'required']);
+
+        $this->assertInstanceOf(ProblemExtensionInterface::class, $exception);
+        $this->assertSame(
+            ['errors' => ['email' => 'invalid', 'age' => 'required']],
+            $exception->getProblemExtensions(),
+        );
+    }
+
+    public function testHttpExceptionsImplementTheContract(): void
+    {
+        $this->assertInstanceOf(HttpExceptionInterface::class, new HttpNotFoundException('/'));
+        $this->assertInstanceOf(HttpExceptionInterface::class, new HttpException('x'));
+    }
+}

--- a/tests/Http/Middleware/ExceptionHandlerMiddlewareTest.php
+++ b/tests/Http/Middleware/ExceptionHandlerMiddlewareTest.php
@@ -7,6 +7,8 @@ namespace Altair\Tests\Http\Middleware;
 use Altair\Http\Contracts\ErrorHandlerInterface;
 use Altair\Http\Contracts\HttpStatusCodeInterface;
 use Altair\Http\Contracts\MiddlewareInterface;
+use Altair\Http\Exception\HttpMethodNotAllowedException;
+use Altair\Http\Exception\HttpNotFoundException;
 use Altair\Http\Middleware\ExceptionHandlerMiddleware;
 use Laminas\Diactoros\Response;
 use Laminas\Diactoros\ResponseFactory;
@@ -15,7 +17,10 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\MiddlewareInterface as PsrMiddlewareInterface;
 use Psr\Http\Server\RequestHandlerInterface;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
+use Stringable;
 
 class ExceptionHandlerMiddlewareTest extends AbstractMiddlewareTest
 {
@@ -84,6 +89,95 @@ class ExceptionHandlerMiddlewareTest extends AbstractMiddlewareTest
         $this->assertSame(HttpStatusCodeInterface::HTTP_INTERNAL_SERVER_ERROR, $response->getStatusCode());
         $this->assertInstanceOf(RuntimeException::class,
             $errorHandler->seen->getAttribute(MiddlewareInterface::ATTRIBUTE_EXCEPTION));
+    }
+
+    public function testThrownHttpExceptionRendersItsOwnStatus(): void
+    {
+        $middleware = new ExceptionHandlerMiddleware(new ResponseFactory(), $this->passthroughHandler(), capture: true);
+
+        $response = $this->dispatch(
+            [$middleware, $this->handlerThrowing(new HttpNotFoundException('/'))],
+            new ServerRequest(),
+        );
+
+        $this->assertSame(HttpStatusCodeInterface::HTTP_NOT_FOUND, $response->getStatusCode());
+    }
+
+    public function testThrownMethodNotAllowedAppliesAllowHeader(): void
+    {
+        $middleware = new ExceptionHandlerMiddleware(new ResponseFactory(), $this->passthroughHandler(), capture: true);
+
+        $response = $this->dispatch(
+            [$middleware, $this->handlerThrowing(new HttpMethodNotAllowedException(['GET', 'POST'], 'nope', 405))],
+            new ServerRequest(),
+        );
+
+        $this->assertSame(HttpStatusCodeInterface::HTTP_METHOD_NOT_ALLOWED, $response->getStatusCode());
+        $this->assertSame('GET,POST', $response->getHeaderLine('Allow'));
+    }
+
+    public function testServerErrorsAreLogged(): void
+    {
+        $logger = $this->spyLogger();
+        $middleware = new ExceptionHandlerMiddleware(
+            new ResponseFactory(),
+            $this->passthroughHandler(),
+            capture: true,
+            logger: $logger,
+        );
+
+        $this->dispatch(
+            [$middleware, $this->handlerThrowing(new RuntimeException('boom'))],
+            new ServerRequest(),
+        );
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('boom', $logger->records[0]['message']);
+        $this->assertSame(500, $logger->records[0]['context']['status']);
+    }
+
+    public function testClientErrorsAreNotLogged(): void
+    {
+        $logger = $this->spyLogger();
+        $middleware = new ExceptionHandlerMiddleware(
+            new ResponseFactory(),
+            $this->passthroughHandler(),
+            capture: true,
+            logger: $logger,
+        );
+
+        $this->dispatch(
+            [$middleware, $this->handlerThrowing(new HttpNotFoundException('/'))],
+            new ServerRequest(),
+        );
+
+        $this->assertSame([], $logger->records);
+    }
+
+    private function passthroughHandler(): ErrorHandlerInterface
+    {
+        return new class () implements ErrorHandlerInterface {
+            public function __invoke(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
+            {
+                return $response;
+            }
+        };
+    }
+
+    /**
+     * @return AbstractLogger&object{records: list<array{message: string, context: array<string, mixed>}>}
+     */
+    private function spyLogger(): LoggerInterface
+    {
+        return new class () extends AbstractLogger {
+            /** @var list<array{message: string, context: array<string, mixed>}> */
+            public array $records = [];
+
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                $this->records[] = ['message' => (string) $message, 'context' => $context];
+            }
+        };
     }
 
     private function handlerReturning(int $code): PsrMiddlewareInterface

--- a/tests/Http/Support/ProblemDetailsErrorHandlerTest.php
+++ b/tests/Http/Support/ProblemDetailsErrorHandlerTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Http\Support;
+
+use Altair\Http\Contracts\MiddlewareInterface;
+use Altair\Http\Contracts\ProblemExtensionInterface;
+use Altair\Http\Exception\HttpException;
+use Altair\Http\Exception\HttpNotFoundException;
+use Altair\Http\Exception\InputValidationException;
+use Altair\Http\Support\ProblemDetailsErrorHandler;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Uri;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use RuntimeException;
+use Throwable;
+
+final class ProblemDetailsErrorHandlerTest extends TestCase
+{
+    public function testRendersProblemJsonForNotFound(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(),
+            $this->request('application/json', '/missing', new HttpNotFoundException('No route for /missing')),
+            new Response('php://memory', 404),
+        );
+
+        $this->assertSame('application/problem+json', $response->getHeaderLine('Content-Type'));
+
+        $problem = $this->decode($response);
+        $this->assertSame('about:blank', $problem['type']);
+        $this->assertSame('Not Found', $problem['title']);
+        $this->assertSame(404, $problem['status']);
+        $this->assertSame('No route for /missing', $problem['detail']);
+        $this->assertSame('/missing', $problem['instance']);
+    }
+
+    public function testProductionHidesServerErrorMessageAndTrace(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(debug: false),
+            $this->request('application/json', '/x', new RuntimeException('secret connection string')),
+            new Response('php://memory', 500),
+        );
+
+        $problem = $this->decode($response);
+        $this->assertSame(500, $problem['status']);
+        $this->assertSame('An unexpected error occurred.', $problem['detail']);
+        $this->assertArrayNotHasKey('exception', $problem);
+        $this->assertArrayNotHasKey('trace', $problem);
+        $this->assertStringNotContainsString('secret connection string', (string) $response->getBody());
+    }
+
+    public function testDebugExposesExceptionAndTrace(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(debug: true),
+            $this->request('application/json', '/x', new RuntimeException('boom detail')),
+            new Response('php://memory', 500),
+        );
+
+        $problem = $this->decode($response);
+        $this->assertSame('boom detail', $problem['detail']);
+        $this->assertSame(RuntimeException::class, $problem['exception']);
+        $this->assertIsArray($problem['trace']);
+        $this->assertArrayHasKey('file', $problem);
+    }
+
+    public function testValidationErrorsBecomeProblemExtensions(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(),
+            $this->request('application/json', '/users', new InputValidationException(['email' => 'invalid'])),
+            new Response('php://memory', 422),
+        );
+
+        $problem = $this->decode($response);
+        $this->assertSame(422, $problem['status']);
+        $this->assertSame(['email' => 'invalid'], $problem['errors']);
+    }
+
+    public function testExtensionsCannotClobberReservedMembers(): void
+    {
+        $malicious = new class('x') extends HttpException implements ProblemExtensionInterface {
+            public function getProblemExtensions(): array
+            {
+                return ['status' => 200, 'title' => 'OK', 'errors' => ['a' => 'b']];
+            }
+        };
+
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(),
+            $this->request('application/json', '/x', $malicious),
+            new Response('php://memory', 403),
+        );
+
+        $problem = $this->decode($response);
+        $this->assertSame(403, $problem['status']);
+        $this->assertSame('Forbidden', $problem['title']);
+        $this->assertSame(['a' => 'b'], $problem['errors']);
+    }
+
+    public function testHtmlOutputEscapesReflectedMessage(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(),
+            $this->request('text/html', '/x', new HttpNotFoundException('<script>alert(1)</script>')),
+            new Response('php://memory', 404),
+        );
+
+        $body = (string) $response->getBody();
+        $this->assertStringStartsWith('text/html', $response->getHeaderLine('Content-Type'));
+        $this->assertStringNotContainsString('<script>alert(1)</script>', $body);
+        $this->assertStringContainsString('&lt;script&gt;', $body);
+    }
+
+    public function testPlainTextNegotiation(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(),
+            $this->request('text/plain', '/x', new HttpNotFoundException('gone')),
+            new Response('php://memory', 404),
+        );
+
+        $this->assertStringStartsWith('text/plain', $response->getHeaderLine('Content-Type'));
+        $this->assertStringContainsString('404 Not Found', (string) $response->getBody());
+    }
+
+    public function testWildcardAcceptDefaultsToJson(): void
+    {
+        $response = $this->handle(
+            new ProblemDetailsErrorHandler(),
+            $this->request('*/*', '/x', new HttpNotFoundException('gone')),
+            new Response('php://memory', 404),
+        );
+
+        $this->assertSame('application/problem+json', $response->getHeaderLine('Content-Type'));
+    }
+
+    private function handle(
+        ProblemDetailsErrorHandler $handler,
+        ServerRequestInterface $request,
+        ResponseInterface $response,
+    ): ResponseInterface {
+        return $handler($request, $response);
+    }
+
+    private function request(string $accept, string $path, ?Throwable $exception): ServerRequestInterface
+    {
+        return (new ServerRequest())
+            ->withUri(new Uri($path))
+            ->withHeader('Accept', $accept)
+            ->withAttribute(MiddlewareInterface::ATTRIBUTE_EXCEPTION, $exception);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(ResponseInterface $response): array
+    {
+        return json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+    }
+}


### PR DESCRIPTION
## What & why

A fresh Univeros app showed a raw PHP **fatal** (vendor paths + stack trace) the moment a request missed a route, because the scaffolded `public/index.php` never wired `ExceptionHandlerMiddleware`. Even when wired per the docs, a thrown `HttpException` collapsed to a generic `500`, and the only shipped handler was `echo`-based, environment-unaware, and reflected unescaped input.

This PR fixes those defects and ships a production-safe, **agent-native** error story wired by default. Full analysis in #199.

## Defects fixed

1. **Skeleton didn't wire the handler** → uncaught fatal. The skeleton now puts `ExceptionHandlerMiddleware` outermost with `capture: true`.
2. **Thrown HTTP exceptions lost their status** (404 rendered as 500). Exceptions now advertise their status via `HttpExceptionInterface`, and the middleware honours it.
3. **Reflected output injection + info disclosure** in `DefaultErrorHandler`. Output is now escaped; the new prod handler never leaks internals.

## What's new

- **`HttpExceptionInterface`** (`getStatusCode()` + `getHeaders()`). The `HttpException` hierarchy carries 404/405/401/403/422; bare bad-request → 400; non-HTTP `Throwable` → 500. `HttpMethodNotAllowedException` advertises its `Allow` header.
- **`ProblemDetailsErrorHandler`** — RFC 7807 `application/problem+json` by default, negotiating to a safe HTML page or plain text. Writes to the PSR-7 body (no `echo`), escapes everything, and is environment-aware:
  - production: generic `detail` for 5xx; never the exception class/message/trace.
  - debug: class, `file:line`, and stack trace attached.
  - `ProblemExtensionInterface` lets exceptions add members (e.g. `InputValidationException` → `"errors": {...}` on its 422), without clobbering reserved members.
- **`ExceptionHandlerMiddleware`** honours the thrown exception's status + headers and logs every 5xx through an optional PSR-3 `LoggerInterface`.
- **Agent memory**: `EventKind::HttpError` + `EventRecordingLogger` (PSR-3 → events log), bound by `EventsConfiguration`. Server-side failures become `http_error` events in `.altair/events.jsonl` (`bin/altair events:filter --kind=http_error`). `Http` depends only on PSR-3 — no coupling to `Events`. 4xx is intentionally not recorded.
- **Skeleton** `public/index.php` wires the handler outermost, verbosity from `APP_DEBUG`, event logger auto-detected when Events is enabled.
- `DefaultErrorHandler` output escaped (kept dev-only).
- `docs/packages/http.md` updated.

## Before / after — `GET /` with no route

```
# before
Fatal error: Uncaught Altair\Http\Exception\HttpNotFoundException: / in .../DispatcherMiddleware.php:65 ...

# after (production)
HTTP 404 | Content-Type: application/problem+json
{"type":"about:blank","title":"Not Found","status":404,"detail":"/","instance":"/"}

# after (APP_DEBUG=true) adds: "exception", "file", "trace"
```

## Test plan

- [x] `composer cs` — clean
- [x] `composer stan` (level 8) — clean
- [x] `composer rector` (dry-run, full tree) — clean (exit 0)
- [x] New tests pass: status mapping (`HttpExceptionStatusTest`), problem handler (`ProblemDetailsErrorHandlerTest`), middleware status/headers/logging (`ExceptionHandlerMiddlewareTest`), event bridge (`EventRecordingLoggerTest`) — 29 tests / 68 assertions
- [x] Full `tests/Http` + `tests/Events` suites green (258 tests)
- [x] Full suite green apart from pre-existing extension-gated errors (redis/mongo/memcached not installed locally)

Closes #199
