### PR TITLE
fix(scaffold): disambiguate colliding openapi:import filenames

### DIFF
--- a/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
@@ -20,7 +20,6 @@ use Altair\Events\EventStatus;
 use Altair\Scaffold\Emitter\EmissionPlan;
 use Altair\Scaffold\Emitter\EmittedFile;
 use Altair\Scaffold\Emitter\EmittedFileKind;
-use Altair\Scaffold\Exception\ScaffoldException;
 use Altair\Scaffold\Journal\Journal;
 use Altair\Scaffold\Journal\JournalEntry;
 use Altair\Scaffold\Journal\SnapshotCollector;
@@ -185,10 +184,15 @@ final readonly class OpenApiImportRunner
             ? new PathDeriver(specRoot: $options->outDir)
             : $this->pathDeriver;
 
+        // Resolve every filename up front so distinct operations that derive the
+        // same short name (e.g. Petstore's two "update pet" operations) get
+        // disambiguated instead of colliding. Throws only on a duplicate
+        // operationId, which is an invalid spec.
+        $filenames = $deriver->resolveFilenames($document->operations);
+
         $files = [];
         $unmapped = [];
         $warnings = [];
-        $seen = [];
         foreach ($document->operations as $operation) {
             try {
                 $structure = $this->operationMapper->map($document, $operation);
@@ -212,23 +216,12 @@ final readonly class OpenApiImportRunner
                 continue;
             }
 
-            $filename = $deriver->filename($operation);
-            if (isset($seen[$filename])) {
-                throw new ScaffoldException(\sprintf(
-                    "Filename collision: '%s' is also emitted by '%s %s'. Set distinct operationIds to disambiguate.",
-                    $filename,
-                    $seen[$filename]['method'],
-                    $seen[$filename]['path'],
-                ));
-            }
-
             if ($options->persistence === 'cycle') {
                 $structure = $this->persistenceInferrer->apply($operation, $structure);
             }
 
             $contents = Yaml::dump($structure, self::YAML_INLINE_LEVEL, self::YAML_INDENT, Yaml::DUMP_OBJECT_AS_MAP);
-            $files[] = new EmittedFile(relativePath: $filename, contents: $contents, kind: EmittedFileKind::Spec);
-            $seen[$filename] = ['method' => $operation->method, 'path' => $operation->path];
+            $files[] = new EmittedFile(relativePath: $filenames[$deriver->operationKey($operation)], contents: $contents, kind: EmittedFileKind::Spec);
         }
 
         // Every operation was skipped: a bare exit 0 would otherwise read as

--- a/src/Altair/Scaffold/Spec/Emitter/Emitter.php
+++ b/src/Altair/Scaffold/Spec/Emitter/Emitter.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 namespace Altair\Scaffold\Spec\Emitter;
 
 use Altair\Scaffold\Sdk\Model\OpenApiDocument;
-use Altair\Scaffold\Sdk\Model\OperationModel;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
 use Symfony\Component\Yaml\Yaml;
 
@@ -43,24 +42,12 @@ final readonly class Emitter
      */
     public function emit(OpenApiDocument $document): array
     {
+        // Filenames are resolved across the whole document so distinct operations
+        // that derive the same short name are disambiguated rather than colliding.
+        $filenames = $this->pathDeriver->resolveFilenames($document->operations);
+
         $emitted = [];
-        $seen = [];
-
         foreach ($document->operations as $operation) {
-            $filename = $this->pathDeriver->filename($operation);
-
-            if (isset($seen[$filename])) {
-                throw new UnmappableSchemaException(
-                    $this->operationPointer($operation),
-                    \sprintf(
-                        "filename collision: '%s' is also emitted by '%s %s'. Set distinct operationIds to disambiguate.",
-                        $filename,
-                        $seen[$filename]['method'],
-                        $seen[$filename]['path'],
-                    ),
-                );
-            }
-
             $structure = $this->operationMapper->map($document, $operation);
             $contents = Yaml::dump(
                 $structure,
@@ -69,17 +56,12 @@ final readonly class Emitter
                 Yaml::DUMP_OBJECT_AS_MAP,
             );
 
-            $emitted[] = new EmittedSpec(relativePath: $filename, contents: $contents);
-            $seen[$filename] = ['method' => $operation->method, 'path' => $operation->path];
+            $emitted[] = new EmittedSpec(
+                relativePath: $filenames[$this->pathDeriver->operationKey($operation)],
+                contents: $contents,
+            );
         }
 
         return $emitted;
-    }
-
-    private function operationPointer(OperationModel $operation): string
-    {
-        $encodedPath = str_replace('/', '~1', $operation->path);
-
-        return '#/paths/' . $encodedPath . '/' . strtolower($operation->method);
     }
 }

--- a/src/Altair/Scaffold/Spec/Emitter/PathDeriver.php
+++ b/src/Altair/Scaffold/Spec/Emitter/PathDeriver.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace Altair\Scaffold\Spec\Emitter;
 
