### PR TITLE
fix(scaffold): order Input DTO constructor params required-first

### DIFF
--- a/src/Altair/Scaffold/Emitter/InputEmitter.php
+++ b/src/Altair/Scaffold/Emitter/InputEmitter.php
@@ -64,10 +64,11 @@ class InputEmitter
             return "    public function __construct() {}\n";
         }
 
-        $lines = $this->renderConstructorDocblock($spec);
+        $fields = $this->orderedInputs($spec);
+        $lines = $this->renderConstructorDocblock($fields);
         $lines[] = '    public function __construct(';
-        $last = \count($spec->inputs) - 1;
-        foreach ($spec->inputs as $i => $field) {
+        $last = \count($fields) - 1;
+        foreach ($fields as $i => $field) {
             $type = $this->typeMapper->toPhpType($field);
             $nullable = $field->isRequired() ? '' : '?';
             $default = $this->renderDefault($field);
@@ -81,17 +82,43 @@ class InputEmitter
     }
 
     /**
+     * Orders fields so required (no-default) params precede optional ones,
+     * preserving spec order within each group. PHP raises a deprecation when a
+     * required parameter follows an optional one, which happens whenever an
+     * imported spec lists an optional field before a required one. This only
+     * reorders the generated PHP signature — the spec, OpenAPI `properties`,
+     * and round-trip order are unaffected.
+     *
+     * @return list<InputFieldSpec>
+     */
+    private function orderedInputs(Spec $spec): array
+    {
+        $required = [];
+        $optional = [];
+        foreach ($spec->inputs as $field) {
+            if ($field->isRequired() && !$field->hasDefault) {
+                $required[] = $field;
+            } else {
+                $optional[] = $field;
+            }
+        }
+
+        return [...$required, ...$optional];
+    }
+
+    /**
      * Constructor-level PHPDoc lines describing the array shape of nested-object
      * and array-of-object params — the one case CLAUDE.md warrants PHPDoc (a
      * shape PHP's `array` type can't express). Empty for scalar-only inputs, so
      * those DTOs stay byte-identical to before nesting existed.
      *
+     * @param  list<InputFieldSpec> $fields
      * @return list<string>
      */
-    private function renderConstructorDocblock(Spec $spec): array
+    private function renderConstructorDocblock(array $fields): array
     {
         $params = [];
-        foreach ($spec->inputs as $field) {
+        foreach ($fields as $field) {
             $shape = $this->arrayShape($field);
             if ($shape !== null) {
                 $params[] = \sprintf('     * @param %s $%s', $shape, $field->name);

--- a/tests/Scaffold/Emitter/InputEmitterTest.php
+++ b/tests/Scaffold/Emitter/InputEmitterTest.php
@@ -13,6 +13,37 @@ use PHPUnit\Framework\TestCase;
 
 final class InputEmitterTest extends TestCase
 {
+    public function testOrdersRequiredConstructorParamsBeforeOptional(): void
+    {
+        // Spec lists an optional field before a required one — the generated
+        // constructor must still emit required (no-default) params first, or PHP
+        // raises a "required parameter after optional" deprecation.
+        $yaml = <<<'YAML'
+            endpoint: { method: POST, path: /users, summary: Create user }
+            input:
+              nickname: { type: string }
+              email: { type: string, rules: [required] }
+              age: { type: int }
+            domain: { class: App\User\CreateUser }
+            YAML;
+        $spec = (new Parser())->parseString($yaml);
+
+        $file = (new InputEmitter())->emit($spec);
+
+        $emailPos = strpos($file->contents, 'public string $email');
+        $nicknamePos = strpos($file->contents, 'public ?string $nickname = null');
+        $agePos = strpos($file->contents, 'public ?int $age = null');
+
+        self::assertNotFalse($emailPos);
+        self::assertNotFalse($nicknamePos);
+        self::assertNotFalse($agePos);
+        // Required first.
+        self::assertLessThan($nicknamePos, $emailPos, 'required $email must precede optional $nickname');
+        self::assertLessThan($agePos, $emailPos, 'required $email must precede optional $age');
+        // Optionals keep their relative spec order (nickname before age).
+        self::assertLessThan($agePos, $nicknamePos);
+    }
+
     public function testEmitsArrayWithShapePhpdocForNestedObject(): void
     {
         $yaml = <<<'YAML'


### PR DESCRIPTION
Closes #205.

## Summary

`InputEmitter` rendered the Input DTO constructor in spec order. When a spec (typically an imported OpenAPI doc) lists an optional field before a required one, the generated constructor placed an optional param before a required one — which PHP deprecates ("required parameter after optional").

Surfaced by the Swagger Petstore (#203 / #204): `Pet` lists optional `id` before required `name`:

```php
// before
public function __construct(public ?int $id = null, public string $name, ...)  // deprecation

// after
public function __construct(public string $name, public ?int $id = null, ...)
```

## Fix

Order constructor params **required-first** (no PHP default), then optional, preserving spec order within each group. Generated-PHP-only — the spec input order, OpenAPI `properties` order, and round-trip are unchanged.

**Safe:** `Altair\Http\Input\DtoInputHydrator` hydrates Inputs by **parameter name** via reflection, never positionally, so reordering the signature cannot break hydration. No generated or framework code constructs an Input positionally.

## Test plan

- [x] New TDD test: a spec with optional-before-required emits the required param first; optionals keep relative order.
- [x] End-to-end: the generated Petstore `UpdatePetInput` now leads with `string $name`, and loads under `error_reporting=E_ALL` with **no deprecation**.
- [x] `CreateUserInput` golden snapshot byte-identical (all-required → no reorder).
- [x] Array-shape `@param` PHPDoc order follows the reordered constructor.
- [x] CS + PHPStan + Rector + full suite green; `.agent/` byte-stable.