### PR TITLE
feat(scaffold): map OpenAPI parameters bidirectionally (#214 Phase 2)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -57,6 +57,7 @@
 - `OperationMapper` _(final)_
 - `OperationModel` _(final)_
 - `OutputResponseSpec` _(final)_
+- `ParameterModel` _(final)_
 - `Parser`
 - `PathDeriver` _(final)_
 - `PathResolver`

--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -16,7 +16,7 @@ closes the gaps.
 ### Mapped
 
 - Paths + operations; `operationId` (or synthesised), `summary`.
-- **Path parameters** (currently always typed `string` — declared schema ignored).
+- **Parameters** — path / query / header / cookie become inputs tagged with their `in:` location (with type + `required`; enums → `in:` rule). *Phase 2.*
 - Request + response bodies in **`application/json`**.
 - Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
 - Internal `$ref` (`#/components/schemas/<Name>`), `properties` + `required`.
@@ -26,7 +26,7 @@ closes the gaps.
 
 `openapi:import` warns about each of these in its receipt (`warnings[]`) and human output:
 
-- **query / header / cookie parameters** and parameter `$ref`.
+- parameter `$ref` (not resolved).
 - **non-`application/json` request bodies** (multipart, form-urlencoded, xml, octet-stream).
 - requestBody **`$ref`** (body dropped).
 - operation + global **`security`**, `components.securitySchemes`.
@@ -44,12 +44,11 @@ closes the gaps.
 
 ## Export (Altair spec → OpenAPI)
 
-`spec:emit-openapi` emits operations, an `application/json` request body from the
-`input:` block, and responses from `output:`. Not yet emitted (mirror of the
-import gaps, tracked in #214): OpenAPI `parameters` (all inputs become a JSON
-body — path/query/header distinction is lost), validation rules → schema
-constraints (`email`→`format`, `min:3`→`minLength`, `in:`→`enum`, `regex`→`pattern`),
-`security`, `servers`.
+`spec:emit-openapi` emits operations, responses from `output:`, an
+`application/json` request body from body inputs, and **OpenAPI `parameters`**
+for inputs tagged `in: path|query|header|cookie` (Phase 2). Not yet emitted
+(tracked in #214): validation rules → schema constraints (`email`→`format`,
+`min:3`→`minLength`, `in:`→`enum`, `regex`→`pattern`), `security`, `servers`.
 
 ## Roadmap
 

--- a/src/Altair/Scaffold/Emitter/OpenApiEmitter.php
+++ b/src/Altair/Scaffold/Emitter/OpenApiEmitter.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace Altair\Scaffold\Emitter;
 
 use Altair\Scaffold\Spec\Ast\IdempotencySpec;
+use Altair\Scaffold\Spec\Ast\InputFieldSpec;
 use Altair\Scaffold\Spec\Ast\OutputResponseSpec;
 use Altair\Scaffold\Spec\Ast\PersistenceFieldSpec;
 use Altair\Scaffold\Spec\Ast\PersistenceSpec;
@@ -71,10 +72,17 @@ class OpenApiEmitter
             $operation[$key] = $value;
         }
 
