### PR TITLE
feat(scaffold): warn on every dropped construct in openapi:import (#214 Phase 1)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -5,6 +5,7 @@
 ## Concrete classes
 
 - `ActionEmitter`
+- `CoverageScanner` _(final)_
 - `DiffCommand` _(final)_
 - `DomainSpec` _(final)_
 - `DomainStubEmitter`
@@ -137,6 +138,7 @@
 - `tests/Scaffold/Sdk/CompileIntegrationTest.php`
 - `tests/Scaffold/Sdk/EmitSdkCommandTest.php`
 - `tests/Scaffold/Sdk/EmitterRegistryTest.php`
+- `tests/Scaffold/Sdk/Model/CoverageScannerTest.php`
 - `tests/Scaffold/Sdk/OpenApiParserExtensionsTest.php`
 - `tests/Scaffold/Sdk/OpenApiParserTest.php`
 - `tests/Scaffold/Sdk/PythonEmitterTest.php`

--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -1,0 +1,58 @@
+# OpenAPI 3.1 coverage
+
+What `bin/altair openapi:import` (OpenAPI → Altair) and `spec:emit-openapi`
+(Altair → OpenAPI) actually do with each OpenAPI feature. This is the honest,
+evidence-based map — kept current as [#214](https://github.com/univeros/framework/issues/214)
+closes the gaps.
+
+> **Standard.** Map everything representable; **surface (warn/error) everything
+> else — never silently drop**; emit spec-compliant OpenAPI; keep the round-trip
+> stable. Literal 100% fidelity into generated code isn't a goal — some features
+> (`callbacks`, `links`, `oneOf` polymorphism, free-form `additionalProperties`)
+> have no clean Altair representation.
+
+## Import (OpenAPI → Altair spec)
+
+### Mapped
+
+- Paths + operations; `operationId` (or synthesised), `summary`.
+- **Path parameters** (currently always typed `string` — declared schema ignored).
+- Request + response bodies in **`application/json`**.
+- Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
+- Internal `$ref` (`#/components/schemas/<Name>`), `properties` + `required`.
+- `x-altair-*` extensions (domain/persistence/queue/idempotency/webhook round-trip).
+
+### Surfaced as warnings (imported, but reported — not silent) — *Phase 1*
+
+`openapi:import` warns about each of these in its receipt (`warnings[]`) and human output:
+
+- **query / header / cookie parameters** and parameter `$ref`.
+- **non-`application/json` request bodies** (multipart, form-urlencoded, xml, octet-stream).
+- requestBody **`$ref`** (body dropped).
+- operation + global **`security`**, `components.securitySchemes`.
+- `servers`, `webhooks` (3.1), `callbacks`, path-item `$ref`.
+
+### Surfaced as errors / skips (fail, or `--skip-unmappable`)
+
+- **External / file / URL `$ref`** (only internal component refs resolve).
+- `oneOf` / `anyOf` / `allOf` in a request body; recursive `$ref`; a bare scalar body.
+
+### Not yet mapped or warned (later phases)
+
+- Validation constraints: `format`, `min/maxLength`, `pattern`, `minimum/maximum`, `multipleOf`, `min/maxItems` (Phase 3 → `Altair\Validation` rules).
+- requestBody `required` flag; `additionalProperties`, `const`, `discriminator`, `not`, `prefixItems`, `nullable`; `deprecated`, `default`, `example(s)`, `title`/`description`; response `headers`/`links`; non-JSON responses.
+
+## Export (Altair spec → OpenAPI)
+
+`spec:emit-openapi` emits operations, an `application/json` request body from the
+`input:` block, and responses from `output:`. Not yet emitted (mirror of the
+import gaps, tracked in #214): OpenAPI `parameters` (all inputs become a JSON
+body — path/query/header distinction is lost), validation rules → schema
+constraints (`email`→`format`, `min:3`→`minLength`, `in:`→`enum`, `regex`→`pattern`),
+`security`, `servers`.
+
+## Roadmap
+
+See [#214](https://github.com/univeros/framework/issues/214) for the phased plan
+(stop silent loss → parameters → validation fidelity → content & composition →
+security & misc). This page is updated as each phase lands.

--- a/docs/guides/openapi/import.md
+++ b/docs/guides/openapi/import.md
@@ -239,6 +239,8 @@ documented normalization.
 
 ## See also
 
+- [coverage.md](coverage.md) — exactly which OpenAPI 3.1 features import maps, warns on, or errors on
+- [#214](https://github.com/univeros/framework/issues/214) — bidirectional OpenAPI fidelity (epic)
 - [#160](https://github.com/univeros/framework/issues/160) — epic
 - [#161](https://github.com/univeros/framework/issues/161) — spec emitter (library)
 - [#163](https://github.com/univeros/framework/issues/163) — `x-altair-*` extensions

--- a/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
@@ -23,6 +23,7 @@ use Altair\Scaffold\Emitter\EmittedFileKind;
 use Altair\Scaffold\Journal\Journal;
 use Altair\Scaffold\Journal\JournalEntry;
 use Altair\Scaffold\Journal\SnapshotCollector;
+use Altair\Scaffold\Sdk\Model\CoverageScanner;
 use Altair\Scaffold\Sdk\Model\OpenApiDocument;
 use Altair\Scaffold\Sdk\Model\OpenApiParser;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
@@ -84,6 +85,7 @@ final readonly class OpenApiImportRunner
         private Parser $specParser = new Parser(),
         private Validator $specValidator = new Validator(),
         private PersistenceInferrer $persistenceInferrer = new PersistenceInferrer(),
+        private CoverageScanner $coverageScanner = new CoverageScanner(),
         private ?Journal $journal = null,
         private ?RecorderInterface $events = null,
     ) {}
@@ -114,8 +116,10 @@ final readonly class OpenApiImportRunner
             return $this->failure($options, $throwable->getMessage(), $startedAt);
         }
 
+        $coverageWarnings = $this->coverageWarnings($sourceContents);
+
         if ($options->dryRun) {
-            return $this->dryRunReceipt($options, $plan, $document);
+            return $this->dryRunReceipt($options, $plan, $document, $coverageWarnings);
         }
 
         $collector = new SnapshotCollector($options->projectRoot);
@@ -124,7 +128,7 @@ final readonly class OpenApiImportRunner
         $writtenSpecs = $this->writeSpecs($plan->files, $writer, $collector, $options->force);
         $scaffoldFiles = [];
         $rolledBack = [];
-        $warnings = [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document), ...$plan->warnings];
+        $warnings = [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document), ...$coverageWarnings, ...$plan->warnings];
 
         if ($options->scaffold && $writtenSpecs !== []) {
             try {
@@ -440,7 +444,10 @@ final readonly class OpenApiImportRunner
         return $contents === false ? null : $contents;
     }
 
-    private function dryRunReceipt(OpenApiImportOptions $options, ImportPlan $plan, OpenApiDocument $document): ImportReceipt
+    /**
+     * @param list<string> $coverageWarnings
+     */
+    private function dryRunReceipt(OpenApiImportOptions $options, ImportPlan $plan, OpenApiDocument $document, array $coverageWarnings): ImportReceipt
     {
         return new ImportReceipt(
             ok: true,
@@ -450,11 +457,29 @@ final readonly class OpenApiImportRunner
             scaffolded: [],
             rolledBack: [],
             unmapped: $plan->unmapped,
-            warnings: [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document), ...$plan->warnings],
+            warnings: [...$this->initialWarnings($options), ...$this->unknownExtensionWarnings($document), ...$coverageWarnings, ...$plan->warnings],
             journalId: null,
             eventId: null,
             error: null,
         );
+    }
+
+    /**
+     * Warnings for every OpenAPI construct the importer drops — so nothing is
+     * lost silently. Best-effort: a document that no longer parses as YAML
+     * simply yields no coverage warnings (the parse failure surfaces elsewhere).
+     *
+     * @return list<string>
+     */
+    private function coverageWarnings(string $sourceContents): array
+    {
+        try {
+            $raw = Yaml::parse($sourceContents);
+        } catch (Throwable) {
+            return [];
+        }
+
+        return \is_array($raw) ? $this->coverageScanner->scan($raw) : [];
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
+++ b/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Sdk\Model;
+
+/**
+ * Walks a raw OpenAPI document and reports every construct `openapi:import`
+ * does not map — so the import warns instead of silently dropping.
+ *
+ * {@see OpenApiParser} reads only a subset (paths, JSON bodies/responses,
+ * component schemas), discarding the rest *before* the mapper runs. This
+ * scanner inspects the same raw document independently and produces one
+ * warning per dropped construct, in document order (deterministic, so import
+ * receipts stay byte-stable). It is Phase 1 of #214 — coverage is widened as
+ * later phases actually map these features.
+ */
+final readonly class CoverageScanner
+{
+    private const array HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
+    /**
+     * @param  array<string, mixed> $document Raw decoded OpenAPI document.
+     * @return list<string>
+     */
+    public function scan(array $document): array
+    {
+        $warnings = [];
+
+        $this->scanDocument($document, $warnings);
+
+        $paths = $document['paths'] ?? null;
+        if (\is_array($paths)) {
+            foreach ($paths as $path => $item) {
+                if (\is_string($path) && \is_array($item)) {
+                    $this->scanPathItem($path, $item, $warnings);
+                }
+            }
+        }
+
+        return $warnings;
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     * @param list<string>         $warnings
+     */
+    private function scanDocument(array $document, array &$warnings): void
+    {
+        if ($this->nonEmptyArray($document['servers'] ?? null)) {
+            $warnings[] = 'document `servers` are not imported.';
+        }
+
+        if ($this->nonEmptyArray($document['security'] ?? null)) {
+            $warnings[] = 'global `security` requirements are not imported.';
+        }
+
+        if ($this->nonEmptyArray($document['webhooks'] ?? null)) {
+            $warnings[] = '`webhooks` are not imported (only `paths` are read).';
+        }
+
+        $components = $document['components'] ?? null;
+        if (\is_array($components) && $this->nonEmptyArray($components['securitySchemes'] ?? null)) {
+            $warnings[] = '`components.securitySchemes` are not imported.';
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     * @param list<string>         $warnings
+     */
+    private function scanPathItem(string $path, array $item, array &$warnings): void
+    {
+        if (isset($item['$ref'])) {
+            $warnings[] = \sprintf('path item `$ref` on %s is not imported.', $path);
+
+            return;
+        }
+
+        $this->scanParameters($item['parameters'] ?? null, $path . ' (all operations)', $warnings);
+
+        foreach (self::HTTP_METHODS as $method) {
+            $operation = $item[$method] ?? null;
+            if (\is_array($operation)) {
+                $this->scanOperation(strtoupper($method) . ' ' . $path, $operation, $warnings);
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $operation
+     * @param list<string>         $warnings
+     */
+    private function scanOperation(string $where, array $operation, array &$warnings): void
+    {
+        $this->scanParameters($operation['parameters'] ?? null, $where, $warnings);
+        $this->scanRequestBody($operation['requestBody'] ?? null, $where, $warnings);
+
+        if ($this->nonEmptyArray($operation['security'] ?? null)) {
+            $warnings[] = \sprintf('operation `security` on %s is not imported.', $where);
+        }
+
+        if ($this->nonEmptyArray($operation['callbacks'] ?? null)) {
+            $warnings[] = \sprintf('`callbacks` on %s are not imported.', $where);
+        }
+    }
+
+    /**
+     * Path parameters are mapped (as strings); query/header/cookie parameters
+     * and `$ref` parameters are dropped, so each is warned.
+     *
+     * @param list<string> $warnings
+     */
+    private function scanParameters(mixed $parameters, string $where, array &$warnings): void
+    {
+        if (!\is_array($parameters)) {
+            return;
+        }
+
+        foreach ($parameters as $parameter) {
+            if (!\is_array($parameter)) {
+                continue;
+            }
+
+            if (isset($parameter['$ref'])) {
+                $warnings[] = \sprintf('parameter `$ref` on %s is not imported.', $where);
+
+                continue;
+            }
+
+            $in = $parameter['in'] ?? null;
+            if (\in_array($in, ['query', 'header', 'cookie'], true)) {
+                $name = isset($parameter['name']) && \is_string($parameter['name']) ? $parameter['name'] : '?';
+                $warnings[] = \sprintf('%s parameter `%s` on %s is dropped.', $in, $name, $where);
+            }
+        }
+    }
+
+    /**
+     * @param list<string> $warnings
+     */
+    private function scanRequestBody(mixed $requestBody, string $where, array &$warnings): void
+    {
+        if (!\is_array($requestBody)) {
+            return;
+        }
+
+        if (isset($requestBody['$ref'])) {
+            $warnings[] = \sprintf('requestBody `$ref` on %s is not imported (body dropped).', $where);
+
+            return;
+        }
+
+        $content = $requestBody['content'] ?? null;
+        if (!\is_array($content)) {
+            return;
+        }
+
+        $otherTypes = array_values(array_filter(
+            array_keys($content),
+            static fn(int|string $type): bool => \is_string($type) && $type !== 'application/json',
+        ));
+        if ($otherTypes === []) {
+            return;
+        }
+
+        $warnings[] = isset($content['application/json'])
+            ? \sprintf('request body content type(s) %s on %s are not imported (only application/json is read).', implode(', ', $otherTypes), $where)
+            : \sprintf('request body on %s uses %s; only application/json is imported, so the body is dropped.', $where, implode(', ', $otherTypes));
+    }
+
+    private function nonEmptyArray(mixed $value): bool
+    {
+        return \is_array($value) && $value !== [];
+    }
+}

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -309,6 +309,36 @@ final class OpenApiImportRunnerTest extends TestCase
         self::assertStringContainsString('every operation was unmappable', implode("\n", $receipt->warnings));
     }
 
+    public function testSurfacesDroppedConstructsAsWarnings(): void
+    {
+        // The import succeeds, but must warn about the query parameter it drops
+        // rather than losing it silently.
+        $documentPath = $this->sandbox . '/openapi.yaml';
+        file_put_contents($documentPath, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets, version: 1.0.0 }
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  parameters:
+                    - { name: status, in: query, required: true, schema: { type: string } }
+                  responses: { '200': { description: ok } }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+            dryRun: true,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertStringContainsString(
+            'query parameter `status` on GET /pets is dropped.',
+            implode("\n", $receipt->warnings),
+        );
+    }
+
     public function testReportsMissingDocument(): void
     {
         $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(

--- a/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
+++ b/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Sdk\Model;
+
+use Altair\Scaffold\Sdk\Model\CoverageScanner;
+use PHPUnit\Framework\TestCase;
+
+final class CoverageScannerTest extends TestCase
+{
+    public function testMinimalDocumentHasNoWarnings(): void
+    {
+        $warnings = (new CoverageScanner())->scan([
+            'openapi' => '3.1.0',
+            'paths' => [
+                '/users' => [
+                    'post' => [
+                        'operationId' => 'createUser',
+                        'requestBody' => ['content' => ['application/json' => ['schema' => ['type' => 'object']]]],
+                        'responses' => ['201' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame([], $warnings);
+    }
+
+    public function testWarnsOnQueryHeaderAndCookieParametersButNotPath(): void
+    {
+        $warnings = (new CoverageScanner())->scan([
+            'paths' => [
+                '/pets/{id}' => [
+                    'get' => [
+                        'parameters' => [
+                            ['name' => 'id', 'in' => 'path', 'schema' => ['type' => 'string']],
+                            ['name' => 'status', 'in' => 'query', 'schema' => ['type' => 'string']],
+                            ['name' => 'x-api', 'in' => 'header', 'schema' => ['type' => 'string']],
+                            ['name' => 'sid', 'in' => 'cookie', 'schema' => ['type' => 'string']],
+                        ],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            'query parameter `status` on GET /pets/{id} is dropped.',
+            'header parameter `x-api` on GET /pets/{id} is dropped.',
+            'cookie parameter `sid` on GET /pets/{id} is dropped.',
+        ], $warnings);
+    }
+
+    public function testWarnsOnRequestBodyRefAndNonJsonBody(): void
+    {
+        $warnings = (new CoverageScanner())->scan([
+            'paths' => [
+                '/a' => ['post' => ['requestBody' => ['$ref' => '#/components/requestBodies/X'], 'responses' => []]],
+                '/b' => ['post' => ['requestBody' => ['content' => ['multipart/form-data' => ['schema' => ['type' => 'object']]]], 'responses' => []]],
+                '/c' => ['post' => ['requestBody' => ['content' => ['application/json' => ['schema' => ['type' => 'object']], 'application/xml' => ['schema' => ['type' => 'object']]]], 'responses' => []]],
+            ],
+        ]);
+
+        self::assertSame([
+            'requestBody `$ref` on POST /a is not imported (body dropped).',
+            'request body on POST /b uses multipart/form-data; only application/json is imported, so the body is dropped.',
+            'request body content type(s) application/xml on POST /c are not imported (only application/json is read).',
+        ], $warnings);
+    }
+
+    public function testWarnsOnDocumentLevelAndOperationLevelConstructs(): void
+    {
+        $warnings = (new CoverageScanner())->scan([
+            'servers' => [['url' => 'https://api.example.com']],
+            'security' => [['apiKey' => []]],
+            'webhooks' => ['newPet' => ['post' => []]],
+            'components' => ['securitySchemes' => ['apiKey' => ['type' => 'apiKey']]],
+            'paths' => [
+                '/things' => [
+                    'get' => [
+                        'security' => [['apiKey' => []]],
+                        'callbacks' => ['onEvent' => []],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame([
+            'document `servers` are not imported.',
+            'global `security` requirements are not imported.',
+            '`webhooks` are not imported (only `paths` are read).',
+            '`components.securitySchemes` are not imported.',
+            'operation `security` on GET /things is not imported.',
+            '`callbacks` on GET /things are not imported.',
+        ], $warnings);
+    }
+}


### PR DESCRIPTION
Part of #214 (bidirectional OpenAPI fidelity). **Phase 1 — stop silent loss.**

## Why

Importing the real Swagger Petstore "succeeded" (`ok=true`) while **silently dropping** every query parameter, non-JSON body, security requirement, and more. That's worse than an error. This makes the importer honest: it now **warns about every construct it drops** instead of losing it silently.

## What

A `CoverageScanner` walks the raw OpenAPI document independently of the (lossy) parser and emits one warning per dropped construct, in document order (deterministic — receipts stay byte-stable). Wired into `OpenApiImportRunner` (`warnings[]` + human output), for both dry-run and write paths.

Surfaced now (were silent): **query/header/cookie parameters** + parameter `$ref`, **non-`application/json` request bodies**, requestBody **`$ref`**, operation + global **`security`** + `components.securitySchemes`, `servers`, `webhooks`, `callbacks`, path-item `$ref`.

## On the real Petstore

```
Wrote 19 spec file(s): ...
warning: query parameter `status` on GET /pet/findByStatus is dropped.
warning: header parameter `api_key` on DELETE /pet/{petId} is dropped.
warning: request body on POST /pet/{petId}/uploadImage uses application/octet-stream; ... body is dropped.
warning: operation `security` on PUT /pet is not imported.
warning: `components.securitySchemes` are not imported.
... (25 warnings total)
```

Still imports the 19 mappable operations — but now tells the truth about the 25 it can't.

## Also

- `docs/guides/openapi/coverage.md` — the evidence-based feature matrix (import + export), linked from the import guide.
- Epic #214 tracks the remaining phases (parameters, validation constraints, content types, security) — each maps these for real, in both directions.

## Test plan

- [x] `CoverageScannerTest`: params (query/header/cookie, not path), requestBody `$ref`/non-JSON, doc + op-level constructs — exact warning strings + deterministic order.
- [x] Runner test: a dropped query param surfaces in the receipt while the import still succeeds.
- [x] Existing import tests unaffected (no params/security in their fixtures).
- [x] CS + PHPStan + Rector + full Scaffold suite (280) green; `.agent/` regenerated.