### PR TITLE
docs: refresh AGENT.md + CLAUDE.md to current state

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -9,7 +9,7 @@ This file is the source of truth. Tool-specific entry points (`CLAUDE.md`) point
 ## 1. Project at a glance
 
 - **Name:** `univeros/framework` — PHP framework, MIT licensed.
-- **Root namespace:** `Altair\*` (legacy reasons; the Composer package is `univeros/*` and 18 sub-packages are bundled via `replace`).
+- **Root namespace:** `Altair\*` (legacy reasons; the Composer package is `univeros/*` and 40 sub-packages are bundled via `replace`).
 - **Origin:** Started ~7 years ago as a learning vehicle. Originally targeted PHP 7.0-7.2 and PSR-3/6/7/11/15/16 v1.
 - **Current target:** PHP **8.3+** (modernization started 2026-05).
 - **Architecture style:** Library-first / framework-agnostic — every sub-package is meant to be usable standalone behind PSR interfaces.
@@ -23,33 +23,50 @@ This file is the source of truth. Tool-specific entry points (`CLAUDE.md`) point
 ├── .github/workflows/ci.yml      ← CI (PHP 8.3 + 8.4 matrix, PHPStan, CS-Fixer, Rector, Codecov)
 ├── .php-cs-fixer.dist.php        ← PHP-CS-Fixer v3 config (@PER-CS2.0, @PHP83Migration)
 ├── phpunit.xml.dist              ← PHPUnit 11 config
-├── phpstan.neon.dist             ← PHPStan config (start at level 5, raise gradually)
+├── phpstan.neon.dist             ← PHPStan config (level 8, no baseline)
 ├── rector.php                    ← Rector config (PHP 8.3 + code-quality + dead-code sets)
 ├── composer.json                 ← Root manifest (monorepo via `replace`)
 ├── src/Altair/
