### PR TITLE
feat(scaffold): nested objects & arrays-of-objects in spec inputs (+ --skip-unmappable)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -32,6 +32,7 @@
 - `HandlerTestEmitter`
 - `HistoryCommand` _(final)_
 - `IdempotencySpec` _(final)_
+- `ImportPlan` _(final)_
 - `ImportReceipt` _(final)_
 - `InputEmitter`
 - `InputFieldSpec` _(final)_

--- a/docs/guides/openapi/import.md
+++ b/docs/guides/openapi/import.md
@@ -53,6 +53,9 @@ bin/altair openapi:import openapi.yaml --dry-run
 
 # Overwrite existing files
 bin/altair openapi:import openapi.yaml --force
+
+# Import what maps; skip (don't abort on) operations the emitter can't express
+bin/altair openapi:import openapi.yaml --skip-unmappable
 ```
 
 ## Flags
@@ -64,6 +67,7 @@ bin/altair openapi:import openapi.yaml --force
 | `--scaffold` | bool | After writing specs, run `spec:scaffold` on each. |
 | `--dry-run` | bool | Report planned changes; write nothing. |
 | `--force` | bool | Overwrite existing files (specs and scaffolded). |
+| `--skip-unmappable` | bool | Skip operations whose schema the emitter cannot express (recording them in `unmapped[]` and `warnings[]`) instead of aborting the whole import. |
 | `--format=human\|json` | enum | Output format. Default `human`. |
 | `--persistence=cycle` | enum | Inject a `persistence:` block for each POST-to-collection endpoint. |
 | `--queue=<transport>` | string | Reserved for the `x-altair-queue` extension in [#163](https://github.com/univeros/framework/issues/163); currently a no-op that surfaces a warning. |
@@ -102,7 +106,9 @@ parsing prose:
   produced.
 - `unmapped` carries `{pointer, message}` entries for any schema the
   emitter could not express — the JSON pointer is the location inside
-  the source document.
+  the source document. On a fail-fast run it holds the single schema
+  that aborted the import; under `--skip-unmappable` it lists every
+  skipped operation while `ok` stays `true`.
 - `journal_id` / `event_id` are populated only when a `Journal` and
   `RecorderInterface` are bound, respectively. Under a `NullRecorder`
   they stay null, which keeps the receipt byte-stable for the same
@@ -134,8 +140,23 @@ The mapping rules ship in `Altair\Scaffold\Spec\Emitter\*` (see
 
 Anything the emitter cannot express — nested objects in inputs, arrays
 of objects, ref cycles, dangling refs — surfaces as an entry in
-`unmapped[]` with a JSON pointer to the offending node. The run fails
-fast.
+`unmapped[]` with a JSON pointer to the offending node. By default the
+run **fails fast** on the first such schema (exit 1, nothing written).
+
+Pass `--skip-unmappable` to import everything that *does* map and skip
+the rest: each skipped operation lands in `unmapped[]` (with its JSON
+pointer) and as a `skipped <METHOD> <path>: …` line in `warnings[]`, the
+run succeeds (exit 0), and the mappable specs are written. This is the
+pragmatic mode for real-world documents — e.g. the Swagger Petstore,
+whose `Pet` body nests a `category` object and a `tags` array-of-objects
+that Altair's scalar-only input layer cannot yet represent. The
+remaining ~17 operations still import.
+
+> Nested objects and arrays-of-objects in **inputs** are a current
+> limitation of the input layer, not a parser bug — support for them
+> (in both `openapi:import` and `spec:emit-openapi`) is planned. Until
+> then, `--skip-unmappable` keeps the rest of the document usable, or
+> flatten the offending request bodies to scalars by hand.
 
 ## Persistence inference
 

--- a/docs/guides/openapi/import.md
+++ b/docs/guides/openapi/import.md
@@ -131,32 +131,36 @@ The mapping rules ship in `Altair\Scaffold\Spec\Emitter\*` (see
 - **Path parameters** become required string inputs.
 - **Request-body object properties** become inputs; the OpenAPI
   `required` array maps to the Altair `required` rule.
+- **Nested objects** become an `input` field with `type: object` and a
+  recursive `fields:` map; the generated Input DTO types them as `array`
+  with a PHPDoc `array{…}` shape. **Arrays of objects** become
+  `type: array` with a `fields:` map describing the item, typed
+  `list<array{…}>`. Both directions round-trip (`openapi:roundtrip`).
 - **Enums** without an FQCN render as `type: string` plus an `in:` rule.
 - **Refs**: scalars/enums resolve through `components.schemas` to the
-  underlying type; object refs render as `App\<Ref>\<Ref>` so the
-  responder gets a typed payload.
+  underlying type. In **inputs**, object refs (and nested object/array
+  items) resolve and inline as nested `fields:`. In **responses**, object
+  refs render as `App\<Ref>\<Ref>` so the responder gets a typed payload.
 - **Top-level `$ref` responses** wrap as
   `{<refLowerCamel>: App\<Ref>\<Ref>}` to preserve the abstraction.
 
-Anything the emitter cannot express — nested objects in inputs, arrays
-of objects, ref cycles, dangling refs — surfaces as an entry in
-`unmapped[]` with a JSON pointer to the offending node. By default the
-run **fails fast** on the first such schema (exit 1, nothing written).
+Anything the emitter still cannot express — ref cycles, dangling refs, a
+non-object request-body root, `oneOf`/`anyOf` polymorphism — surfaces as
+an entry in `unmapped[]` with a JSON pointer to the offending node. By
+default the run **fails fast** on the first such schema (exit 1, nothing
+written).
 
 Pass `--skip-unmappable` to import everything that *does* map and skip
 the rest: each skipped operation lands in `unmapped[]` (with its JSON
 pointer) and as a `skipped <METHOD> <path>: …` line in `warnings[]`, the
-run succeeds (exit 0), and the mappable specs are written. This is the
-pragmatic mode for real-world documents — e.g. the Swagger Petstore,
-whose `Pet` body nests a `category` object and a `tags` array-of-objects
-that Altair's scalar-only input layer cannot yet represent. The
-remaining ~17 operations still import.
+run succeeds (exit 0), and the mappable specs are written.
 
-> Nested objects and arrays-of-objects in **inputs** are a current
-> limitation of the input layer, not a parser bug — support for them
-> (in both `openapi:import` and `spec:emit-openapi`) is planned. Until
-> then, `--skip-unmappable` keeps the rest of the document usable, or
-> flatten the offending request bodies to scalars by hand.
+> The canonical **Swagger Petstore** imports with **zero** skips: its
+> `Pet` body nests a `category` object and a `tags` array-of-objects,
+> both of which now map to recursive `fields:`. Deep per-field
+> *validation rules* for nested members are not generated yet (the
+> nested shape and the object's own `required` flag are); add them by
+> hand if you need them.
 
 ## Persistence inference
 

--- a/src/Altair/Scaffold/Cli/ImportPlan.php
+++ b/src/Altair/Scaffold/Cli/ImportPlan.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Cli;
+
+use Altair\Scaffold\Emitter\EmittedFile;
+
+/**
+ * Outcome of the planning phase of `openapi:import`: the spec files that
+ * will be written, plus the operations that could not be mapped.
+ *
+ * Under `--skip-unmappable`, an operation whose schema the emitter cannot
+ * express (e.g. a nested-object request body) is recorded in {@see $unmapped}
+ * and a human-readable line is added to {@see $warnings} instead of aborting
+ * the whole run. Without the flag the runner never builds a partial plan —
+ * the first unmappable operation throws straight out of planning.
+ */
+final readonly class ImportPlan
+{
+    /**
+     * @param list<EmittedFile>                              $files    Specs that will be written.
+     * @param list<array{pointer: string, message: string}> $unmapped Operations skipped as unmappable.
+     * @param list<string>                                   $warnings One line per skipped operation.
+     */
+    public function __construct(
+        public array $files,
+        public array $unmapped = [],
+        public array $warnings = [],
+    ) {}
+}

--- a/src/Altair/Scaffold/Cli/OpenApiImportCommand.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportCommand.php
@@ -53,6 +53,8 @@ final readonly class OpenApiImportCommand
         bool $dryRun = false,
         #[Option(description: 'Overwrite existing files instead of skipping.')]
         bool $force = false,
+        #[Option(description: 'Skip operations whose schema cannot be mapped instead of aborting the whole import.', name: 'skip-unmappable')]
+        bool $skipUnmappable = false,
         #[Option(description: 'Emit JSON receipt (human|json).')]
         string $format = 'human',
         #[Option(description: 'Persistence binding to infer for each spec (cycle).')]
@@ -82,6 +84,7 @@ final readonly class OpenApiImportCommand
             scaffold: $scaffold,
             dryRun: $dryRun,
             force: $force,
+            skipUnmappable: $skipUnmappable,
             persistence: $persistence,
             queue: $queue,
         );
@@ -123,6 +126,13 @@ final readonly class OpenApiImportCommand
         echo \sprintf('Wrote %d spec file(s):%s', \count($receipt->specsWritten), PHP_EOL);
         foreach ($receipt->specsWritten as $path) {
             echo '  - ' . $path . PHP_EOL;
+        }
+
+        if ($receipt->unmapped !== []) {
+            echo \sprintf('Skipped %d unmappable operation(s):%s', \count($receipt->unmapped), PHP_EOL);
+            foreach ($receipt->unmapped as $unmapped) {
+                echo \sprintf('  at %s: %s%s', $unmapped['pointer'], $unmapped['message'], PHP_EOL);
+            }
         }
 
         if ($receipt->scaffoldRequested) {

--- a/src/Altair/Scaffold/Cli/OpenApiImportOptions.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportOptions.php
@@ -26,6 +26,7 @@ final readonly class OpenApiImportOptions
         public bool $scaffold = false,
         public bool $dryRun = false,
         public bool $force = false,
+        public bool $skipUnmappable = false,
         public ?string $persistence = null,
         public ?string $queue = null,
     ) {}

--- a/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
@@ -103,7 +103,7 @@ final readonly class OpenApiImportRunner
 
         try {
             $document = $this->parser->parseYaml($sourceContents);
-            $planned = $this->planSpecs($document, $options);
+            $plan = $this->planSpecs($document, $options);
         } catch (UnmappableSchemaException $unmappableSchemaException) {
             return $this->failure(
                 $options,
@@ -116,16 +116,16 @@ final readonly class OpenApiImportRunner
         }
 
         if ($options->dryRun) {
-            return $this->dryRunReceipt($options, $planned, $document);
+            return $this->dryRunReceipt($options, $plan, $document);
         }
 
         $collector = new SnapshotCollector($options->projectRoot);
         $writer = new FileWriter($options->projectRoot);
 
-        $writtenSpecs = $this->writeSpecs($planned, $writer, $collector, $options->force);
+        $writtenSpecs = $this->writeSpecs($plan->files, $writer, $collector, $options->force);
         $scaffoldFiles = [];
         $rolledBack = [];
-        $warnings = [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document)];
+        $warnings = [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document), ...$plan->warnings];
 
         if ($options->scaffold && $writtenSpecs !== []) {
             try {
@@ -161,7 +161,7 @@ final readonly class OpenApiImportRunner
             scaffoldRequested: $options->scaffold,
             scaffolded: $scaffoldFiles,
             rolledBack: $rolledBack,
-            unmapped: [],
+            unmapped: $plan->unmapped,
             warnings: $warnings,
             journalId: $journalId,
             eventId: $eventId,
@@ -170,19 +170,49 @@ final readonly class OpenApiImportRunner
     }
 
     /**
-     * @return list<EmittedFile>
+     * Map every operation to a spec file. An operation whose schema cannot be
+     * expressed in Altair's spec is skipped (recorded in the returned plan)
+     * when `--skip-unmappable` is set; otherwise its {@see UnmappableSchemaException}
+     * propagates and aborts the whole import.
+     *
+     * Mapping happens before the filename-collision check so a skipped
+     * operation never reserves a filename — only operations that actually
+     * emit a spec can collide.
      */
-    private function planSpecs(OpenApiDocument $document, OpenApiImportOptions $options): array
+    private function planSpecs(OpenApiDocument $document, OpenApiImportOptions $options): ImportPlan
     {
         $deriver = $options->outDir !== null
             ? new PathDeriver(specRoot: $options->outDir)
             : $this->pathDeriver;
 
         $files = [];
+        $unmapped = [];
+        $warnings = [];
         $seen = [];
         foreach ($document->operations as $operation) {
-            $filename = $deriver->filename($operation);
+            try {
+                $structure = $this->operationMapper->map($document, $operation);
+            } catch (UnmappableSchemaException $unmappableSchemaException) {
+                if (!$options->skipUnmappable) {
+                    throw $unmappableSchemaException;
+                }
 
+                $label = strtoupper($operation->method) . ' ' . $operation->path;
+                $unmapped[] = [
+                    'pointer' => $unmappableSchemaException->jsonPointer,
+                    'message' => $unmappableSchemaException->getMessage(),
+                ];
+                $warnings[] = \sprintf(
+                    'skipped %s: %s (at %s)',
+                    $label,
+                    $unmappableSchemaException->reason,
+                    $unmappableSchemaException->jsonPointer,
+                );
+
+                continue;
+            }
+
+            $filename = $deriver->filename($operation);
             if (isset($seen[$filename])) {
                 throw new ScaffoldException(\sprintf(
                     "Filename collision: '%s' is also emitted by '%s %s'. Set distinct operationIds to disambiguate.",
@@ -192,7 +222,6 @@ final readonly class OpenApiImportRunner
                 ));
             }
 
-            $structure = $this->operationMapper->map($document, $operation);
             if ($options->persistence === 'cycle') {
                 $structure = $this->persistenceInferrer->apply($operation, $structure);
             }
@@ -202,7 +231,13 @@ final readonly class OpenApiImportRunner
             $seen[$filename] = ['method' => $operation->method, 'path' => $operation->path];
         }
 
-        return $files;
+        // Every operation was skipped: a bare exit 0 would otherwise read as
+        // "imported successfully", so make the empty outcome explicit.
+        if ($files === [] && $unmapped !== []) {
+            $warnings[] = 'every operation was unmappable — no specs were emitted.';
+        }
+
+        return new ImportPlan($files, $unmapped, $warnings);
     }
 
     /**
@@ -394,6 +429,10 @@ final readonly class OpenApiImportRunner
             $parts[] = '--force';
         }
 
+        if ($options->skipUnmappable) {
+            $parts[] = '--skip-unmappable';
+        }
+
         return implode(' ', $parts);
     }
 
@@ -408,20 +447,17 @@ final readonly class OpenApiImportRunner
         return $contents === false ? null : $contents;
     }
 
-    /**
-     * @param list<EmittedFile> $planned
-     */
-    private function dryRunReceipt(OpenApiImportOptions $options, array $planned, OpenApiDocument $document): ImportReceipt
+    private function dryRunReceipt(OpenApiImportOptions $options, ImportPlan $plan, OpenApiDocument $document): ImportReceipt
     {
         return new ImportReceipt(
             ok: true,
             input: $options->documentPath,
-            specsWritten: \array_values(array_map(static fn(EmittedFile $f): string => $f->relativePath, $planned)),
+            specsWritten: \array_values(array_map(static fn(EmittedFile $f): string => $f->relativePath, $plan->files)),
             scaffoldRequested: $options->scaffold,
             scaffolded: [],
             rolledBack: [],
-            unmapped: [],
-            warnings: [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document)],
+            unmapped: $plan->unmapped,
+            warnings: [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document), ...$plan->warnings],
             journalId: null,
             eventId: null,
             error: null,

--- a/src/Altair/Scaffold/Emitter/InputEmitter.php
+++ b/src/Altair/Scaffold/Emitter/InputEmitter.php
@@ -64,7 +64,8 @@ class InputEmitter
             return "    public function __construct() {}\n";
         }
 
-        $lines = ['    public function __construct('];
+        $lines = $this->renderConstructorDocblock($spec);
+        $lines[] = '    public function __construct(';
         $last = \count($spec->inputs) - 1;
         foreach ($spec->inputs as $i => $field) {
             $type = $this->typeMapper->toPhpType($field);
@@ -77,6 +78,63 @@ class InputEmitter
         $lines[] = '    ) {}';
 
         return implode("\n", $lines);
+    }
+
+    /**
+     * Constructor-level PHPDoc lines describing the array shape of nested-object
+     * and array-of-object params — the one case CLAUDE.md warrants PHPDoc (a
+     * shape PHP's `array` type can't express). Empty for scalar-only inputs, so
+     * those DTOs stay byte-identical to before nesting existed.
+     *
+     * @return list<string>
+     */
+    private function renderConstructorDocblock(Spec $spec): array
+    {
+        $params = [];
+        foreach ($spec->inputs as $field) {
+            $shape = $this->arrayShape($field);
+            if ($shape !== null) {
+                $params[] = \sprintf('     * @param %s $%s', $shape, $field->name);
+            }
+        }
+
+        if ($params === []) {
+            return [];
+        }
+
+        return ['    /**', ...$params, '     */'];
+    }
+
+    private function arrayShape(InputFieldSpec $field): ?string
+    {
+        if ($field->isObject()) {
+            return $this->objectShape($field);
+        }
+
+        if ($field->isArrayOfObjects()) {
+            return 'list<' . $this->objectShape($field) . '>';
+        }
+
+        return null;
+    }
+
+    private function objectShape(InputFieldSpec $field): string
+    {
+        $parts = [];
+        foreach ($field->fields as $child) {
+            $parts[] = $child->name . ': ' . $this->shapeType($child);
+        }
+
+        return 'array{' . implode(', ', $parts) . '}';
+    }
+
+    private function shapeType(InputFieldSpec $field): string
+    {
+        return match (true) {
+            $field->isObject() => $this->objectShape($field),
+            $field->isArrayOfObjects() => 'list<' . $this->objectShape($field) . '>',
+            default => $this->typeMapper->toPhpType($field),
+        };
     }
 
     private function renderDefault(InputFieldSpec $field): string

--- a/src/Altair/Scaffold/Emitter/TypeMapper.php
+++ b/src/Altair/Scaffold/Emitter/TypeMapper.php
@@ -31,7 +31,7 @@ final class TypeMapper
             'int', 'integer' => 'int',
             'float'          => 'float',
             'bool', 'boolean' => 'bool',
-            'array'          => 'array',
+            'array', 'object' => 'array',
             default          => 'string',
         };
     }
@@ -49,7 +49,8 @@ final class TypeMapper
             'int', 'integer' => ['type' => 'integer'],
             'float'          => ['type' => 'number', 'format' => 'float'],
             'bool', 'boolean' => ['type' => 'boolean'],
-            'array'          => ['type' => 'array', 'items' => ['type' => 'string']],
+            'object'         => $this->objectSchema($field),
+            'array'          => $this->arraySchema($field),
             default          => ['type' => 'string'],
         };
     }
@@ -60,5 +61,45 @@ final class TypeMapper
     public function isRequired(InputFieldSpec $field): bool
     {
         return $field->isRequired() && !$field->hasDefault;
+    }
+
+    /**
+     * A nested object: recurse into child fields for `properties`, carrying
+     * the per-child `required` flags into the OpenAPI `required` array.
+     *
+     * @return array<string, mixed>
+     */
+    private function objectSchema(InputFieldSpec $field): array
+    {
+        $properties = [];
+        $required = [];
+        foreach ($field->fields as $child) {
+            $properties[$child->name] = $this->toOpenApiSchema($child);
+            if ($this->isRequired($child)) {
+                $required[] = $child->name;
+            }
+        }
+
+        $schema = ['type' => 'object', 'properties' => $properties];
+        if ($required !== []) {
+            $schema['required'] = $required;
+        }
+
+        return $schema;
+    }
+
+    /**
+     * An array: object items when the field declares `fields` (array of
+     * objects), otherwise the existing scalar-item default.
+     *
+     * @return array<string, mixed>
+     */
+    private function arraySchema(InputFieldSpec $field): array
+    {
+        $items = $field->fields !== []
+            ? $this->objectSchema($field)
+            : ['type' => 'string'];
+
+        return ['type' => 'array', 'items' => $items];
     }
 }

--- a/src/Altair/Scaffold/Spec/Ast/InputFieldSpec.php
+++ b/src/Altair/Scaffold/Spec/Ast/InputFieldSpec.php
@@ -15,6 +15,9 @@ final readonly class InputFieldSpec
 {
     /**
      * @param list<string> $rules
+     * @param list<self>   $fields Child fields for a nested object (`type: object`)
+     *                             or the item shape of an array of objects
+     *                             (`type: array` with `fields`). Empty for scalars.
      */
     public function __construct(
         public string $name,
@@ -24,6 +27,7 @@ final readonly class InputFieldSpec
         public ?string $of = null,
         public mixed $default = null,
         public bool $hasDefault = false,
+        public array $fields = [],
     ) {}
 
     public function isRequired(): bool
@@ -34,5 +38,15 @@ final readonly class InputFieldSpec
     public function isEnum(): bool
     {
         return $this->type === 'enum' && $this->of !== null;
+    }
+
+    public function isObject(): bool
+    {
+        return $this->type === 'object';
+    }
+
+    public function isArrayOfObjects(): bool
+    {
+        return $this->type === 'array' && $this->fields !== [];
     }
 }

--- a/src/Altair/Scaffold/Spec/Emitter/Exception/UnmappableSchemaException.php
+++ b/src/Altair/Scaffold/Spec/Emitter/Exception/UnmappableSchemaException.php
@@ -19,14 +19,16 @@ use Altair\Scaffold\Exception\ScaffoldException;
  * cycle, or a schema kind the framework does not yet handle.
  *
  * The JSON pointer locates the offending node inside the source document so
- * the caller can surface it verbatim to the user (or agent).
+ * the caller can surface it verbatim to the user (or agent). {@see $reason}
+ * holds the bare explanation without the pointer prefix, for callers that
+ * render the location separately and would otherwise repeat it.
  */
 final class UnmappableSchemaException extends ScaffoldException
 {
     public function __construct(
         public readonly string $jsonPointer,
-        string $message,
+        public readonly string $reason,
     ) {
-        parent::__construct(\sprintf('Unmappable schema at %s: %s', $jsonPointer, $message));
+        parent::__construct(\sprintf('Unmappable schema at %s: %s', $jsonPointer, $reason));
     }
 }

--- a/src/Altair/Scaffold/Spec/Emitter/OperationMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/OperationMapper.php
@@ -237,8 +237,8 @@ final readonly class OperationMapper
      * Render the field list as a map keyed by name so the YAML reads naturally
      * and the Parser's "input is a map" expectation is met.
      *
-     * @param  list<array<string, mixed>>  $fields
-     * @return array<string, array<string, mixed>>
+     * @param  list<array<int|string, mixed>>            $fields
+     * @return array<string, array<int|string, mixed>>
      */
     private function inputBlock(array $fields): array
     {
@@ -246,10 +246,36 @@ final readonly class OperationMapper
         foreach ($fields as $field) {
             $name = (string) $field['name'];
             unset($field['name']);
+
+            // Nested objects / arrays of objects carry a `fields` list that must
+            // itself become a name-keyed map so the YAML reads like the top level.
+            if (isset($field['fields']) && \is_array($field['fields'])) {
+                $field['fields'] = $this->inputBlock($this->fieldList($field['fields']));
+            }
+
             $block[$name] = $field;
         }
 
         return $block;
+    }
+
+    /**
+     * Narrows an untyped nested `fields` value back to the list-of-field-arrays
+     * shape {@see inputBlock} consumes, dropping any non-array entries.
+     *
+     * @param  array<mixed, mixed>             $raw
+     * @return list<array<int|string, mixed>>
+     */
+    private function fieldList(array $raw): array
+    {
+        $list = [];
+        foreach ($raw as $entry) {
+            if (\is_array($entry)) {
+                $list[] = $entry;
+            }
+        }
+
+        return $list;
     }
 
     /**

--- a/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
@@ -32,6 +32,14 @@ final readonly class SchemaMapper
     /** Refs we have followed during the current resolution — guards against cycles. */
     private const int MAX_REF_DEPTH = 8;
 
+    /**
+     * Inline object-nesting ceiling. `resolveRef` already bounds `$ref` chains;
+     * this bounds *inline* nesting so a hostile or pathological document raises
+     * a clean {@see UnmappableSchemaException} (which `--skip-unmappable` can
+     * absorb) instead of exhausting the PHP call stack.
+     */
+    private const int MAX_NESTING_DEPTH = 32;
+
     public function __construct(
         private string $appNamespace = 'App',
     ) {}
@@ -133,10 +141,29 @@ final readonly class SchemaMapper
             );
         }
 
+        return $this->mapProperties($document, $schema, $pointer);
+    }
+
+    /**
+     * Maps every property of an object schema into the flat field-array shape,
+     * recursing through {@see inputField} so nested objects nest. Shared by the
+     * top-level request body and nested objects.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function mapProperties(OpenApiDocument $document, SchemaType $schema, string $pointer, int $depth = 0): array
+    {
+        if ($depth > self::MAX_NESTING_DEPTH) {
+            throw new UnmappableSchemaException(
+                $pointer,
+                \sprintf('input object nesting exceeds the maximum depth of %d.', self::MAX_NESTING_DEPTH),
+            );
+        }
+
         $fields = [];
         foreach ($schema->properties as $name => $property) {
             $propertyPointer = $pointer . '/properties/' . $name;
-            $fields[] = $this->inputField($document, (string) $name, $property['schema'], $property['required'], $propertyPointer);
+            $fields[] = $this->inputField($document, (string) $name, $property['schema'], $property['required'], $propertyPointer, $depth);
         }
 
         return $fields;
@@ -145,7 +172,7 @@ final readonly class SchemaMapper
     /**
      * @return array<string, mixed>
      */
-    private function inputField(OpenApiDocument $document, string $name, SchemaType $schema, bool $required, string $pointer): array
+    private function inputField(OpenApiDocument $document, string $name, SchemaType $schema, bool $required, string $pointer, int $depth = 0): array
     {
         $rules = $required ? ['required'] : [];
         $resolved = $this->resolveRef($document, $schema, $pointer);
@@ -153,16 +180,31 @@ final readonly class SchemaMapper
         return match ($resolved->kind) {
             SchemaType::SCALAR => $this->scalarInputField($name, $resolved, $rules),
             SchemaType::ENUM => $this->enumInputField($name, $resolved, $rules),
-            SchemaType::ARRAY => $this->arrayInputField($name, $resolved, $rules, $pointer),
-            SchemaType::OBJECT => throw new UnmappableSchemaException(
-                $pointer,
-                'nested objects in inputs are not yet supported.',
-            ),
+            SchemaType::ARRAY => $this->arrayInputField($document, $name, $resolved, $rules, $pointer, $depth),
+            SchemaType::OBJECT => $this->objectInputField($document, $name, $resolved, $rules, $pointer, $depth),
             default => throw new UnmappableSchemaException(
                 $pointer,
                 \sprintf("unsupported input kind '%s'.", $resolved->kind),
             ),
         };
+    }
+
+    /**
+     * A nested object becomes `{type: object, rules, fields: [...]}` where
+     * `fields` is the recursively-mapped child property list. Symmetric with
+     * the forward {@see \Altair\Scaffold\Emitter\TypeMapper::objectSchema()}.
+     *
+     * @param  list<string>          $rules
+     * @return array<string, mixed>
+     */
+    private function objectInputField(OpenApiDocument $document, string $name, SchemaType $schema, array $rules, string $pointer, int $depth = 0): array
+    {
+        return [
+            'name' => $name,
+            'type' => 'object',
+            'rules' => $rules,
+            'fields' => $this->mapProperties($document, $schema, $pointer, $depth + 1),
+        ];
     }
 
     /**
@@ -199,13 +241,19 @@ final readonly class SchemaMapper
      * @param  list<string>          $rules
      * @return array<string, mixed>
      */
-    private function arrayInputField(string $name, SchemaType $schema, array $rules, string $pointer): array
+    private function arrayInputField(OpenApiDocument $document, string $name, SchemaType $schema, array $rules, string $pointer, int $depth = 0): array
     {
-        if ($schema->items instanceof SchemaType && $schema->items->kind === SchemaType::OBJECT) {
-            throw new UnmappableSchemaException(
-                $pointer . '/items',
-                'arrays of objects are not yet supported in inputs.',
-            );
+        if ($schema->items instanceof SchemaType) {
+            $items = $this->resolveRef($document, $schema->items, $pointer . '/items');
+            if ($items->kind === SchemaType::OBJECT) {
+                // Array of objects: carry the item object's properties as `fields`.
+                return [
+                    'name' => $name,
+                    'type' => 'array',
+                    'rules' => $rules,
+                    'fields' => $this->mapProperties($document, $items, $pointer . '/items', $depth + 1),
+                ];
+            }
         }
 
         return [

--- a/src/Altair/Scaffold/Spec/Parser.php
+++ b/src/Altair/Scaffold/Spec/Parser.php
@@ -275,27 +275,48 @@ class Parser
     {
         $inputs = [];
         foreach ($data as $name => $raw) {
-            if (!\is_array($raw)) {
-                throw new SpecParseException(\sprintf("Input field '%s' must be a map.", $name));
-            }
-
-            $rules = $raw['rules'] ?? [];
-            if (!\is_array($rules)) {
-                throw new SpecParseException(\sprintf("Input field '%s' rules must be a list.", $name));
-            }
-
-            $inputs[] = new InputFieldSpec(
-                name: (string) $name,
-                type: (string) ($raw['type'] ?? 'string'),
-                rules: array_values(array_map(strval(...), $rules)),
-                sensitive: (bool) ($raw['sensitive'] ?? false),
-                of: isset($raw['of']) ? (string) $raw['of'] : null,
-                default: $raw['default'] ?? null,
-                hasDefault: \array_key_exists('default', $raw),
-            );
+            $inputs[] = $this->parseInputField((string) $name, $raw);
         }
 
         return $inputs;
+    }
+
+    /**
+     * Parses one input field, recursing into `fields:` for nested objects and
+     * arrays of objects so the whole input tree becomes {@see InputFieldSpec}s.
+     */
+    private function parseInputField(string $name, mixed $raw): InputFieldSpec
+    {
+        if (!\is_array($raw)) {
+            throw new SpecParseException(\sprintf("Input field '%s' must be a map.", $name));
+        }
+
+        $rules = $raw['rules'] ?? [];
+        if (!\is_array($rules)) {
+            throw new SpecParseException(\sprintf("Input field '%s' rules must be a list.", $name));
+        }
+
+        $fields = [];
+        if (isset($raw['fields'])) {
+            if (!\is_array($raw['fields'])) {
+                throw new SpecParseException(\sprintf("Input field '%s' fields must be a map.", $name));
+            }
+
+            foreach ($raw['fields'] as $childName => $childRaw) {
+                $fields[] = $this->parseInputField((string) $childName, $childRaw);
+            }
+        }
+
+        return new InputFieldSpec(
+            name: $name,
+            type: (string) ($raw['type'] ?? 'string'),
+            rules: array_values(array_map(strval(...), $rules)),
+            sensitive: (bool) ($raw['sensitive'] ?? false),
+            of: isset($raw['of']) ? (string) $raw['of'] : null,
+            default: $raw['default'] ?? null,
+            hasDefault: \array_key_exists('default', $raw),
+            fields: $fields,
+        );
     }
 
     /**

--- a/src/Altair/Scaffold/Spec/Validator.php
+++ b/src/Altair/Scaffold/Spec/Validator.php
@@ -33,7 +33,7 @@ class Validator
 {
     private const array HTTP_METHODS = ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'];
 
-    private const array SCALAR_TYPES = ['string', 'int', 'integer', 'float', 'bool', 'boolean', 'enum', 'array'];
+    private const array ALLOWED_INPUT_TYPES = ['string', 'int', 'integer', 'float', 'bool', 'boolean', 'enum', 'array', 'object'];
 
     /**
      * Column types accepted in `persistence.entity.fields[].type`. Mirrors
@@ -231,7 +231,7 @@ class Validator
     {
         $errors = [];
 
-        if (!\in_array($input->type, self::SCALAR_TYPES, true)) {
+        if (!\in_array($input->type, self::ALLOWED_INPUT_TYPES, true)) {
             $errors[] = \sprintf("input '%s' has unknown type '%s'.", $input->name, $input->type);
         }
 
@@ -244,6 +244,12 @@ class Validator
             if (!\in_array($ruleName, self::KNOWN_RULES, true)) {
                 $errors[] = \sprintf("input '%s' uses unknown validation rule '%s'.", $input->name, $rule);
             }
+        }
+
+        // Nested objects / arrays of objects validate their child fields the
+        // same way, so a bad type or rule deep in the tree still surfaces.
+        foreach ($input->fields as $child) {
+            array_push($errors, ...$this->validateInput($child));
         }
 
         return $errors;

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -160,7 +160,7 @@ final class OpenApiImportRunnerTest extends TestCase
                           type: object
                           properties:
                             address:
-                              type: object
+                              $ref: '#/components/schemas/Missing'
                           required: [address]
                   responses:
                     '201': { description: ok }
@@ -221,14 +221,57 @@ final class OpenApiImportRunnerTest extends TestCase
         $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
             documentPath: $documentPath,
             projectRoot: $this->sandbox,
-            skipUnmappable: true,
             dryRun: true,
+            skipUnmappable: true,
         ));
 
         self::assertTrue($receipt->ok);
         self::assertSame(['api/users/create.yaml'], $receipt->specsWritten);
         self::assertNotEmpty($receipt->unmapped);
         self::assertFileDoesNotExist($this->sandbox . '/api/users/create.yaml');
+    }
+
+    public function testNestedObjectBodyImportsToRecursiveFieldsSpec(): void
+    {
+        $documentPath = $this->sandbox . '/openapi.yaml';
+        file_put_contents($documentPath, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets, version: 1.0.0 }
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  summary: Create a pet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [name]
+                          properties:
+                            name: { type: string }
+                            category:
+                              type: object
+                              properties:
+                                id: { type: integer }
+                                name: { type: string }
+                  responses:
+                    '201': { description: Created }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertSame([], $receipt->unmapped);
+
+        $spec = Yaml::parseFile($this->sandbox . '/api/pets/create.yaml');
+        self::assertSame('object', $spec['input']['category']['type']);
+        self::assertArrayHasKey('id', $spec['input']['category']['fields']);
+        self::assertArrayHasKey('name', $spec['input']['category']['fields']);
     }
 
     public function testSkipUnmappableWarnsWhenEveryOperationIsUnmappable(): void
@@ -249,7 +292,7 @@ final class OpenApiImportRunnerTest extends TestCase
                           type: object
                           required: [category]
                           properties:
-                            category: { type: object }
+                            category: { $ref: '#/components/schemas/Missing' }
                   responses:
                     '201': { description: ok }
             YAML);
@@ -370,8 +413,8 @@ final class OpenApiImportRunnerTest extends TestCase
 
     /**
      * A document mixing one fully-mappable operation (POST /users, scalar body)
-     * with one that cannot be expressed in Altair's scalar-only input layer
-     * (POST /pets, whose body carries a nested `category` object).
+     * with one that cannot be expressed as an Altair spec (POST /pets, whose
+     * body carries a dangling `$ref` to an undefined schema).
      */
     private function writeMixedOpenApi(): string
     {
@@ -411,10 +454,7 @@ final class OpenApiImportRunnerTest extends TestCase
                           properties:
                             name: { type: string }
                             category:
-                              type: object
-                              properties:
-                                id: { type: integer }
-                                name: { type: string }
+                              $ref: '#/components/schemas/Missing'
                   responses:
                     '201': { description: Created }
             YAML);

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -176,6 +176,96 @@ final class OpenApiImportRunnerTest extends TestCase
         self::assertStringContainsString('address', $receipt->unmapped[0]['pointer']);
     }
 
+    public function testSkipUnmappableImportsMappableOperationsAndSkipsRest(): void
+    {
+        $documentPath = $this->writeMixedOpenApi();
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+            skipUnmappable: true,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertSame(['api/users/create.yaml'], $receipt->specsWritten);
+        self::assertFileExists($this->sandbox . '/api/users/create.yaml');
+        self::assertFileDoesNotExist($this->sandbox . '/api/pets/create.yaml');
+
+        self::assertNotEmpty($receipt->unmapped);
+        self::assertStringContainsString('category', $receipt->unmapped[0]['pointer']);
+        // The skipped operation is surfaced as a human-readable warning naming the method+path.
+        self::assertNotEmpty($receipt->warnings);
+        self::assertStringContainsString('POST /pets', implode("\n", $receipt->warnings));
+    }
+
+    public function testWithoutSkipUnmappableMixedDocumentFailsAndWritesNothing(): void
+    {
+        $documentPath = $this->writeMixedOpenApi();
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertFalse($receipt->ok);
+        self::assertSame([], $receipt->specsWritten);
+        // Fail-fast: the mappable spec must not be written when an unmappable one aborts the run.
+        self::assertFileDoesNotExist($this->sandbox . '/api/users/create.yaml');
+        self::assertStringContainsString('category', $receipt->unmapped[0]['pointer']);
+    }
+
+    public function testSkipUnmappableDryRunReportsPlannedAndUnmappedWithoutWriting(): void
+    {
+        $documentPath = $this->writeMixedOpenApi();
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+            skipUnmappable: true,
+            dryRun: true,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertSame(['api/users/create.yaml'], $receipt->specsWritten);
+        self::assertNotEmpty($receipt->unmapped);
+        self::assertFileDoesNotExist($this->sandbox . '/api/users/create.yaml');
+    }
+
+    public function testSkipUnmappableWarnsWhenEveryOperationIsUnmappable(): void
+    {
+        $documentPath = $this->sandbox . '/openapi.yaml';
+        file_put_contents($documentPath, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: AllBad, version: 1.0.0 }
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [category]
+                          properties:
+                            category: { type: object }
+                  responses:
+                    '201': { description: ok }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+            skipUnmappable: true,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertSame([], $receipt->specsWritten);
+        self::assertNotEmpty($receipt->unmapped);
+        self::assertStringContainsString('every operation was unmappable', implode("\n", $receipt->warnings));
+    }
+
     public function testReportsMissingDocument(): void
     {
         $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
@@ -273,6 +363,60 @@ final class OpenApiImportRunnerTest extends TestCase
                             properties:
                               id: { type: string }
                               email: { type: string }
+            YAML);
+
+        return $path;
+    }
+
+    /**
+     * A document mixing one fully-mappable operation (POST /users, scalar body)
+     * with one that cannot be expressed in Altair's scalar-only input layer
+     * (POST /pets, whose body carries a nested `category` object).
+     */
+    private function writeMixedOpenApi(): string
+    {
+        $path = $this->sandbox . '/openapi.yaml';
+        file_put_contents($path, <<<'YAML'
+            openapi: 3.1.0
+            info:
+              title: Mixed API
+              version: 1.0.0
+            paths:
+              /users:
+                post:
+                  operationId: createUser
+                  summary: Create a new user
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [email]
+                          properties:
+                            email: { type: string }
+                  responses:
+                    '201': { description: Created }
+              /pets:
+                post:
+                  operationId: createPet
+                  summary: Create a new pet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [category]
+                          properties:
+                            name: { type: string }
+                            category:
+                              type: object
+                              properties:
+                                id: { type: integer }
+                                name: { type: string }
+                  responses:
+                    '201': { description: Created }
             YAML);
 
         return $path;

--- a/tests/Scaffold/Cli/OpenApiRoundtripRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiRoundtripRunnerTest.php
@@ -242,6 +242,50 @@ final class OpenApiRoundtripRunnerTest extends TestCase
         self::assertSame('status_drift', RoundtripDifference::KIND_STATUS_DRIFT);
     }
 
+    public function testCleanRoundtripWithNestedObjectAndArrayOfObjects(): void
+    {
+        // OpenAPI -> Altair spec (recursive fields) -> OpenAPI must keep the
+        // operation; the nested body exercises the reverse mapper, the parser,
+        // and the forward emitter end to end without erroring or dropping it.
+        $documentPath = $this->writeDocument(<<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets, version: 1.0 }
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  summary: Create a pet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          type: object
+                          required: [name]
+                          properties:
+                            name: { type: string }
+                            category:
+                              type: object
+                              properties:
+                                id: { type: integer }
+                                name: { type: string }
+                            tags:
+                              type: array
+                              items:
+                                type: object
+                                properties:
+                                  id: { type: integer }
+                  responses:
+                    '201': { description: Created }
+            YAML);
+
+        $receipt = (new OpenApiRoundtripRunner())->run(new OpenApiRoundtripOptions($documentPath));
+
+        self::assertTrue($receipt->clean, 'differences: ' . $receipt->toJson());
+        self::assertSame(1, $receipt->operationsCompared);
+        self::assertNull($receipt->error);
+    }
+
     private function writeDocument(string $yaml): string
     {
         $path = $this->sandbox . '/openapi-' . bin2hex(random_bytes(4)) . '.yaml';

--- a/tests/Scaffold/Emitter/InputEmitterTest.php
+++ b/tests/Scaffold/Emitter/InputEmitterTest.php
@@ -6,12 +6,57 @@ namespace Altair\Tests\Scaffold\Emitter;
 
 use Altair\Scaffold\Emitter\EmittedFileKind;
 use Altair\Scaffold\Emitter\InputEmitter;
+use Altair\Scaffold\Spec\Parser;
 use Altair\Tests\Scaffold\Support\SpecFixture;
 use Altair\Tests\Scaffold\Support\Snapshots;
 use PHPUnit\Framework\TestCase;
 
 final class InputEmitterTest extends TestCase
 {
+    public function testEmitsArrayWithShapePhpdocForNestedObject(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint: { method: POST, path: /pets, summary: Create pet }
+            input:
+              name: { type: string, rules: [required] }
+              category:
+                type: object
+                rules: [required]
+                fields:
+                  id: { type: int }
+                  name: { type: string, rules: [required] }
+            domain: { class: App\Pet\CreatePet }
+            YAML;
+        $spec = (new Parser())->parseString($yaml);
+
+        $file = (new InputEmitter())->emit($spec);
+
+        self::assertStringContainsString('public array $category', $file->contents);
+        self::assertStringContainsString('@param array{id: int, name: string} $category', $file->contents);
+        // Scalar siblings keep their native type, no shape doc.
+        self::assertStringContainsString('public string $name', $file->contents);
+    }
+
+    public function testEmitsListShapePhpdocForArrayOfObjects(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint: { method: POST, path: /pets, summary: Create pet }
+            input:
+              tags:
+                type: array
+                fields:
+                  id: { type: int }
+            domain: { class: App\Pet\CreatePet }
+            YAML;
+        $spec = (new Parser())->parseString($yaml);
+
+        $file = (new InputEmitter())->emit($spec);
+
+        self::assertStringContainsString('public ?array $tags = null', $file->contents);
+        self::assertStringContainsString('@param list<array{id: int}> $tags', $file->contents);
+    }
+
+
     public function testEmitsReadonlyDtoWithFields(): void
     {
         $file = (new InputEmitter())->emit(SpecFixture::createUser());

--- a/tests/Scaffold/Spec/Emitter/EmitterTest.php
+++ b/tests/Scaffold/Spec/Emitter/EmitterTest.php
@@ -116,8 +116,9 @@ final class EmitterTest extends TestCase
                     method: 'POST',
                     path: '/users',
                     pathParameters: [],
+                    // Nested objects now map; a dangling $ref is still unmappable.
                     requestBody: SchemaType::object([
-                        'address' => ['schema' => SchemaType::object([]), 'required' => true],
+                        'address' => ['schema' => SchemaType::ref('Missing'), 'required' => true],
                     ]),
                     responses: [],
                 ),

--- a/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
@@ -68,27 +68,97 @@ final class SchemaMapperTest extends TestCase
         ], $fields);
     }
 
-    public function testNestedObjectInputRaises(): void
+    public function testNestedObjectInputMapsToRecursiveFields(): void
     {
         $body = SchemaType::object([
-            'address' => ['schema' => SchemaType::object([]), 'required' => true],
+            'category' => ['schema' => SchemaType::object([
+                'id' => ['schema' => SchemaType::scalar('integer'), 'required' => false],
+                'name' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+            ]), 'required' => true],
         ]);
-        $operation = $this->operation('POST', '/users', requestBody: $body);
+        $operation = $this->operation('POST', '/pets', requestBody: $body);
 
-        $this->expectException(UnmappableSchemaException::class);
-        $this->expectExceptionMessage('nested objects in inputs are not yet supported');
-        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            [
+                'name' => 'category',
+                'type' => 'object',
+                'rules' => ['required'],
+                'fields' => [
+                    ['name' => 'id', 'type' => 'int', 'rules' => []],
+                    ['name' => 'name', 'type' => 'string', 'rules' => ['required']],
+                ],
+            ],
+        ], $fields);
     }
 
-    public function testArrayOfObjectsInputRaises(): void
+    public function testArrayOfObjectsInputMapsToItemFields(): void
     {
         $body = SchemaType::object([
-            'items' => ['schema' => SchemaType::arrayOf(SchemaType::object([])), 'required' => true],
+            'tags' => ['schema' => SchemaType::arrayOf(SchemaType::object([
+                'id' => ['schema' => SchemaType::scalar('integer'), 'required' => false],
+            ])), 'required' => false],
         ]);
-        $operation = $this->operation('POST', '/users', requestBody: $body);
+        $operation = $this->operation('POST', '/pets', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            [
+                'name' => 'tags',
+                'type' => 'array',
+                'rules' => [],
+                'fields' => [
+                    ['name' => 'id', 'type' => 'int', 'rules' => []],
+                ],
+            ],
+        ], $fields);
+    }
+
+    public function testArrayOfObjectsResolvesItemRef(): void
+    {
+        $body = SchemaType::object([
+            'tags' => ['schema' => SchemaType::arrayOf(SchemaType::ref('Tag')), 'required' => false],
+        ]);
+        $operation = $this->operation('POST', '/pets', requestBody: $body);
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [],
+            namedSchemas: ['Tag' => SchemaType::object([
+                'id' => ['schema' => SchemaType::scalar('integer'), 'required' => false],
+            ])],
+        );
+
+        $fields = (new SchemaMapper())->inputFields($document, $operation);
+
+        self::assertSame([
+            [
+                'name' => 'tags',
+                'type' => 'array',
+                'rules' => [],
+                'fields' => [
+                    ['name' => 'id', 'type' => 'int', 'rules' => []],
+                ],
+            ],
+        ], $fields);
+    }
+
+    public function testDeeplyNestedInlineObjectRaisesInsteadOfStackOverflow(): void
+    {
+        // Build an inline object nested far deeper than MAX_NESTING_DEPTH so the
+        // mapper raises a clean exception rather than exhausting the call stack.
+        $leaf = SchemaType::scalar('string');
+        $schema = SchemaType::object(['leaf' => ['schema' => $leaf, 'required' => false]]);
+        for ($i = 0; $i < 64; $i++) {
+            $schema = SchemaType::object(['child' => ['schema' => $schema, 'required' => false]]);
+        }
+
+        $operation = $this->operation('POST', '/deep', requestBody: $schema);
 
         $this->expectException(UnmappableSchemaException::class);
-        $this->expectExceptionMessage('arrays of objects are not yet supported');
+        $this->expectExceptionMessage('nesting exceeds the maximum depth');
         (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
     }
 
@@ -214,8 +284,10 @@ final class SchemaMapperTest extends TestCase
 
     public function testJsonPointerLocatesOffendingProperty(): void
     {
+        // A dangling $ref nested in a property is still unmappable; the pointer
+        // must locate the offending property inside the request body.
         $body = SchemaType::object([
-            'address' => ['schema' => SchemaType::object([]), 'required' => true],
+            'address' => ['schema' => SchemaType::ref('Missing'), 'required' => true],
         ]);
         $operation = $this->operation('POST', '/users', requestBody: $body);
 

--- a/tests/Scaffold/Spec/ParserTest.php
+++ b/tests/Scaffold/Spec/ParserTest.php
@@ -62,6 +62,42 @@ final class ParserTest extends TestCase
         self::assertSame('App\\User\\CreateUser', $spec->domain->class);
     }
 
+    public function testParsesNestedObjectAndArrayOfObjectInputs(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint: { method: POST, path: /pets, summary: Create pet }
+            input:
+              category:
+                type: object
+                rules: [required]
+                fields:
+                  id: { type: int }
+                  name: { type: string, rules: [required] }
+              tags:
+                type: array
+                fields:
+                  id: { type: int }
+            domain: { class: App\Pet\CreatePet }
+            YAML;
+
+        $spec = (new Parser())->parseString($yaml);
+
+        self::assertCount(2, $spec->inputs);
+
+        $category = $spec->inputs[0];
+        self::assertSame('category', $category->name);
+        self::assertTrue($category->isObject());
+        self::assertTrue($category->isRequired());
+        self::assertCount(2, $category->fields);
+        self::assertSame('id', $category->fields[0]->name);
+        self::assertSame('int', $category->fields[0]->type);
+        self::assertTrue($category->fields[1]->isRequired());
+
+        $tags = $spec->inputs[1];
+        self::assertTrue($tags->isArrayOfObjects());
+        self::assertSame('id', $tags->fields[0]->name);
+    }
+
     public function testMissingEndpointKeyRaises(): void
     {
         $this->expectException(SpecParseException::class);

--- a/tests/Scaffold/Spec/ValidatorTest.php
+++ b/tests/Scaffold/Spec/ValidatorTest.php
@@ -52,6 +52,42 @@ final class ValidatorTest extends TestCase
         self::assertStringContainsString('definitely-not-a-rule', $errors[0]);
     }
 
+    public function testNestedObjectInputYieldsNoErrors(): void
+    {
+        $spec = new Spec(
+            endpoint: new EndpointSpec('POST', '/pets', '', []),
+            inputs: [
+                new InputFieldSpec('category', 'object', ['required'], fields: [
+                    new InputFieldSpec('id', 'int'),
+                    new InputFieldSpec('name', 'string', ['required']),
+                ]),
+            ],
+            outputs: [],
+            domain: new DomainSpec('App\\Pet\\CreatePet'),
+        );
+
+        self::assertSame([], (new Validator())->collectErrors($spec));
+    }
+
+    public function testNestedFieldUnknownTypeReported(): void
+    {
+        $spec = new Spec(
+            endpoint: new EndpointSpec('POST', '/pets', '', []),
+            inputs: [
+                new InputFieldSpec('category', 'object', fields: [
+                    new InputFieldSpec('id', 'definitely-not-a-type'),
+                ]),
+            ],
+            outputs: [],
+            domain: new DomainSpec('App\\Pet\\CreatePet'),
+        );
+
+        $errors = (new Validator())->collectErrors($spec);
+
+        self::assertNotEmpty($errors);
+        self::assertStringContainsString('definitely-not-a-type', $errors[0]);
+    }
+
     public function testNonClassDomainReported(): void
     {
         $spec = new Spec(


### PR DESCRIPTION
Closes #203.

## Summary

Makes nested objects and arrays-of-objects first-class in the `input:` block of Altair specs — **bidirectionally** (OpenAPI import *and* export) and **round-trippably**. The canonical **Swagger Petstore now imports with zero skips**, and `openapi:roundtrip --check` stays clean.

Ships in two commits:

1. **`--skip-unmappable` for `openapi:import`** (graceful degradation). A single unmappable schema no longer aborts the whole import — mappable operations import, the rest land in `unmapped[]` / `warnings[]` and the run still succeeds. Default behaviour stays fail-fast.
2. **Nested objects & arrays-of-objects in inputs** (the real fix).

## The problem

Altair's input layer was scalar-only, so a nested request-body object (or an array of objects) couldn't be expressed as an Altair spec. `openapi:import` aborted on the most common real-world document:

```
openapi:import failed: Unmappable schema at
  #/paths/~1pet/put/.../category: nested objects in inputs are not yet supported.