+use Altair\Scaffold\Exception\ScaffoldException;
 use Altair\Scaffold\Sdk\Model\OperationModel;
 
 /**
@@ -28,6 +29,55 @@ final readonly class PathDeriver
     public function filename(OperationModel $operation): string
     {
         return $this->specRoot . '/' . $this->resourceDir($operation) . '/' . $this->verb($operation) . '.yaml';
+    }
+
+    /**
+     * Collision-free filename for every operation, resolved in one pass.
+     *
+     * The clean `api/<resource>/<verb>.yaml` name is kept when unique; when two
+     * distinct operations would derive the same name — e.g. the Swagger
+     * Petstore's `PUT /pet` (updatePet) and `POST /pet/{petId}`
+     * (updatePetWithForm), both "update pet" — each falls back to its
+     * operationId, which OpenAPI guarantees unique. Two operations sharing one
+     * operationId is rejected: it is an invalid spec whose generated domain
+     * classes would collide too.
+     *
+     * @param  list<OperationModel>   $operations
+     * @return array<string, string>  {@see operationKey} => relative filename
+     */
+    public function resolveFilenames(array $operations): array
+    {
+        $this->assertUniqueOperationIds($operations);
+
+        $frequency = [];
+        foreach ($operations as $operation) {
+            $name = $this->filename($operation);
+            $frequency[$name] = ($frequency[$name] ?? 0) + 1;
+        }
+
+        $result = [];
+        $used = [];
+        foreach ($operations as $operation) {
+            $name = $this->filename($operation);
+            if (($frequency[$name] ?? 0) > 1) {
+                $name = $this->specRoot . '/' . $this->resourceDir($operation) . '/' . $this->disambiguator($operation) . '.yaml';
+            }
+
+            $name = $this->ensureUnique($name, $used);
+            $used[$name] = true;
+            $result[$this->operationKey($operation)] = $name;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Stable identity for an operation (unique within a valid OpenAPI document):
+     * the key {@see resolveFilenames} maps to a filename.
+     */
+    public function operationKey(OperationModel $operation): string
+    {
+        return strtoupper($operation->method) . ' ' . $operation->path;
     }
 
     public function domainFqcn(OperationModel $operation): string
@@ -123,6 +173,66 @@ final readonly class PathDeriver
         }
 
         return $value;
+    }
+
+    /**
+     * @param list<OperationModel> $operations
+     */
+    private function assertUniqueOperationIds(array $operations): void
+    {
+        $seen = [];
+        foreach ($operations as $operation) {
+            $id = $operation->operationId;
+            if ($id === '') {
+                continue;
+            }
+
+            if (isset($seen[$id])) {
+                throw new ScaffoldException(\sprintf(
+                    "Duplicate operationId '%s' on '%s' and '%s'. operationIds must be unique — each maps to one domain class.",
+                    $id,
+                    $seen[$id],
+                    $this->operationKey($operation),
+                ));
+            }
+
+            $seen[$id] = $this->operationKey($operation);
+        }
+    }
+
+    private function disambiguator(OperationModel $operation): string
+    {
+        if ($operation->operationId !== '') {
+            return $this->kebabCase($operation->operationId);
+        }
+
+        return $this->verb($operation) . '-' . strtolower($operation->method);
+    }
+
+    /**
+     * @param array<string, true> $used
+     */
+    private function ensureUnique(string $name, array $used): string
+    {
+        if (!isset($used[$name])) {
+            return $name;
+        }
+
+        $base = substr($name, 0, -\strlen('.yaml'));
+        $suffix = 2;
+        while (isset($used[$base . '-' . $suffix . '.yaml'])) {
+            $suffix++;
+        }
+
+        return $base . '-' . $suffix . '.yaml';
+    }
+
+    private function kebabCase(string $value): string
+    {
+        $words = preg_split('/[^A-Za-z0-9]+|(?<=[a-z])(?=[A-Z])/', $value) ?: [];
+        $words = array_filter($words, static fn(string $w): bool => $w !== '');
+
+        return implode('-', array_map(strtolower(...), $words));
     }
 
     private function pascalCase(string $value): string

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -335,8 +335,10 @@ final class OpenApiImportRunnerTest extends TestCase
         self::assertSame($first, $second);
     }
 
-    public function testFilenameCollisionFails(): void
+    public function testDuplicateOperationIdFails(): void
     {
+        // Two operations sharing one operationId is an invalid spec — their
+        // generated domain classes would collide — so it is rejected outright.
         $documentPath = $this->sandbox . '/openapi.yaml';
         file_put_contents($documentPath, <<<'YAML'
             openapi: 3.1.0
@@ -357,7 +359,42 @@ final class OpenApiImportRunnerTest extends TestCase
         ));
 
         self::assertFalse($receipt->ok);
