### PR TITLE
fix(scaffold): map top-level array request bodies on openapi:import

### DIFF
--- a/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
@@ -65,7 +65,7 @@ final readonly class SchemaMapper
         if ($requestBody instanceof SchemaType) {
             $pointer = $this->requestBodyPointer($operation);
             $bodySchema = $this->resolveRef($document, $requestBody, $pointer);
-            foreach ($this->objectInputFields($document, $bodySchema, $pointer) as $field) {
+            foreach ($this->bodyInputFields($document, $bodySchema, $pointer) as $field) {
                 $fields[] = $field;
             }
         }
@@ -130,18 +130,25 @@ final readonly class SchemaMapper
     }
 
     /**
+     * Maps a request body to input fields. An object body becomes one field per
+     * property. A top-level **array** body — e.g. the Petstore's
+     * `POST /user/createWithList`, a bare array of `User` — becomes a single
+     * `items` array field carrying the element shape, since Altair inputs are a
+     * named field list and the list needs a name. Any other root kind is
+     * unmappable.
+     *
      * @return list<array<string, mixed>>
      */
-    private function objectInputFields(OpenApiDocument $document, SchemaType $schema, string $pointer): array
+    private function bodyInputFields(OpenApiDocument $document, SchemaType $schema, string $pointer): array
     {
-        if ($schema->kind !== SchemaType::OBJECT) {
-            throw new UnmappableSchemaException(
+        return match ($schema->kind) {
+            SchemaType::OBJECT => $this->mapProperties($document, $schema, $pointer),
+            SchemaType::ARRAY => [$this->arrayInputField($document, 'items', $schema, [], $pointer)],
+            default => throw new UnmappableSchemaException(
                 $pointer,
-                'request body must be an object (got ' . $schema->kind . ').',
-            );
-        }
-
-        return $this->mapProperties($document, $schema, $pointer);
+                'request body must be an object or array (got ' . $schema->kind . ').',
+            ),
+        };
     }
 
     /**

--- a/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
@@ -145,6 +145,53 @@ final class SchemaMapperTest extends TestCase
         ], $fields);
     }
 
+    public function testTopLevelArrayRequestBodyBecomesItemsField(): void
+    {
+        // The real Petstore's POST /user/createWithList: a bare array of User.
+        // Altair inputs are a named field list, so the array becomes one `items`
+        // field carrying the element shape.
+        $body = SchemaType::arrayOf(SchemaType::object([
+            'id' => ['schema' => SchemaType::scalar('integer'), 'required' => false],
+            'name' => ['schema' => SchemaType::scalar('string'), 'required' => true],
+        ]));
+        $operation = $this->operation('POST', '/users/createWithList', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            [
+                'name' => 'items',
+                'type' => 'array',
+                'rules' => [],
+                'fields' => [
+                    ['name' => 'id', 'type' => 'int', 'rules' => []],
+                    ['name' => 'name', 'type' => 'string', 'rules' => ['required']],
+                ],
+            ],
+        ], $fields);
+    }
+
+    public function testTopLevelArrayOfScalarsBecomesItemsField(): void
+    {
+        $body = SchemaType::arrayOf(SchemaType::scalar('string'));
+        $operation = $this->operation('POST', '/tags/bulk', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'items', 'type' => 'array', 'rules' => []],
+        ], $fields);
+    }
+
+    public function testScalarRequestBodyIsUnmappable(): void
+    {
+        $operation = $this->operation('POST', '/ping', requestBody: SchemaType::scalar('string'));
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('request body must be an object or array');
+        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+    }
+
     public function testDeeplyNestedInlineObjectRaisesInsteadOfStackOverflow(): void
     {
         // Build an inline object nested far deeper than MAX_NESTING_DEPTH so the


### PR DESCRIPTION
Closes #212. The last Petstore import blocker.

## Problem (reported)

The real Swagger Petstore's `POST /user/createWithList` takes a bare array of `User`:
```
openapi:import failed: Unmappable schema at #/paths/~1user~1createWithList/.../schema:
request body must be an object (got array).
```

## Fix

`SchemaMapper::bodyInputFields()` dispatches on the request-body root kind:
- **object** → one input field per property (existing);
- **array** → a single `items` array field carrying the element shape (new — reuses array-of-objects support);
- anything else (a bare scalar body) → unmappable, now with an accurate "object or array" message.

```yaml
input:
  items:
    type: array
    fields: { id: { type: int }, username: { type: string }, ... }
```

## Verified on YOUR petstore file

```
$ bin/altair openapi:import .altair/petstore-openapi.yaml --dry-run
Wrote 19 spec file(s)        # all operations, exit 0, no --skip-unmappable
```
- All 19 emitted specs pass Parser + Validator (0 invalid).
- `openapi:roundtrip --check` → clean: 19 operations, no drift.

## Test plan

- [x] Top-level array-of-objects body → single `items` field with element fields.
- [x] Top-level array-of-scalars body → `items` array (no fields).
- [x] Bare scalar body → unmappable with "object or array" message.
- [x] CS + PHPStan + Rector + full Scaffold suite (275) green; `.agent/` byte-stable.

With #204 (nested objects), #211 (filename collisions) and this, the full Swagger Petstore imports end-to-end.