-│   ├── Cache/         ← PSR-6 + PSR-16 cache; storage adapters for filesystem/Memcached/Redis/Predis
-│   ├── Common/        ← Cross-cutting helpers (intl, primitives)
-│   ├── Configuration/ ← Dotenv-based config + container bindings
-│   ├── Container/     ← DI container (PSR-11)
-│   ├── Cookie/        ← Cookie value objects (PSR-7 aware)
-│   ├── Courier/       ← Mail/transport abstraction
-│   ├── Data/          ← Entity/DTO base + attribute mutators
-│   ├── Events/        ← Append-only mutation event log (.altair/events.jsonl) + CLI (events:tail/show/since/checkpoint/compact)
-│   ├── Filesystem/    ← Flysystem v3 adapters & configuration
-│   ├── Happen/        ← Event dispatcher
-│   ├── Http/          ← PSR-7/15 stack: routing (FastRoute), middleware, CORS, JWT, content negotiation
-│   ├── Introspection/ ← "What's wired into this project right now?" CLI inspectors (container:inspect, routes:list, listeners:list, middleware:list, manifest:diff, spec:list/show, config:dump)
-│   ├── Messaging/     ← MessageBus + worker over Symfony Messenger, attribute-driven handlers, scaffold queue: block
-│   ├── Middleware/    ← PSR-15 middleware primitives
-│   ├── Module/        ← Pluggable extension modules: one class self-registers a feature's routes/entities/migrations (bin/altair module:new)
-│   ├── Persistence/   ← Repository/UnitOfWork over Cycle ORM v2 + migration CLI
-│   ├── Sanitation/    ← Input sanitation rules
-│   ├── Scaffold/      ← YAML-spec-to-code generator (bin/altair spec:scaffold), with optional persistence: and queue: blocks; Journal sub-feature (journal:*) for rewindable scaffold ops; SDK emitters (spec:emit-sdk typescript|python) for typed clients
-│   ├── Security/      ← Hashing, encryption, CSRF tokens
-│   ├── Session/       ← Session handlers (file, Redis, Mongo)
-│   ├── Structure/     ← Collection primitives (Map, Set, etc.)
-│   ├── TestReporter/  ← AI-native PHPUnit Extension: JSON output with failures mapped to source-under-test (`bin/altair test --format=json`)
-│   └── Validation/    ← Validation rules + middleware
+│   ├── AgentSpec/     ← AI-readable manifests describing every package + the host app (.agent/, manifest:generate)
+│   ├── Bootstrap/     ← bin/altair new — materialises a runnable API from the skeleton template
+│   ├── Cache/         ← PSR-6 + PSR-16 cache; filesystem/Redis/Predis/Memcached backends
+│   ├── Cli/           ← Attribute-driven CLI on top of Symfony Console
+│   ├── Common/        ← Pure-PHP utilities (string/array helpers, key-value registry) shared everywhere
+│   ├── Configuration/ ← Container-aware config; loads .env (phpdotenv 5) + wires bindings
+│   ├── Container/     ← Reflection-backed PSR-11 DI: auto-wiring, contextual bindings, tags, decorators, scopes
+│   ├── Cookie/        ← Immutable HTTP cookie value objects + PSR-7 read/write manager
+│   ├── Courier/       ← Synchronous command bus routing immutable messages to handlers via middleware
+│   ├── Data/          ← Immutable-by-default data objects: JSON/Serializable, Carbon date mutators
+│   ├── Doctor/        ← bin/altair doctor — health checks; agent-actionable JSON + human text
+│   ├── Eval/          ← bin/altair eval — sandboxed PHP-snippet runner inside the project container
+│   ├── Events/        ← Append-only mutation event log (.altair/events.jsonl) — session memory; events:*
+│   ├── Examples/      ← Curated idiomatic-pattern library + CLI/MCP discovery tools
+│   ├── Filesystem/    ← Flysystem v3 wrapper: local/S3/SFTP/FTP/Dropbox behind one API
+│   ├── Happen/        ← PSR-14 event dispatcher: priorities, subscribers, wildcards, batch dispatch
+│   ├── Http/          ← PSR-15 stack: Action/Domain/Input/Responder, FastRoute, content negotiation, JWT
+│   ├── Idempotency/   ← Stripe-style Idempotency-Key primitive: storage contract + adapters
+│   ├── Index/         ← bin/altair index — AST+spec symbol index (find-usages, callers, dead-code); SQLite, JSON
+│   ├── Introspection/ ← "What's wired right now?" inspectors: container/routes/listeners/middleware/specs/config
+│   ├── Logging/       ← PSR-3 logging backed by Monolog, wired from LOG_*; JSON-lines to stderr by default
+│   ├── Mcp/           ← Model Context Protocol server exposing the framework as MCP tools for agents
+│   ├── Messaging/     ← MessageBus + worker bridge over Symfony Messenger; scaffold queue: block
+│   ├── Middleware/    ← Generic typed-Payload pipeline driven by a Runner (NOT PSR-15 HTTP middleware)
+│   ├── MigrationIntelligence/ ← bin/altair db:migration-plan — safe Cycle migration plans from spec/entity diffs
+│   ├── Module/        ← Pluggable extensions: one class self-registers routes/entities/migrations (module:new)
+│   ├── Observability/ ← observability:* — native OTel-compatible spans/metrics (OTLP-JSON) + per-request middleware
+│   ├── Observatory/   ← Dev-only web monitoring panel over introspection/doctor/events/messaging/persistence
+│   ├── Persistence/   ← Repository + UnitOfWork over Cycle ORM v2 + migration CLI (db:migrate*)
+│   ├── Profiling/     ← bin/altair profile — sampling profiler (excimer/xdebug): call tree, flamegraph, diff
+│   ├── Sanitation/    ← Composable input sanitation: untrusted input → safe canonical form
+│   ├── Scaffold/      ← YAML-spec-to-code: Action/Input/Responder + OpenAPI + tests; journal, SDK emitters, openapi:import
+│   ├── Security/      ← Crypto primitives: key derivation (HKDF/PBKDF2), symmetric encryption, timing-safe MAC
+│   ├── Session/       ← Server-side sessions: file, MongoDB, PDO (MySQL/Postgres/SQLite), Redis handlers
+│   ├── Structure/     ← Typed structures (Map, Set, Vector, Deque, Queue, Stack, PriorityQueue) in pure PHP
+│   ├── Suggest/       ← bin/altair suggest — proposes refactors (dead bindings, fat ctors, routes w/o specs)
+│   ├── TestReporter/  ← AI-native PHPUnit reporter: JSON failures mapped to source-under-test
+│   ├── Tinker/        ← bin/altair tinker — PsySH REPL with the container in scope (dev tool, not an agent surface)
+│   ├── Validation/    ← Rule-based input validation — the gatekeeping counterpart to Sanitation
+│   └── Webhooks/      ← Signing, inbound-verify middleware, outbound dispatcher (retry/dead-letter/replay)
 └── tests/             ← Mirrors `src/Altair` layout. Suffix `Test.php`. Fixtures: `tests/{pkg}/fixtures.php`.
 ```
 
@@ -86,39 +103,41 @@ CI runs the same scripts on every push/PR (see `.github/workflows/ci.yml`).
 
 **PHP:** `>=8.3`. We use 8.3 features (typed class constants, `json_validate`, `#[\Override]`, readonly classes, enums, first-class callables, `match`, nullsafe, intersection/DNF types).
 
