### PR TITLE
test(infra): paratest + docker-CLI integration harness (Redis proof)

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -235,13 +235,29 @@ Enforcement is layered and live:
 - Bootstrap: `tests/bootstrap.php`. Per-package fixtures in `tests/{Container,Courier,Sanitation,Validation}/fixtures.php`.
 - Suffix `Test.php`, mirror the `src/Altair/<Pkg>` layout under `tests/<Pkg>/`.
 - Coverage target: **80%+** for new code (unit + integration).
-- Integration tests against Redis/Memcached/MongoDB use real services. CI starts containers; locally use Docker.
 
 ```bash
-vendor/bin/phpunit                              # full suite
+vendor/bin/phpunit                              # full suite (canonical gate)
 vendor/bin/phpunit --filter CookieManagerTest   # one test class
-vendor/bin/phpunit --testsuite "Univeros Test Suite"
+composer test:par                               # parallel run via paratest — fast local loop
 ```
+
+### Running the integration suite
+
+Some packages talk to a real service (Redis, MongoDB, Memcached, Beanstalk, a SQL database). Those tests resolve their endpoint in this order, and **skip gracefully** when none is available — so `composer test` stays green and Docker-free on a bare machine:
+
+1. an explicit env endpoint (e.g. `REDIS_HOST` / `REDIS_PORT`);
+2. a service already listening on the conventional local port (a CI service container, or a locally-running server) — reused as-is;
+3. a throwaway container booted via the `docker` CLI ([tests/Support/Integration/DockerContainer.php](tests/Support/Integration/DockerContainer.php)), torn down on shutdown;
+4. otherwise the test is skipped.
+
+So with Docker running you get the integration coverage locally with **no global service install and no PHP client extension** — provided the client is pure-PHP (`predis/predis`, `pda/pheanstalk`, PDO). Tests using `ext-redis` / `ext-mongodb` / `ext-memcached` still need that extension loaded in the CLI runtime even with a container, so they skip without it. `PredisCacheItemStorageTest` is the reference port; resolve new ones through a small per-service helper like [`RedisServer`](tests/Support/Integration/RedisServer.php).
+
+> We deliberately do **not** use testcontainers-php: its Docker client requires `psr/http-message ^2`, which conflicts with this tree's `relay/relay ~1.0` and `neomerx/cors-psr7 ^1.0`. The dependency-free `docker`-CLI helper does the same job.
+
+### Parallel runs (`composer test:par`)
+
+`paratest` runs the suite across CPU cores for a fast local loop. **`composer test` (single-process) remains the canonical gate** (CI uses it): a few suites that share an on-disk fixture path (`tests/Cache/tmp` for the filesystem cache, the events log under `Events\ReaderTest`) are not yet isolated per worker, so they can collide under `test:par`. Making every service/file-backed test parallel-safe (per-worker container / per-test keyspace, DB name, or temp dir keyed off `TEST_TOKEN`) is tracked in [#129](https://github.com/univeros/framework/issues/129).
 
 ---
 

--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "ext-mongodb": "*",
         "ext-openssl": "*",
         "ext-redis": "*",
+        "brianium/paratest": "^7",
         "friendsofphp/php-cs-fixer": "^3.64",
         "lcobucci/jwt": "^5.3",
         "league/flysystem-aws-s3-v3": "^3.29",
@@ -130,6 +131,7 @@
     },
     "scripts": {
         "test": "phpunit",
+        "test:par": "paratest --no-coverage",
         "test:coverage": "phpunit --coverage-html build/coverage",
         "cs": "php-cs-fixer fix --dry-run --diff",
         "cs:fix": "php-cs-fixer fix",

--- a/tests/Cache/PredisCacheItemStorageTest.php
+++ b/tests/Cache/PredisCacheItemStorageTest.php
@@ -5,13 +5,21 @@ declare(strict_types=1);
 namespace Altair\Tests\Cache;
 
 use Altair\Cache\Storage\PredisCacheItemStorage;
+use Altair\Tests\Support\Integration\RedisServer;
 use Predis\Client;
 
 class PredisCacheItemStorageTest extends AbstractStorageTestCase
 {
     #[\Override]
-    protected function setUp(): void    {
-        $redis = new Client(['host' => 'localhost', 'port' => 6379]);
+    protected function setUp(): void
+    {
+        $endpoint = RedisServer::endpoint();
+        if ($endpoint === null) {
+            self::markTestSkipped('Redis integration test needs REDIS_HOST, a Redis on 127.0.0.1:6379, or Docker.');
+        }
+
+        [$host, $port] = $endpoint;
+        $redis = new Client(['host' => $host, 'port' => $port]);
 
         $this->store = new PredisCacheItemStorage($redis, 'test');
     }

--- a/tests/Support/Integration/DockerContainer.php
+++ b/tests/Support/Integration/DockerContainer.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Support\Integration;
+
+use RuntimeException;
+
+/**
+ * Boots a throwaway service container for integration tests by shelling out to
+ * the `docker` CLI — deliberately dependency-free (testcontainers-php pulls in a
+ * Docker client that requires psr/http-message ^2, which conflicts with this
+ * tree's relay/relay ~1.0 and neomerx/cors-psr7 ^1.0).
+ *
+ * A container is booted at most once per image+port per PHP process (so paratest
+ * workers each get their own isolated instance) and torn down on shutdown. Tests
+ * that need a service should resolve their endpoint through a per-service helper
+ * (e.g. {@see RedisServer}) which skips gracefully when neither a running service
+ * nor Docker is available.
+ */
+final class DockerContainer
+{
+    private static ?bool $available = null;
+
+    /** @var array<string, self> One booted container per image+port, reused within the process. */
+    private static array $shared = [];
+
+    private function __construct(
+        private readonly string $id,
+        private readonly string $host,
+        private readonly int $port,
+    ) {}
+
+    public static function dockerAvailable(): bool
+    {
+        if (self::$available === null) {
+            exec('docker info > /dev/null 2>&1', $output, $code);
+            self::$available = $code === 0;
+        }
+
+        return self::$available;
+    }
+
+    /**
+     * Whether something is already accepting TCP connections at host:port — used
+     * both to reuse an existing service (e.g. a CI service container) and as the
+     * readiness probe after a boot.
+     */
+    public static function tcpIsOpen(string $host, int $port, float $timeout = 0.5): bool
+    {
+        $connection = @fsockopen($host, $port, $errno, $errstr, $timeout);
+        if ($connection === false) {
+            return false;
+        }
+
+        fclose($connection);
+
+        return true;
+    }
+
+    /**
+     * @param array<string, string> $env environment variables passed to the container
+     */
+    public static function boot(string $image, int $containerPort, array $env = []): self
+    {
+        $key = $image . '/' . $containerPort;
+        if (isset(self::$shared[$key])) {
+            return self::$shared[$key];
+        }
+
+        $envFlags = '';
+        foreach ($env as $name => $value) {
+            $envFlags .= ' -e ' . escapeshellarg($name . '=' . $value);
+        }
+
+        $id = trim((string) shell_exec(\sprintf('docker run -d -P%s %s 2>/dev/null', $envFlags, escapeshellarg($image))));
+        if ($id === '') {
+            throw new RuntimeException(\sprintf("Failed to start a Docker container for image '%s'.", $image));
+        }
+
+        $container = new self($id, '127.0.0.1', self::mappedPort($id, $containerPort));
+        self::$shared[$key] = $container;
+        register_shutdown_function(static fn(): null => $container->stop());
+
+        return $container;
+    }
+
+    public function host(): string
+    {
+        return $this->host;
+    }
+
+    public function port(): int
+    {
+        return $this->port;
+    }
+
+    /**
+     * Blocks until the mapped port accepts connections, so callers never race a
+     * still-starting service.
+     */
+    public function waitUntilReady(float $timeoutSeconds = 20.0): self
+    {
+        $deadline = microtime(true) + $timeoutSeconds;
+        while (microtime(true) < $deadline) {
+            if (self::tcpIsOpen($this->host, $this->port)) {
+                return $this;
+            }
+
+            usleep(100_000);
+        }
+
+        throw new RuntimeException(\sprintf('Container %s did not accept connections on %s:%d within %.0fs.', substr($this->id, 0, 12), $this->host, $this->port, $timeoutSeconds));
+    }
+
+    public function stop(): null
+    {
+        exec(\sprintf('docker rm -f %s > /dev/null 2>&1', escapeshellarg($this->id)));
+
+        return null;
+    }
+
+    private static function mappedPort(string $id, int $containerPort): int
+    {
+        $format = \sprintf('{{(index (index .NetworkSettings.Ports "%d/tcp") 0).HostPort}}', $containerPort);
+        $port = trim((string) shell_exec(\sprintf('docker inspect --format %s %s 2>/dev/null', escapeshellarg($format), escapeshellarg($id))));
+        if ($port === '' || !ctype_digit($port)) {
+            throw new RuntimeException(\sprintf('Could not read the host port mapped to %d/tcp for container %s.', $containerPort, substr($id, 0, 12)));
+        }
+
+        return (int) $port;
+    }
+}

--- a/tests/Support/Integration/RedisServer.php
+++ b/tests/Support/Integration/RedisServer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Tests\Support\Integration;
+
+/**
+ * Resolves a reachable Redis endpoint for integration tests, in priority order:
+ *
+ *   1. `REDIS_HOST` / `REDIS_PORT` env (an explicitly configured server, e.g. CI);
+ *   2. an already-listening server on 127.0.0.1:6379 (a CI service container or a
+ *      locally-running Redis) — reused as-is, no Docker needed;
+ *   3. a throwaway `redis:7-alpine` container via {@see DockerContainer};
+ *   4. none available → the caller skips.
+ *
+ * Returns `[host, port]`, or `null` when there is no server and no Docker — letting
+ * the unit suite stay green and Docker-free on a machine without either.
+ *
+ * @phpstan-type Endpoint array{0: string, 1: int}
+ */
+final class RedisServer
+{
+    private const string IMAGE = 'redis:7-alpine';
+
+    private const int DEFAULT_PORT = 6379;
+
+    /**
+     * @return array{0: string, 1: int}|null
+     */
+    public static function endpoint(): ?array
+    {
+        $envHost = getenv('REDIS_HOST');
+        if (\is_string($envHost) && $envHost !== '') {
+            $envPort = getenv('REDIS_PORT');
+
+            return [$envHost, \is_string($envPort) && ctype_digit($envPort) ? (int) $envPort : self::DEFAULT_PORT];
+        }
+
+        if (DockerContainer::tcpIsOpen('127.0.0.1', self::DEFAULT_PORT)) {
+            return ['127.0.0.1', self::DEFAULT_PORT];
+        }
+
+        if (DockerContainer::dockerAvailable()) {
+            $container = DockerContainer::boot(self::IMAGE, self::DEFAULT_PORT)->waitUntilReady();
+
+            return [$container->host(), $container->port()];
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Part of #129 (foundation + first proof; the remaining boxes stay open).

## What this delivers

**Parallel runs.** `brianium/paratest` (dev) + `composer test:par` (`--no-coverage`) — runs the suite across cores for a fast local loop (~4s wall-clock here vs single-process). **`composer test` stays the canonical gate**, and CI is unchanged.

**Container-backed integration tests, dependency-free.** A small `docker`-CLI harness ([DockerContainer](tests/Support/Integration/DockerContainer.php)) boots a throwaway service container, reads the mapped host port, waits for readiness, and tears it down on shutdown — one container per image+port per process, so paratest workers stay isolated.

> **Why not testcontainers-php?** Its Docker client (`beluga-php/docker-php`) requires `psr/http-message ^2`, which can't resolve against this tree's `relay/relay ~1.0` and `neomerx/cors-psr7 ^1.0`. The `docker`-CLI helper does the same job with zero new runtime deps and no transitive disruption.

**Proof port.** `PredisCacheItemStorageTest` previously hard-coded `localhost:6379` (worked only where a Redis happened to be running). It now resolves via [`RedisServer`](tests/Support/Integration/RedisServer.php): `REDIS_HOST` env → an existing local/CI service on 6379 → a booted `redis:7-alpine` container → skip. So it runs locally **with Docker and no PHP extension** (Predis is pure-PHP), reuses the CI service unchanged, and skips gracefully on a bare machine.

## Scope note (the rest of #129)

The issue's hard part — **per-worker / per-test isolation for full parallel-safety** — is intentionally *not* in this PR. A few suites share an on-disk fixture (`tests/Cache/tmp` for the filesystem cache; the events log in `Events\ReaderTest`) and collide under `test:par`; that's documented and left as the next box. Also deferred: porting the `ext-`-bound services (Mongo/Memcached) and the Cycle DB / Beanstalk tests, and switching CI to the container path. Note `ext-redis`/`ext-mongodb`/`ext-memcached` tests still need the client extension even with a container — only pure-PHP clients (Predis, pheanstalk, PDO) become extension-free locally.

## Test plan

- [x] `PredisCacheItemStorageTest` passes serially (reuses local/CI Redis) and via the Docker boot path (verified: booted `redis:7-alpine` → mapped port → Predis SET/GET round-trip → torn down).
- [x] Skips gracefully when neither a Redis nor Docker is present.
- [x] `composer test:par` runs the suite in parallel (parallel-safety caveats documented).
- [x] CS + PHPStan + Rector green; `.agent/` byte-stable (no new `src` symbols).
- [x] Docs: AGENT.md §6 "Running the integration suite" + parallel-safety status.