-        self::assertStringContainsString('collision', (string) $receipt->error);
+        self::assertStringContainsString('Duplicate operationId', (string) $receipt->error);
+        self::assertStringContainsString('listUsers', (string) $receipt->error);
+    }
+
+    public function testCollidingShortNamesAreDisambiguated(): void
+    {
+        // The real Swagger Petstore case: PUT /pet (updatePet) and
+        // POST /pet/{petId} (updatePetWithForm) both derive api/pet/update.yaml.
+        // Distinct operationIds => disambiguate to unique files, not a collision.
+        $documentPath = $this->sandbox . '/openapi.yaml';
+        file_put_contents($documentPath, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets, version: 1.0.0 }
+            paths:
+              /pet:
+                put:
+                  operationId: updatePet
+                  summary: Update an existing pet
+                  responses: { '200': { description: ok } }
+              /pet/{petId}:
+                post:
+                  operationId: updatePetWithForm
+                  summary: Update a pet with form data
+                  responses: { '200': { description: ok } }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok, (string) $receipt->error);
+        self::assertCount(2, $receipt->specsWritten);
+        self::assertCount(2, array_unique($receipt->specsWritten));
+        self::assertContains('api/pet/update-pet.yaml', $receipt->specsWritten);
+        self::assertContains('api/pet/update-pet-with-form.yaml', $receipt->specsWritten);
     }
 
     private function writeOpenApi(): string

--- a/tests/Scaffold/Spec/Emitter/EmitterTest.php
+++ b/tests/Scaffold/Spec/Emitter/EmitterTest.php
@@ -9,6 +9,7 @@ use Altair\Scaffold\Sdk\Model\OpenApiParser;
 use Altair\Scaffold\Sdk\Model\OperationModel;
 use Altair\Scaffold\Sdk\Model\ResponseModel;
 use Altair\Scaffold\Sdk\Model\SchemaType;
+use Altair\Scaffold\Spec\Emitter\EmittedSpec;
 use Altair\Scaffold\Spec\Emitter\Emitter;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
 use Altair\Scaffold\Spec\Parser;
@@ -30,8 +31,10 @@ final class EmitterTest extends TestCase
         self::assertSame('api/pets/get.yaml', $emitted[2]->relativePath);
     }
 
-    public function testFilenameCollisionRaises(): void
+    public function testCollidingShortNamesAreDisambiguated(): void
     {
+        // Two distinct operations that derive the same short name (api/users/list)
+        // must each get a unique filename rather than colliding.
         $document = new OpenApiDocument(
             title: 'X',
             version: '1.0',
@@ -41,9 +44,12 @@ final class EmitterTest extends TestCase
             ],
         );
 
-        $this->expectException(UnmappableSchemaException::class);
-        $this->expectExceptionMessage('filename collision');
-        (new Emitter())->emit($document);
+        $paths = array_map(static fn(EmittedSpec $s): string => $s->relativePath, (new Emitter())->emit($document));
+
+        self::assertCount(2, $paths);
+        self::assertCount(2, array_unique($paths), 'filenames must be distinct');
+        self::assertContains('api/users/list-get.yaml', $paths);
+        self::assertContains('api/users/list-users.yaml', $paths);
     }
 
     public function testEmittedYamlIsParsedByExistingParser(): void


### PR DESCRIPTION
Closes #210.

## Problem (reported)

`./vendor/bin/altair openapi:import ./resources/petstore-openapi.yaml --dry-run` on the real Swagger Petstore failed:

```
Filename collision: 'api/pet/update.yaml' is also emitted by 'PUT /pet'. Set distinct operationIds to disambiguate.
```

`PUT /pet` (`updatePet`) and `POST /pet/{petId}` (`updatePetWithForm`) both derive `api/pet/update.yaml` — the path parameter is stripped from the resource and both operationIds start "update". The operationIds *are* distinct, so the "set distinct operationIds" advice was misleading.

## Fix

`PathDeriver::resolveFilenames()` resolves every filename in one pass:

- keeps the clean `api/<resource>/<verb>.yaml` when unique;
- when distinct operations collide, falls back to each operation's **operationId** (OpenAPI-unique) → `api/pet/update-pet.yaml` + `api/pet/update-pet-with-form.yaml`, while non-colliding ops keep their short names;
- **duplicate operationIds** (invalid spec — the generated domain classes would collide too) are still rejected, now with a message naming the id and both paths.

Wired through both call sites: `OpenApiImportRunner` (import) and `Spec\Emitter\Emitter` (round-trip).

## Verified

End-to-end on a Petstore doc with the exact collision **plus** nested `category` + array-of-`$ref` `tags`:
```
Wrote 5 spec file(s):
  - api/pet/update-pet.yaml          (updatePet — was colliding)
  - api/pet/add.yaml                 (addPet — clean short name kept)
  - api/pet/update-pet-with-form.yaml (updatePetWithForm — was colliding)
  - api/pet/get.yaml
  - api/pet/delete.yaml
exit=0   # no collision, no --skip-unmappable needed
```

## Test plan

- [x] New: colliding distinct operations → unique disambiguated filenames (runner + emitter).
- [x] Updated: duplicate operationId → clear `Duplicate operationId` error (was the old "collision" message).
- [x] Non-colliding operations keep their short verb-based names.
- [x] CS + PHPStan + Rector + full Scaffold suite green; `.agent/` byte-stable.