-**Core deps (current majors):**
+**Core runtime deps (current majors):**
 
-| Package | Version | Notes |
+| Package | Version | Used by / notes |
 |---|---|---|
-| `nikic/php-parser` | ^5 | Used by `univeros/scaffold` drift linter to re-parse emitted code |
-| `symfony/yaml` | ^7 | Spec parsing in `univeros/scaffold` |
-| `psr/log` | ^3 | Typed signatures |
-| `psr/container` | ^2 | Typed `get`/`has` |
-| `psr/cache` | ^3 | |
-| `psr/simple-cache` | ^3 | |
-| `psr/http-message` | ^2 | PSR-7 with return types |
-| `psr/http-server-middleware` / `psr/http-server-handler` | ^1 | PSR-15 (single-pass) |
-| `psr/http-factory` | ^1.1 | |
-| `laminas/laminas-diactoros` | ^3.5 | Replaces abandoned `zendframework/zend-diactoros` |
-| `nikic/fast-route` | ^1.3 | |
-| `relay/relay` | ^2.1 | **PSR-15** single-pass dispatcher (v1 used double-pass + `RelayBuilder` — both gone) |
-| `vlucas/phpdotenv` | ^5.6 | API changed: `Dotenv::createImmutable($path)->load()` |
-| `nesbot/carbon` | ^3.8 | |
-| `neomerx/cors-psr7` | ^3 | |
-| `willdurand/negotiation` | ^3.1 | |
-| `league/flysystem` | ^3.29 | **Major rewrite** — see §7 |
-| `micheh/psr7-cache` | ^0.5 | No newer release; review if it falls behind |
+| `psr/log` ^3 · `psr/container` ^2 · `psr/cache` ^3 · `psr/simple-cache` ^3 · `psr/clock` ^1 · `psr/event-dispatcher` ^1 | | PSR interfaces the framework implements |
+| `psr/http-message` ^2 · `psr/http-factory` ^1.1 · `psr/http-server-middleware` / `psr/http-server-handler` ^1 | | PSR-7 + PSR-15 (single-pass) |
+| `laminas/laminas-diactoros` | ^3.5 | PSR-7 implementation (replaced abandoned `zend-diactoros`) |
+| `relay/relay` | ^2.1 | PSR-15 single-pass dispatcher |
+| `nikic/fast-route` | ^1.3 | HTTP routing |
+| `neomerx/cors-psr7` ^3 · `willdurand/negotiation` ^3.1 | | CORS + content negotiation |
+| `lcobucci/jwt` | ^5.3 | HTTP JWT authentication |
+| `monolog/monolog` | ^3 | backs `univeros/logging` (PSR-3) |
+| `symfony/console` | ^7 | the `bin/altair` CLI (`univeros/cli`) |
+| `symfony/messenger` | ^7 | `univeros/messaging` bus + worker |
+| `symfony/serializer` · `symfony/uid` · `symfony/yaml` | ^7 | serialization · ULIDs (events/journal) · spec parsing |
+| `cycle/orm` + `cycle/database` `cycle/migrations` `cycle/annotated` `cycle/schema-builder` | ^2 / ^4 | `univeros/persistence` ORM bridge + migrations |
+| `nikic/php-parser` ^5 · `spiral/tokenizer` ^3.13 | | AST parsing for the scaffold drift linter + `univeros/index` |
+| `opis/json-schema` | ^2.4 | OpenAPI / spec schema validation |
+| `vlucas/phpdotenv` | ^5.6 | `.env` loading |
+| `nesbot/carbon` | ^3.8 | date mutators in `univeros/data` |
+| `league/flysystem` | ^3.29 | `univeros/filesystem` (v3) |
 
 **Dev tooling:**
 