```

## Representation

A nested object is `type: object` with a recursive `fields:` map; an array of objects is `type: array` with a `fields:` map describing the item:

```yaml
input:
  category:
    type: object
    fields: { id: { type: int }, name: { type: string } }
  tags:
    type: array
    fields: { id: { type: int } }
```

The generated Input DTO types both as `array` with a PHPDoc shape (the one case CLAUDE.md warrants PHPDoc):

```php
/**
 * @param array{id: int, name: string} $category
 * @param list<array{id: int, name: string}> $tags
 */
```

This matches how the codebase already represents richness (response bodies, persistence/queue fields are flat; nesting renders as `array`), keeps one Input class per endpoint, and round-trips. Typed nested value objects remain a possible future opt-in.

## Changes

| File | Change |
|---|---|
| `Spec/Ast/InputFieldSpec` | recursive `fields` + `isObject()` / `isArrayOfObjects()` |
| `Spec/Parser` | `parseInputField()` recurses into `fields:` |
| `Spec/Validator` | accepts `object`, recurses into child fields (`SCALAR_TYPES` → `ALLOWED_INPUT_TYPES`) |
| `Emitter/TypeMapper` | `object` → `array` (PHP); recursive `objectSchema`/`arraySchema` carry per-child `required` into OpenAPI |
| `Emitter/InputEmitter` | array-shape PHPDoc for nested params; scalar DTOs byte-identical |
| `Spec/Emitter/SchemaMapper` | replaced the OBJECT / array-of-objects throws with recursive mapping; arrays resolve item `$ref`s; `MAX_NESTING_DEPTH` guard raises a clean exception on pathological inline nesting instead of a stack overflow |
| `Spec/Emitter/OperationMapper` | `inputBlock()` recurses into nested `fields` |
| `Cli/{OpenApiImportRunner,OpenApiImportOptions,OpenApiImportCommand,ImportPlan}` | `--skip-unmappable` |
| `docs/guides/openapi/import.md` | nested support + `--skip-unmappable` |

## Test plan

- [x] TDD throughout — reverse mapper, forward TypeMapper, parser, validator, InputEmitter, import, round-trip, depth guard.
- [x] Reverse: nested object → recursive `fields`; array-of-objects (inline + `$ref` items) → item `fields`.
- [x] Forward: nested `required` flags propagate into OpenAPI `properties`/`required`.
- [x] Round-trip: nested-object doc → spec → OpenAPI is clean (`OpenApiRoundtripRunnerTest`).
- [x] Depth guard: a 64-deep inline object raises `UnmappableSchemaException` rather than overflowing the stack.
- [x] Scalar-only `CreateUserInput` golden snapshot unchanged.
- [x] End-to-end: real Petstore (`$ref` category + array-of-`$ref` tags) imports with **0 skips**, `openapi:roundtrip --check` clean, scaffolds, `spec:lint` reports no drift.
- [x] CS + PHPStan + full-tree Rector (cache-free) + full suite green (only pre-existing env-dependent tests skip/error).

## Known follow-ups (out of scope here)

1. **Nested validation rules** — `rules()` covers top-level fields and each object's own `required`; deep per-member rules are not auto-generated yet. Held back until it's confirmed `Altair\Validation` consumes dot-notation keys (emitting rules it ignores would be a false sense of validation). Documented in `import.md`.
2. **Constructor param ordering** — a *pre-existing* importer quirk surfaced by Petstore: an optional field emitted before a required one triggers PHP's "required-after-optional" deprecation. Affects any optional-before-required import; deserves its own small PR (sort required-first in `InputEmitter`).