-        if ($spec->inputs !== []) {
+        $parameterInputs = array_values(array_filter($spec->inputs, static fn(InputFieldSpec $f): bool => $f->isParameter()));
+        $bodyInputs = array_values(array_filter($spec->inputs, static fn(InputFieldSpec $f): bool => !$f->isParameter()));
+
+        if ($parameterInputs !== []) {
+            $operation['parameters'] = array_map($this->renderParameter(...), $parameterInputs);
+        }
+
+        if ($bodyInputs !== []) {
             $properties = [];
             $required = [];
-            foreach ($spec->inputs as $field) {
+            foreach ($bodyInputs as $field) {
                 $properties[$field->name] = $this->typeMapper->toOpenApiSchema($field);
                 if ($this->typeMapper->isRequired($field)) {
                     $required[] = $field->name;
@@ -97,6 +105,22 @@ class OpenApiEmitter
         $operation['responses'] = $this->renderResponses($spec->outputs);
 
         return $operation;
+    }
+
+    /**
+     * A non-body input renders as an OpenAPI `parameters` entry at its `in`
+     * location (path/query/header/cookie).
+     *
+     * @return array<string, mixed>
+     */
+    private function renderParameter(InputFieldSpec $field): array
+    {
+        return [
+            'name' => $field->name,
+            'in' => $field->location,
+            'required' => $this->typeMapper->isRequired($field),
+            'schema' => $this->typeMapper->toOpenApiSchema($field),
+        ];
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
+++ b/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
@@ -113,8 +113,8 @@ final readonly class CoverageScanner
     }
 
     /**
-     * Path parameters are mapped (as strings); query/header/cookie parameters
-     * and `$ref` parameters are dropped, so each is warned.
+     * Path/query/header/cookie parameters are imported (as inputs tagged with
+     * their `in` location). A parameter `$ref` is not resolved, so it is warned.
      *
      * @param list<string> $warnings
      */
@@ -125,20 +125,8 @@ final readonly class CoverageScanner
         }
 
         foreach ($parameters as $parameter) {
-            if (!\is_array($parameter)) {
-                continue;
-            }
-
-            if (isset($parameter['$ref'])) {
+            if (\is_array($parameter) && isset($parameter['$ref'])) {
                 $warnings[] = \sprintf('parameter `$ref` on %s is not imported.', $where);
-
-                continue;
-            }
-
-            $in = $parameter['in'] ?? null;
-            if (\in_array($in, ['query', 'header', 'cookie'], true)) {
-                $name = isset($parameter['name']) && \is_string($parameter['name']) ? $parameter['name'] : '?';
-                $warnings[] = \sprintf('%s parameter `%s` on %s is dropped.', $in, $name, $where);
             }
         }
     }

--- a/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
+++ b/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
@@ -26,6 +26,8 @@ use Symfony\Component\Yaml\Yaml;
  */
 final readonly class OpenApiParser
 {
+    private const array HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
+
     public function parseYaml(string $yaml): OpenApiDocument
     {
         try {
@@ -54,13 +56,21 @@ final readonly class OpenApiParser
         $namedSchemas = $this->parseComponents($doc);
         $operations = [];
 
-        foreach ($paths as $path => $methods) {
-            if (!\is_array($methods)) {
+        foreach ($paths as $path => $item) {
+            if (!\is_array($item)) {
                 continue;
             }
 
-            foreach ($methods as $method => $operation) {
+            // Path-item-level `parameters` apply to every operation under the path.
+            $pathLevelParams = \is_array($item['parameters'] ?? null) ? $item['parameters'] : [];
+
+            foreach ($item as $method => $operation) {
+                // Skip non-operation keys (parameters, summary, description, $ref).
                 if (!\is_string($method)) {
+                    continue;
+                }
+
+                if (!\in_array(strtolower($method), self::HTTP_METHODS, true)) {
                     continue;
                 }
 
@@ -68,7 +78,7 @@ final readonly class OpenApiParser
                     continue;
                 }
 
-                $operations[] = $this->parseOperation((string) $path, strtolower($method), $operation);
+                $operations[] = $this->parseOperation((string) $path, strtolower($method), $operation, $pathLevelParams);
             }
         }
 
@@ -101,11 +111,13 @@ final readonly class OpenApiParser
     }
 
     /**
-     * @param array<string, mixed> $operation
+     * @param array<string, mixed>    $operation
+     * @param array<int|string, mixed> $pathLevelParams
      */
-    private function parseOperation(string $path, string $method, array $operation): OperationModel
+    private function parseOperation(string $path, string $method, array $operation, array $pathLevelParams = []): OperationModel
     {
         $pathParams = $this->extractPathParameters($path);
+        $parameters = $this->parseParameters($pathParams, $pathLevelParams, $operation['parameters'] ?? null);
 
         $requestBody = null;
         $schema = $this->requestBodySchema($operation);
@@ -137,7 +149,85 @@ final readonly class OpenApiParser
             responses: $responses,
             summary: isset($operation['summary']) && \is_string($operation['summary']) ? $operation['summary'] : '',
             extensions: $this->extractExtensions($operation),
+            parameters: $parameters,
         );
+    }
+
+    /**
+     * Merges path-template params (as required path strings) with declared
+     * path-level then operation-level `parameters`, deduped by `in:name` with
+     * the most specific (operation-level) winning. Parameter `$ref`s are not
+     * resolved (the {@see CoverageScanner} warns about them).
+     *
+     * @param  list<string>            $templateParams Path-template `{name}`s.
+     * @param  array<int|string,mixed> $pathLevelParams
+     * @return list<ParameterModel>
+     */
+    private function parseParameters(array $templateParams, array $pathLevelParams, mixed $operationParams): array
+    {
+        /** @var array<string, ParameterModel> $byKey */
+        $byKey = [];
+        /** @var list<string> $order */
+        $order = [];
+        $add = static function (ParameterModel $parameter) use (&$byKey, &$order): void {
+            $key = $parameter->in . ':' . $parameter->name;
+            if (!isset($byKey[$key])) {
+                $order[] = $key;
+            }
+
+            $byKey[$key] = $parameter;
+        };
+
+        foreach ($templateParams as $name) {
+            $add(new ParameterModel($name, ParameterModel::IN_PATH, true));
+        }
+
+        foreach ($this->toParameterModels($pathLevelParams) as $parameter) {
+            $add($parameter);
+        }
+
+        foreach ($this->toParameterModels(\is_array($operationParams) ? $operationParams : []) as $parameter) {
+            $add($parameter);
+        }
+
+        return array_values(array_map(static fn(string $key): ParameterModel => $byKey[$key], $order));
+    }
+
+    /**
+     * @param  array<int|string, mixed> $raw
+     * @return list<ParameterModel>
+     */
+    private function toParameterModels(array $raw): array
+    {
+        $out = [];
+        foreach ($raw as $param) {
+            if (!\is_array($param)) {
+                continue;
+            }
+
+            if (isset($param['$ref'])) {
+                continue;
+            }
+
+            $name = $param['name'] ?? null;
+            $in = $param['in'] ?? null;
+            if (!\is_string($name)) {
+                continue;
+            }
+
+            if (!\is_string($in)) {
+                continue;
+            }
+
+            $out[] = new ParameterModel(
+                name: $name,
+                in: $in,
+                required: ($param['required'] ?? false) === true || $in === ParameterModel::IN_PATH,
+                schema: \is_array($param['schema'] ?? null) ? $this->parseSchema($param['schema']) : null,
+            );
+        }
+
+        return $out;
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/OperationModel.php
+++ b/src/Altair/Scaffold/Sdk/Model/OperationModel.php
@@ -22,9 +22,10 @@ namespace Altair\Scaffold\Sdk\Model;
 final readonly class OperationModel
 {
     /**
-     * @param list<string>        $pathParameters Names of `{param}` path segments, in order.
-     * @param list<ResponseModel> $responses
-     * @param array<string, mixed> $extensions    `x-altair-*` keys carried verbatim from the OpenAPI document.
+     * @param list<string>          $pathParameters Names of `{param}` path segments, in order.
+     * @param list<ResponseModel>   $responses
+     * @param array<string, mixed>  $extensions     `x-altair-*` keys carried verbatim from the OpenAPI document.
+     * @param list<ParameterModel>  $parameters     Declared parameters (path/query/header/cookie) with schema + required.
      */
     public function __construct(
         public string $operationId,
@@ -35,6 +36,7 @@ final readonly class OperationModel
         public array $responses,
         public string $summary = '',
         public array $extensions = [],
+        public array $parameters = [],
     ) {}
 
     public function hasRequestBody(): bool

--- a/src/Altair/Scaffold/Sdk/Model/ParameterModel.php
+++ b/src/Altair/Scaffold/Sdk/Model/ParameterModel.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Sdk\Model;
+
+/**
+ * One OpenAPI operation parameter — `in` is its location (`path`, `query`,
+ * `header`, or `cookie`). Carried on {@see OperationModel} so the importer can
+ * turn every parameter into an Altair input tagged with its location (rather
+ * than dropping query/header/cookie parameters as earlier releases did).
+ */
+final readonly class ParameterModel
+{
+    public const string IN_PATH = 'path';
+
+    public const string IN_QUERY = 'query';
+
+    public const string IN_HEADER = 'header';
+
+    public const string IN_COOKIE = 'cookie';
+
+    public function __construct(
+        public string $name,
+        public string $in,
+        public bool $required,
+        public ?SchemaType $schema = null,
+    ) {}
+}

--- a/src/Altair/Scaffold/Spec/Ast/InputFieldSpec.php
+++ b/src/Altair/Scaffold/Spec/Ast/InputFieldSpec.php
@@ -13,11 +13,16 @@ namespace Altair\Scaffold\Spec\Ast;
 
 final readonly class InputFieldSpec
 {
+    public const string IN_BODY = 'body';
+
     /**
      * @param list<string> $rules
-     * @param list<self>   $fields Child fields for a nested object (`type: object`)
-     *                             or the item shape of an array of objects
-     *                             (`type: array` with `fields`). Empty for scalars.
+     * @param list<self>   $fields   Child fields for a nested object (`type: object`)
+     *                               or the item shape of an array of objects
+     *                               (`type: array` with `fields`). Empty for scalars.
+     * @param string       $location Where the value comes from: `body` (default),
+     *                               `path`, `query`, `header`, or `cookie`. Non-body
+     *                               inputs export as OpenAPI `parameters`.
      */
     public function __construct(
         public string $name,
@@ -28,7 +33,13 @@ final readonly class InputFieldSpec
         public mixed $default = null,
         public bool $hasDefault = false,
         public array $fields = [],
+        public string $location = self::IN_BODY,
     ) {}
+
+    public function isParameter(): bool
+    {
+        return $this->location !== self::IN_BODY;
+    }
 
     public function isRequired(): bool
     {

--- a/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
@@ -13,6 +13,7 @@ namespace Altair\Scaffold\Spec\Emitter;
 
 use Altair\Scaffold\Sdk\Model\OpenApiDocument;
 use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Sdk\Model\ParameterModel;
 use Altair\Scaffold\Sdk\Model\ResponseModel;
 use Altair\Scaffold\Sdk\Model\SchemaType;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
@@ -53,12 +54,8 @@ final readonly class SchemaMapper
     {
         $fields = [];
 
-        foreach ($operation->pathParameters as $name) {
-            $fields[] = [
-                'name' => $name,
-                'type' => 'string',
-                'rules' => ['required'],
-            ];
+        foreach ($this->operationParameters($operation) as $parameter) {
+            $fields[] = $this->parameterField($parameter);
         }
 
         $requestBody = $operation->requestBody;
@@ -99,6 +96,57 @@ final readonly class SchemaMapper
         }
 
         return $outputs;
+    }
+
+    /**
+     * Declared parameters, falling back to bare path-parameter names for an
+     * {@see OperationModel} built without a `parameters` list (older callers).
+     *
+     * @return list<ParameterModel>
+     */
+    private function operationParameters(OperationModel $operation): array
+    {
+        if ($operation->parameters !== []) {
+            return $operation->parameters;
+        }
+
+        return array_map(
+            static fn(string $name): ParameterModel => new ParameterModel($name, ParameterModel::IN_PATH, true),
+            $operation->pathParameters,
+        );
+    }
+
+    /**
+     * A path/query/header/cookie parameter becomes an input field tagged with
+     * its `in` location (so it exports back to an OpenAPI parameter). Parameters
+     * are scalars/enums/arrays in practice; anything richer falls back to string.
+     *
+     * @return array<string, mixed>
+     */
+    private function parameterField(ParameterModel $parameter): array
+    {
+        $rules = $parameter->required ? ['required'] : [];
+        $type = 'string';
+        $schema = $parameter->schema;
+
+        if ($schema instanceof SchemaType) {
+            if ($schema->kind === SchemaType::ENUM && $schema->enumValues !== []) {
+                $rules[] = 'in:' . implode(',', $schema->enumValues);
+            } else {
+                $type = match ($schema->kind) {
+                    SchemaType::ARRAY => 'array',
+                    SchemaType::SCALAR => $this->inputScalarType((string) $schema->scalarType),
+                    default => 'string',
+                };
+            }
+        }
+
+        return [
+            'name' => $parameter->name,
+            'type' => $type,
+            'in' => $parameter->in,
+            'rules' => $rules,
+        ];
     }
 
     /**

--- a/src/Altair/Scaffold/Spec/Parser.php
+++ b/src/Altair/Scaffold/Spec/Parser.php
@@ -316,6 +316,7 @@ class Parser
             default: $raw['default'] ?? null,
             hasDefault: \array_key_exists('default', $raw),
             fields: $fields,
+            location: isset($raw['in']) ? (string) $raw['in'] : InputFieldSpec::IN_BODY,
         );
     }
 

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -311,8 +311,35 @@ final class OpenApiImportRunnerTest extends TestCase
 
     public function testSurfacesDroppedConstructsAsWarnings(): void
     {
-        // The import succeeds, but must warn about the query parameter it drops
-        // rather than losing it silently.
+        // The import succeeds, but must warn about constructs it drops (here:
+        // operation security) rather than losing them silently.
+        $documentPath = $this->sandbox . '/openapi.yaml';
+        file_put_contents($documentPath, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets, version: 1.0.0 }
+            paths:
+              /pets:
+                get:
+                  operationId: listPets
+                  security: [{ apiKey: [] }]
+                  responses: { '200': { description: ok } }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $documentPath,
+            projectRoot: $this->sandbox,
+            dryRun: true,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertStringContainsString(
+            'operation `security` on GET /pets is not imported.',
+            implode("\n", $receipt->warnings),
+        );
+    }
+
+    public function testQueryParametersAreImportedAsInputs(): void
+    {
         $documentPath = $this->sandbox . '/openapi.yaml';
         file_put_contents($documentPath, <<<'YAML'
             openapi: 3.1.0
@@ -329,14 +356,13 @@ final class OpenApiImportRunnerTest extends TestCase
         $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
             documentPath: $documentPath,
             projectRoot: $this->sandbox,
-            dryRun: true,
         ));
 
-        self::assertTrue($receipt->ok);
-        self::assertStringContainsString(
-            'query parameter `status` on GET /pets is dropped.',
-            implode("\n", $receipt->warnings),
-        );
+        self::assertTrue($receipt->ok, (string) $receipt->error);
+        $spec = Yaml::parseFile($this->sandbox . '/api/pets/list.yaml');
+        self::assertSame('query', $spec['input']['status']['in']);
+        self::assertSame('string', $spec['input']['status']['type']);
+        self::assertContains('required', $spec['input']['status']['rules']);
     }
 
     public function testReportsMissingDocument(): void

--- a/tests/Scaffold/Emitter/OpenApiEmitterTest.php
+++ b/tests/Scaffold/Emitter/OpenApiEmitterTest.php
@@ -6,6 +6,7 @@ namespace Altair\Tests\Scaffold\Emitter;
 
 use Altair\Scaffold\Emitter\EmittedFileKind;
 use Altair\Scaffold\Emitter\OpenApiEmitter;
+use Altair\Scaffold\Spec\Parser;
 use Altair\Tests\Scaffold\Support\SpecFixture;
 use Altair\Tests\Scaffold\Support\Snapshots;
 use PHPUnit\Framework\TestCase;
@@ -13,6 +14,38 @@ use Symfony\Component\Yaml\Yaml;
 
 final class OpenApiEmitterTest extends TestCase
 {
+    public function testEmitsNonBodyInputsAsParameters(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint: { method: GET, path: /pets, summary: List pets }
+            input:
+              status: { type: string, in: query, rules: [required] }
+              tenant: { type: string, in: header }
+            output:
+              200: { body: { result: 'list<App\Pet\Pet>' } }
+            domain: { class: App\Pet\ListPets }
+            YAML;
+        $spec = (new Parser())->parseString($yaml);
+
+        $parsed = Yaml::parse((new OpenApiEmitter())->emit($spec)->contents);
+        self::assertIsArray($parsed);
+        $operation = $parsed['paths']['/pets']['get'];
+
+        self::assertArrayHasKey('parameters', $operation);
+        self::assertArrayNotHasKey('requestBody', $operation, 'all inputs are parameters, so there is no body');
+
+        $byName = [];
+        foreach ($operation['parameters'] as $parameter) {
+            $byName[$parameter['name']] = $parameter;
+        }
+
+        self::assertSame('query', $byName['status']['in']);
+        self::assertTrue($byName['status']['required']);
+        self::assertSame(['type' => 'string'], $byName['status']['schema']);
+        self::assertSame('header', $byName['tenant']['in']);
+        self::assertFalse($byName['tenant']['required']);
+    }
+
     public function testEmitsOpenApi3Fragment(): void
     {
         $file = (new OpenApiEmitter())->emit(SpecFixture::createUser());

--- a/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
+++ b/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
@@ -27,8 +27,10 @@ final class CoverageScannerTest extends TestCase
         self::assertSame([], $warnings);
     }
 
-    public function testWarnsOnQueryHeaderAndCookieParametersButNotPath(): void
+    public function testParametersAreImportedSoOnlyRefParametersWarn(): void
     {
+        // path/query/header/cookie parameters are now mapped (Phase 2); only an
+        // unresolved parameter `$ref` is still dropped.
         $warnings = (new CoverageScanner())->scan([
             'paths' => [
                 '/pets/{id}' => [
@@ -38,6 +40,7 @@ final class CoverageScannerTest extends TestCase
                             ['name' => 'status', 'in' => 'query', 'schema' => ['type' => 'string']],
                             ['name' => 'x-api', 'in' => 'header', 'schema' => ['type' => 'string']],
                             ['name' => 'sid', 'in' => 'cookie', 'schema' => ['type' => 'string']],
+                            ['$ref' => '#/components/parameters/Tenant'],
                         ],
                         'responses' => ['200' => ['description' => 'ok']],
                     ],
@@ -46,9 +49,7 @@ final class CoverageScannerTest extends TestCase
         ]);
 
         self::assertSame([
-            'query parameter `status` on GET /pets/{id} is dropped.',
-            'header parameter `x-api` on GET /pets/{id} is dropped.',
-            'cookie parameter `sid` on GET /pets/{id} is dropped.',
+            'parameter `$ref` on GET /pets/{id} is not imported.',
         ], $warnings);
     }
 

--- a/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
@@ -6,6 +6,7 @@ namespace Altair\Tests\Scaffold\Spec\Emitter;
 
 use Altair\Scaffold\Sdk\Model\OpenApiDocument;
 use Altair\Scaffold\Sdk\Model\OperationModel;
+use Altair\Scaffold\Sdk\Model\ParameterModel;
 use Altair\Scaffold\Sdk\Model\ResponseModel;
 use Altair\Scaffold\Sdk\Model\SchemaType;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
@@ -20,7 +21,24 @@ final class SchemaMapperTest extends TestCase
         $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
 
         self::assertSame([
-            ['name' => 'id', 'type' => 'string', 'rules' => ['required']],
+            ['name' => 'id', 'type' => 'string', 'in' => 'path', 'rules' => ['required']],
+        ], $fields);
+    }
+
+    public function testQueryHeaderAndEnumParametersBecomeInputs(): void
+    {
+        $operation = $this->operation('GET', '/pets', parameters: [
+            new ParameterModel('status', ParameterModel::IN_QUERY, true, SchemaType::enum(['available', 'sold'])),
+            new ParameterModel('limit', ParameterModel::IN_QUERY, false, SchemaType::scalar('integer')),
+            new ParameterModel('x-tenant', ParameterModel::IN_HEADER, false, SchemaType::scalar('string')),
+        ]);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'status', 'type' => 'string', 'in' => 'query', 'rules' => ['required', 'in:available,sold']],
+            ['name' => 'limit', 'type' => 'int', 'in' => 'query', 'rules' => []],
+            ['name' => 'x-tenant', 'type' => 'string', 'in' => 'header', 'rules' => []],
         ], $fields);
     }
 
@@ -347,8 +365,9 @@ final class SchemaMapperTest extends TestCase
     }
 
     /**
-     * @param list<string>        $pathParameters
-     * @param list<ResponseModel> $responses
+     * @param list<string>          $pathParameters
+     * @param list<ResponseModel>   $responses
+     * @param list<ParameterModel>  $parameters
      */
     private function operation(
         string $method,
@@ -357,6 +376,7 @@ final class SchemaMapperTest extends TestCase
         array $pathParameters = [],
         ?SchemaType $requestBody = null,
         array $responses = [],
+        array $parameters = [],
     ): OperationModel {
         return new OperationModel(
             operationId: $operationId,
@@ -365,6 +385,7 @@ final class SchemaMapperTest extends TestCase
             pathParameters: $pathParameters,
             requestBody: $requestBody,
             responses: $responses,
+            parameters: $parameters,
         );
     }
 


### PR DESCRIPTION
Part of #214. **Phase 2 — parameters.**

## Why

Query/header/cookie parameters were **silently dropped** on import and never emitted on export (all inputs leaked into a JSON request body — wrong for a GET). Now parameters round-trip.

## Import (OpenAPI → Altair)

- The parser reads the **`parameters` array** (path-item + operation level, deduped by `in:name`, operation-level wins) into a new `ParameterModel`.
- The reverse mapper turns each into an Altair input tagged with its **`in:` location** (type from the parameter schema, `required`, enums → `in:` rule). Path parameters are tagged `in: path` too.
- Latent bug fixed: a path-item `parameters` key was being treated as a bogus operation — the method loop now filters to real HTTP methods.

## Export (Altair → OpenAPI)

`OpenApiEmitter` splits inputs by location: `in != body` → OpenAPI **`parameters`** (`name`/`in`/`required`/`schema`); body inputs stay in the `application/json` request body.

## Spec

`InputFieldSpec` gains `location` (default `body`); the spec Parser reads `in:`; the reverse mapper / OperationMapper emit it.

## On the real Petstore

```yaml
# api/findByStatus/find.yaml — previously had NO input at all
input:
  status:
    type: string
    in: query
    rules: [required, 'in:available,pending,sold']
```
- Warning count drops **25 → 17** (the 8 query/header param warnings are gone — they're mapped now).
- `openapi:roundtrip --check` → clean, 19 operations.

## Test plan

- [x] Reverse: path param → `in: path`; query/header/enum params → inputs with `in` + type + rules.
- [x] Forward: non-body inputs emit as OpenAPI `parameters`; all-param op has no `requestBody`.
- [x] Runner: query param imports as an input; still-dropped constructs (security) still warn.
- [x] `CoverageScanner` no longer warns on mapped params (only parameter `$ref`).
- [x] CS + PHPStan + Rector + full suite green (only pre-existing env errors); `.agent/` regenerated; coverage doc updated.