-| Tool | Version |
-|---|---|
-| `phpunit/phpunit` | ^11.4 |
-| `phpstan/phpstan` | ^1.12 |
-| `rector/rector` | ^1.2 |
-| `friendsofphp/php-cs-fixer` | ^3.64 |
-| `squizlabs/php_codesniffer` | ^3.10 |
-| `roave/security-advisories` | dev-latest (pinned via `prefer-stable`) |
+| Tool | Version | Notes |
+|---|---|---|
+| `phpunit/phpunit` | ^11.4 | |
+| `phpstan/phpstan` | ^2.1 | level 8, **no baseline** |
+| `rector/rector` | ^2.0 | dry-run in CI's `static-analysis` job, not in `composer qa` |
+| `friendsofphp/php-cs-fixer` | ^3.64 | `@PER-CS2.0` + `@PHP83Migration` |
+| `squizlabs/php_codesniffer` | ^3.10 | |
+| `psy/psysh` | ^0.12 | powers `bin/altair tinker` |
+| `roave/security-advisories` | dev-latest | |
+
+Optional test deps gated behind extensions/services (skipped when absent): `mongodb/mongodb`, `predis/predis`, `pda/pheanstalk`, the `league/flysystem-*` adapters, and `ext-{mongodb,redis,memcached,intl,openssl}`.
 
 ---
 
@@ -228,7 +247,7 @@ vendor/bin/phpunit --testsuite "Univeros Test Suite"
 
 ## 7. Modernization status (started 2026-05)
 
-The codebase is mid-migration from PHP 7.2 / abandoned deps to PHP 8.3. Phases 1, 2, 3a–3c are **done**; Phase 3d is all but PSR-14 (tracked in [#97](https://github.com/univeros/framework/issues/97)); Phase 4 is in progress (PHPStan at level 6, burn-down tracked in [#96](https://github.com/univeros/framework/issues/96); PHPUnit attribute migration done).
+The migration from PHP 7.2 / abandoned deps to PHP 8.3 is **complete** — all phases (1, 2, 3a–3d, 4) are done. The tree targets PHP 8.3+, runs a PHP 8.3 + 8.4 CI matrix, and passes **PHPStan level 8 with no baseline**. The section below is kept as a record of what each phase changed; there is no outstanding modernization work. New work is tracked in the open issues, not here.
 
 ### Phase 1 — COMPLETE
 
@@ -279,18 +298,18 @@ Decorator middleware that depend on the next response (CORS, cache headers) must
 - `FilesystemAdapterConfiguration` no longer wires a `CachedAdapter` — Flysystem v3 removed caching from core. Wrap with a caching decorator separately if needed.
 - The `FlysystemAdapter.php` exclusion from PHPUnit coverage, PHPStan, and Rector is removed — the new implementation is testable.
 
-### Phase 3d — MOSTLY COMPLETE (targeted modern idioms)
+### Phase 3d — COMPLETE (targeted modern idioms)
 
-- Value objects → `readonly` — **done** (148 `readonly` classes in `src/`).
-- Sentinel `class const` → **enums** — **done** (8 enums in `src/`).
+- Value objects → `readonly` — **done**.
+- Sentinel `class const` → **enums** — **done**.
 - Rector-driven cleanup of PHPDoc-only types — **done** (`TYPE_DECLARATION` set applied; `rector --dry-run` clean).
-- **Remaining:** `Altair\Happen\*` PSR-14. The dep + `StoppableEventInterface` are already wired, but the dispatcher/provider are name-based, not PSR-14's object-based interfaces — tracked in [#97](https://github.com/univeros/framework/issues/97) (it's a design choice, deferred deliberately).
+- `Altair\Happen\*` PSR-14 — **done** ([#97](https://github.com/univeros/framework/issues/97)): the dispatcher/provider now implement PSR-14's object-based interfaces alongside the original name-based API.
 
-### Phase 4 — IN PROGRESS (static analysis + test attribute migration)
+### Phase 4 — COMPLETE (static analysis + test attribute migration)
 
-1. **PHPStan level 5 → 8.** Now at **level 6** (raised in [#95](https://github.com/univeros/framework/pull/95)) with a regenerated `phpstan-baseline.neon` grandfathering 746 errors (mostly missing `array<K,V>` value-type shapes). Burn-down of the baseline and the 6 → 7 → 8 raises are tracked in [#96](https://github.com/univeros/framework/issues/96). Don't hand-edit the baseline — regenerate with `vendor/bin/phpstan analyse --generate-baseline`.
-2. PHPUnit annotation → attribute migration — **done**. The suite already uses `#[DataProvider]` (157 files) / `#[CoversClass]` (43 files); the only remaining `@covers` is `tests/TestReporter/Fixtures/LegacyCoversAnnotationTest.php`, an intentional fixture exercising the test-reporter's legacy-annotation fallback.
-3. Verify coverage ≥ 80% per sub-package. (Still a standing goal.)
+1. **PHPStan level 5 → 8 — done** ([#96](https://github.com/univeros/framework/issues/96)). The tree analyses at **level 8 with no `phpstan-baseline.neon`** — the original 746-error baseline was fully burned down. The only remaining suppressions are a handful of inline `ignoreErrors` in `phpstan.neon.dist`, each with a comment explaining why (optional ext-* stubs, intentional collection-trait variance, etc.). Keep it that way: fix at root cause, and never reintroduce a baseline.
+2. PHPUnit annotation → attribute migration — **done**. The suite uses `#[DataProvider]` / `#[CoversClass]`; the only remaining `@covers` is `tests/TestReporter/Fixtures/LegacyCoversAnnotationTest.php`, an intentional fixture exercising the test-reporter's legacy-annotation fallback.
+3. Per-sub-package coverage ≥ 80% remains a standing quality goal (not a migration blocker).
 
 ---
 
@@ -316,9 +335,9 @@ If Rector or PHPStan find new issues your change introduced, fix at root cause �
 
 ### What's risky in this codebase
 
-- **Middleware signature mismatch:** Phase 3 is incomplete. Some classes still implement `Altair\Http\Contracts\MiddlewareInterface` (old double-pass). Treat as in-flight.
-- **Flysystem configurations:** Several `*AdapterConfiguration` classes reference removed adapters and will throw at runtime until Phase 3c lands.
-- **No working `composer.lock`** until the user runs `composer update` post-Phase-1.
+- **Env-/service-backed tests only run where the extension or service exists.** Tests needing `ext-mongodb`, `ext-redis`, `ext-memcached`, `ext-apcu`, `ext-excimer`, or a live database skip (or error in `setUp`) on a machine without them — and the SDK compile tests need `tsc` / `mypy`. A green run with those skipped is expected; don't read the skips as failures. Parallel + container-backed infra to make them runnable everywhere is tracked in [#129](https://github.com/univeros/framework/issues/129).
+- **Rector is a CI gate but is NOT in `composer qa`.** CI's `static-analysis` job runs `rector process --dry-run` over the whole tree (PHP 8.3); `composer qa` is only cs + stan + test. Run `composer rector` manually before pushing or CI will catch drift you didn't see locally.
+- **`composer.lock` is gitignored.** `composer install` regenerates it; don't commit one.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,9 @@ Claude Code entry point for the **Univeros / Altair Framework** (`univeros/frame
 
 ## 1. Quick orientation
 
-- **What it is:** A monorepo PHP framework with 18 sub-packages under `src/Altair/*`, bundled via composer `replace`.
+- **What it is:** A monorepo PHP framework with 40 sub-packages under `src/Altair/*`, bundled via composer `replace`.
 - **Where conventions live:** [AGENT.md](AGENT.md) §5 (coding style), §6 (testing).
-- **Where the modernization roadmap lives:** [AGENT.md](AGENT.md) §7. Phase 1 done; Phases 2-4 pending.
+- **Modernization is complete:** [AGENT.md](AGENT.md) §7 records the (finished) PHP 7.2 → 8.3 migration — Phases 1–4 all done, PHPStan level 8 with no baseline. There is no pending modernization work; new work lives in the open GitHub issues.
 
 If you're being asked to make a change, read the relevant sub-package's `Contracts/` directory before its concrete classes.
 
@@ -44,7 +44,7 @@ CI mirrors these: `.github/workflows/ci.yml`.
 
 | Situation | Subagent |
 |---|---|
-| Bulk search across the 388 source files | `Explore` |
+| Bulk search across the ~1,100 source files | `Explore` |
 | Designing a new sub-package or refactor spanning several files | `architect` then `planner` |
 | Writing new code or fixing bugs | `tdd-guide` (write the failing test first) |
 | Immediately after code changes | `code-reviewer` |
@@ -58,7 +58,7 @@ CI mirrors these: `.github/workflows/ci.yml`.
 - `/code-review` after writing code (security + quality + style)
 - `/security-review` before committing anything touching `Altair\Security\*`, `Altair\Session\*`, `Altair\Http\Middleware\Csrf*`, `Altair\Cookie\*`, or JWT handling
 - `/verify` to run the full QA pipeline (cs + stan + test)
-- `/refactor-clean` for dead-code passes (esp. after Phase 2 Rector run)
+- `/refactor-clean` for dead-code passes
 - `/tdd` for new features — tests first, implementation second
 
 ### Generating HTTP endpoints
@@ -192,11 +192,14 @@ When writing new tests, **don't fight the resolver** — name the test class `<C
 
 Output is deterministic for the same outcomes — golden-file-safe for CI. `build/test-results.json` is gitignored.
 
-### Plan/Skill choices for the open work
+### Plan/Skill choices for new work
 
-- **Phase 2 (Rector):** Don't `Plan` it — just run `composer rector:fix`, then `composer cs:fix && composer test`. Triage failures one at a time.
-- **Phase 3 (manual breaking changes):** Use `planner` first. Each item in [AGENT.md §7](AGENT.md#phase-3--pending-manual-breaking-change-migrations) is independently scoped — do one at a time, run tests between.
-- **Phase 4 (PHPStan + PHPUnit attributes):** Raise PHPStan level one notch at a time. Use `phpstan.neon.dist`'s `ignoreErrors` only with a comment explaining why.
+The PHP 7.2 → 8.3 modernization is finished (see [AGENT.md §7](AGENT.md)); there is no phase backlog. For new work:
+
+- **New feature spanning several files:** `architect` then `planner`, then TDD.
+- **New HTTP endpoint:** write the YAML spec and `bin/altair spec:scaffold` — don't hand-write the Action/Input/Responder triple.
+- **Static analysis:** PHPStan is at **level 8 with no baseline**. Keep it there — fix at root cause; only add an inline `ignoreErrors` entry in `phpstan.neon.dist` with a `// reason:` comment. Never regenerate a `phpstan-baseline.neon`.
+- **Before pushing:** run `composer rector` (whole-tree dry-run) — it's a CI gate but not part of `composer qa`.
 
 ---
 
@@ -206,7 +209,7 @@ These are stricter than what other agents need because of past patterns in this 
 
 - **Immutability — required.** Never mutate value objects. New copies via `withFoo()` methods. See `Altair\Cookie\Cookie` as the reference implementation.
 - **Many small files > few big ones.** 200-400 LOC typical, 800 hard cap. Extract aggressively.
-- **`declare(strict_types=1)` is non-negotiable** — every file, every time. Currently 388/388 source files comply; don't be the one who breaks it.
+- **`declare(strict_types=1)` is non-negotiable** — every file, every time. Currently every source file under `src/` complies; don't be the one who breaks it.
 - **Native types beat PHPDoc.** Add PHPDoc only for `array<K, V>` shapes or unions PHP can't express natively. Don't write `@param string $foo` next to `string $foo` — Rector deletes those anyway.
 - **No emojis** in source files, commit messages, or docs unless the user explicitly asks for them.
 - **No new code without tests.** TDD per [AGENT.md §6](AGENT.md#6-testing). 80%+ coverage on new code.
@@ -218,9 +221,9 @@ These are stricter than what other agents need because of past patterns in this 
 
 When you encounter these, **stop and surface them** instead of working around:
 
-1. **Composer install fails:** likely a version conflict from Phase 1. Don't relax constraints — diagnose with `composer why-not <pkg> <version>` and report.
-2. **A file still uses `Zend\Diactoros\*`:** Phase 1 swap missed it. Fix the import and report which file.
-3. **A test uses `Relay\RelayBuilder` or `$next($req, $res)`:** double-pass middleware leak. Belongs to Phase 3a — flag for batched work, don't fix in isolation unless asked.
+1. **Composer install fails:** a version conflict. Don't relax constraints — diagnose with `composer why-not <pkg> <version>` and report.
+2. **A file uses `Zend\Diactoros\*`** (or any abandoned dep from [AGENT.md §4](AGENT.md#4-php--dependency-baseline)): that's a regression — the migration removed these. Fix the import to `Laminas\Diactoros\*` and report which file.
+3. **A test uses `Relay\RelayBuilder` or double-pass `$next($req, $res)`:** a PSR-15 regression — middleware is single-pass now. Flag it.
 4. **PHPStan finds an issue you'd ignore:** add to `ignoreErrors` only with an inline `// reason: …` comment.
 5. **A change requires editing 10+ files mechanically:** stop, suggest Rector or a one-off transform script instead.
 
@@ -235,10 +238,10 @@ When you encounter these, **stop and surface them** instead of working around:
 
 ---
 
-## 7. State at last update (2026-05)
+## 7. State at last update (2026-06)
 
-- Working tree may contain uncommitted Phase 1 changes. Run `git status` first.
-- `composer.lock` is gitignored and will be regenerated by the user.
-- Open items: see [AGENT.md §7](AGENT.md#7-modernization-status-started-2026-05) Phases 2-4.
+- The PHP 7.2 → 8.3 modernization is **complete** (Phases 1–4). PHPStan runs at **level 8 with no baseline**; the 8.3 + 8.4 CI matrix is green. Don't reintroduce a `phpstan-baseline.neon`.
+- `composer.lock` is gitignored and will be regenerated by the user. Run `git status` first regardless.
+- Open work is tracked in GitHub issues, not in AGENT.md §7 (which is now a historical record of the finished migration).
 
 When in doubt, **read [AGENT.md](AGENT.md) first**, then ask the user before making architectural choices.


### PR DESCRIPTION
The canonical agent guides had drifted from the codebase. This brings both back in sync — no code changes.

## What was wrong

- **Sub-package count: said 18, actually 40.** AGENT.md §2's tree listed ~23 packages and omitted 17 — including **Logging (Monolog)**, Observatory, Observability, Idempotency, Webhooks, Mcp, Doctor, Eval, Index, Profiling, Suggest, Tinker, MigrationIntelligence, Examples, AgentSpec, Cli, Bootstrap. Several listed entries were also *wrong* (Courier described as "mail/transport" — it's a command bus; Security as "CSRF tokens"; Middleware as "PSR-15 primitives").
- **§7 modernization status stale.** Claimed "Phase 4 in progress (PHPStan level 6)" and "Phase 3d all but PSR-14." Reality: **PHPStan level 8, no baseline**; #96 and #97 both closed; all phases done.
- **§4 dependency baseline incomplete/stale.** Missing now-core deps (monolog, symfony console/messenger/serializer/uid, the cycle/* family, spiral/tokenizer, opis/json-schema, lcobucci/jwt, psr/clock, psr/event-dispatcher); listed a removed dep (micheh/psr7-cache); wrong dev-tool versions (phpstan ^1.12 → ^2.1, rector ^1.2 → ^2.0).
- **Stale "what's risky" warnings** about Phase 3 being incomplete / Flysystem throwing / no composer.lock.
- **CLAUDE.md** repeated the 18 count, cited "388 source files" (actually ~1,100), and had a "Plan/Skill choices for the open work" section + flag-list still framed around completing Phases 2–4.

## What changed

- §2 package tree **rebuilt from each package's `composer.json` description** — all 40, accurate.
- §7: Phases 3d + 4 → COMPLETE; summary reframed as a historical record (PHPStan level 8, no baseline; no pending modernization work).
- §4: complete core-dep + dev-tooling tables; removed the dropped dep; added a note on extension/service-gated optional test deps.
- Gotchas rewritten to the real ones (env/service-gated tests skip locally; `rector` is a CI gate outside `composer qa`).
- CLAUDE.md: counts, §7 state, the new-work plan/skill guidance, and the flag list all corrected.

## Verification

- Counts cross-checked against the tree: 40 `src/Altair/*` dirs = 40 `replace` entries = 40 `docs/packages/*.md`; package one-liners sourced from `composer.json`; dep versions read from the root manifest; source-file count from `find src -name '*.php'` (1,098, all `declare(strict_types=1)`).
- Docs-only — no `src/`/`tests/` touched.