### PR TITLE
feat(scaffold): map validation constraints <-> rules (#214 Phase 3)

### DIFF
--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -19,6 +19,7 @@ closes the gaps.
 - **Parameters** — path / query / header / cookie become inputs tagged with their `in:` location (with type + `required`; enums → `in:` rule). *Phase 2.*
 - Request + response bodies in **`application/json`**.
 - Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
+- **Validation constraints** ↔ rules (Phase 3): `format` (`email`/`uri`/`ip`/`date-time`)→`email`/`url`/`ip`/`datetime`; `minLength`/`maxLength`→`min`/`max`; `minimum`/`maximum`→`min`/`max`; `pattern`→`regex:`. Round-trips (the forward emitter writes the inverse).
 - Internal `$ref` (`#/components/schemas/<Name>`), `properties` + `required`.
 - `x-altair-*` extensions (domain/persistence/queue/idempotency/webhook round-trip).
 
@@ -39,16 +40,17 @@ closes the gaps.
 
 ### Not yet mapped or warned (later phases)
 
-- Validation constraints: `format`, `min/maxLength`, `pattern`, `minimum/maximum`, `multipleOf`, `min/maxItems` (Phase 3 → `Altair\Validation` rules).
+- Remaining constraints: `multipleOf`, `min/maxItems`, `uniqueItems` (no Altair rule yet).
 - requestBody `required` flag; `additionalProperties`, `const`, `discriminator`, `not`, `prefixItems`, `nullable`; `deprecated`, `default`, `example(s)`, `title`/`description`; response `headers`/`links`; non-JSON responses.
 
 ## Export (Altair spec → OpenAPI)
 
 `spec:emit-openapi` emits operations, responses from `output:`, an
-`application/json` request body from body inputs, and **OpenAPI `parameters`**
-for inputs tagged `in: path|query|header|cookie` (Phase 2). Not yet emitted
-(tracked in #214): validation rules → schema constraints (`email`→`format`,
-`min:3`→`minLength`, `in:`→`enum`, `regex`→`pattern`), `security`, `servers`.
+`application/json` request body from body inputs, **OpenAPI `parameters`** for
+inputs tagged `in: path|query|header|cookie` (Phase 2), and **schema
+constraints** from validation rules — `email`→`format`, `min:3`→`minLength`,
+`in:`→`enum`, `regex`→`pattern` (Phase 3). Not yet emitted (tracked in #214):
+`security`, `servers`.
 
 ## Roadmap
 

--- a/src/Altair/Scaffold/Emitter/TypeMapper.php
+++ b/src/Altair/Scaffold/Emitter/TypeMapper.php
@@ -46,12 +46,12 @@ final class TypeMapper
         }
 
         return match (strtolower($field->type)) {
-            'int', 'integer' => ['type' => 'integer'],
-            'float'          => ['type' => 'number', 'format' => 'float'],
+            'int', 'integer' => $this->applyConstraints(['type' => 'integer'], $field),
+            'float'          => $this->applyConstraints(['type' => 'number', 'format' => 'float'], $field),
             'bool', 'boolean' => ['type' => 'boolean'],
             'object'         => $this->objectSchema($field),
             'array'          => $this->arraySchema($field),
-            default          => ['type' => 'string'],
+            default          => $this->applyConstraints(['type' => 'string'], $field),
         };
     }
 
@@ -61,6 +61,49 @@ final class TypeMapper
     public function isRequired(InputFieldSpec $field): bool
     {
         return $field->isRequired() && !$field->hasDefault;
+    }
+
+    /**
+     * Adds the JSON-Schema constraints encoded in a field's validation rules —
+     * the inverse of the import-side rule mapping, so the two round-trip:
+     * `email`→`format: email`, `regex:p`→`pattern: p`, `in:a,b`→`enum`,
+     * `min`/`max`→`minLength`/`maxLength` (strings) or `minimum`/`maximum`.
+     *
+     * @param  array<string, mixed> $schema
+     * @return array<string, mixed>
+     */
+    private function applyConstraints(array $schema, InputFieldSpec $field): array
+    {
+        $isString = ($schema['type'] ?? '') === 'string';
+        foreach ($field->rules as $rule) {
+            $schema = [...$schema, ...$this->constraintFromRule($rule, $isString)];
+        }
+
+        return $schema;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function constraintFromRule(string $rule, bool $isString): array
+    {
+        [$name, $arg] = array_pad(explode(':', $rule, 2), 2, '');
+
+        return match ($name) {
+            'email'    => ['format' => 'email'],
+            'url'      => ['format' => 'uri'],
+            'datetime' => ['format' => 'date-time'],
+            'regex'    => $arg !== '' ? ['pattern' => $arg] : [],
+            'in'       => $arg !== '' ? ['enum' => explode(',', $arg)] : [],
+            'min'      => $isString ? ['minLength' => (int) $arg] : ['minimum' => $this->numericArg($arg)],
+            'max'      => $isString ? ['maxLength' => (int) $arg] : ['maximum' => $this->numericArg($arg)],
+            default    => [],
+        };
+    }
+
+    private function numericArg(string $arg): int|float
+    {
+        return str_contains($arg, '.') ? (float) $arg : (int) $arg;
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
+++ b/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
@@ -325,12 +325,35 @@ final readonly class OpenApiParser
                 $nullable,
             ),
             'object' => SchemaType::object($this->parseProperties($schema), $nullable),
-            'integer' => SchemaType::scalar('integer', $this->formatOf($schema), $nullable),
-            'number' => SchemaType::scalar('number', $this->formatOf($schema), $nullable),
+            'integer' => SchemaType::scalar('integer', $this->formatOf($schema), $nullable, $this->constraintsOf($schema)),
+            'number' => SchemaType::scalar('number', $this->formatOf($schema), $nullable, $this->constraintsOf($schema)),
             'boolean' => SchemaType::scalar('boolean', null, $nullable),
-            'string' => SchemaType::scalar('string', $this->formatOf($schema), $nullable),
+            'string' => SchemaType::scalar('string', $this->formatOf($schema), $nullable, $this->constraintsOf($schema)),
             default => $this->fallbackSchema($schema, $nullable),
         };
+    }
+
+    /**
+     * The JSON-Schema validation keywords the importer maps to Altair rules.
+     *
+     * @param  array<string, mixed>            $schema
+     * @return array<string, int|float|string>
+     */
+    private function constraintsOf(array $schema): array
+    {
+        $out = [];
+        foreach (['minLength', 'maxLength', 'minimum', 'maximum'] as $keyword) {
+            $value = $schema[$keyword] ?? null;
+            if (\is_int($value) || \is_float($value)) {
+                $out[$keyword] = $value;
+            }
+        }
+
+        if (isset($schema['pattern']) && \is_string($schema['pattern'])) {
+            $out['pattern'] = $schema['pattern'];
+        }
+
+        return $out;
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/SchemaType.php
+++ b/src/Altair/Scaffold/Sdk/Model/SchemaType.php
@@ -35,8 +35,10 @@ final readonly class SchemaType
     public const string MIXED = 'mixed';
 
     /**
-     * @param array<string, PropertyShape> $properties Object properties (OBJECT kind).
-     * @param list<string>                  $enumValues Allowed values (ENUM kind).
+     * @param array<string, PropertyShape>      $properties  Object properties (OBJECT kind).
+     * @param list<string>                       $enumValues  Allowed values (ENUM kind).
+     * @param array<string, int|float|string>    $constraints JSON-Schema validation keywords kept verbatim
+     *                                                        (`minLength`, `maxLength`, `pattern`, `minimum`, `maximum`).
      */
     public function __construct(
         public string $kind,
@@ -47,11 +49,15 @@ final readonly class SchemaType
         public array $enumValues = [],
         public ?string $format = null,
         public bool $nullable = false,
+        public array $constraints = [],
     ) {}
 
-    public static function scalar(string $scalarType, ?string $format = null, bool $nullable = false): self
+    /**
+     * @param array<string, int|float|string> $constraints
+     */
+    public static function scalar(string $scalarType, ?string $format = null, bool $nullable = false, array $constraints = []): self
     {
-        return new self(kind: self::SCALAR, scalarType: $scalarType, format: $format, nullable: $nullable);
+        return new self(kind: self::SCALAR, scalarType: $scalarType, format: $format, nullable: $nullable, constraints: $constraints);
     }
 
     public static function mixed(): self

--- a/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
@@ -138,6 +138,7 @@ final readonly class SchemaMapper
                     SchemaType::SCALAR => $this->inputScalarType((string) $schema->scalarType),
                     default => 'string',
                 };
+                $rules = [...$rules, ...$this->constraintRules($schema)];
             }
         }
 
@@ -271,8 +272,55 @@ final readonly class SchemaMapper
         return [
             'name' => $name,
             'type' => $this->inputScalarType((string) $schema->scalarType),
-            'rules' => $rules,
+            'rules' => [...$rules, ...$this->constraintRules($schema)],
         ];
+    }
+
+    /**
+     * Translates a scalar schema's `format` + JSON-Schema validation keywords
+     * into Altair validation rules. The inverse of the forward
+     * {@see \Altair\Scaffold\Emitter\TypeMapper}'s rule → constraint mapping, so
+     * the pair round-trips.
+     *
+     * @return list<string>
+     */
+    private function constraintRules(SchemaType $schema): array
+    {
+        $rules = [];
+
+        $formatRule = match (strtolower((string) $schema->format)) {
+            'email' => 'email',
+            'uri', 'url' => 'url',
+            'ipv4', 'ipv6', 'ip' => 'ip',
+            'date-time', 'date', 'time' => 'datetime',
+            default => null,
+        };
+        if ($formatRule !== null) {
+            $rules[] = $formatRule;
+        }
+
+        $constraints = $schema->constraints;
+        if (isset($constraints['minLength'])) {
+            $rules[] = 'min:' . $constraints['minLength'];
+        }
+
+        if (isset($constraints['maxLength'])) {
+            $rules[] = 'max:' . $constraints['maxLength'];
+        }
+
+        if (isset($constraints['minimum'])) {
+            $rules[] = 'min:' . $constraints['minimum'];
+        }
+
+        if (isset($constraints['maximum'])) {
+            $rules[] = 'max:' . $constraints['maximum'];
+        }
+
+        if (isset($constraints['pattern'])) {
+            $rules[] = 'regex:' . $constraints['pattern'];
+        }
+
+        return $rules;
     }
 
     /**

--- a/tests/Scaffold/Emitter/OpenApiEmitterTest.php
+++ b/tests/Scaffold/Emitter/OpenApiEmitterTest.php
@@ -14,6 +14,32 @@ use Symfony\Component\Yaml\Yaml;
 
 final class OpenApiEmitterTest extends TestCase
 {
+    public function testValidationRulesBecomeSchemaConstraints(): void
+    {
+        $yaml = <<<'YAML'
+            endpoint: { method: POST, path: /users, summary: Create }
+            input:
+              email: { type: string, rules: [required, email] }
+              name: { type: string, rules: ['min:2', 'max:50', 'regex:^[a-z]+$'] }
+              age: { type: int, rules: ['min:0', 'max:120'] }
+              role: { type: string, rules: ['in:admin,user'] }
+            domain: { class: App\User\CreateUser }
+            YAML;
+        $spec = (new Parser())->parseString($yaml);
+
+        $parsed = Yaml::parse((new OpenApiEmitter())->emit($spec)->contents);
+        self::assertIsArray($parsed);
+        $props = $parsed['paths']['/users']['post']['requestBody']['content']['application/json']['schema']['properties'];
+
+        self::assertSame('email', $props['email']['format']);
+        self::assertSame(2, $props['name']['minLength']);
+        self::assertSame(50, $props['name']['maxLength']);
+        self::assertSame('^[a-z]+$', $props['name']['pattern']);
+        self::assertSame(0, $props['age']['minimum']);
+        self::assertSame(120, $props['age']['maximum']);
+        self::assertSame(['admin', 'user'], $props['role']['enum']);
+    }
+
     public function testEmitsNonBodyInputsAsParameters(): void
     {
         $yaml = <<<'YAML'

--- a/tests/Scaffold/Snapshots/create-user.openapi.yaml
+++ b/tests/Scaffold/Snapshots/create-user.openapi.yaml
@@ -17,7 +17,7 @@ paths:
           application/json:
             schema:
               type: object
-              properties: { email: { type: string }, password: { type: string } }
+              properties: { email: { type: string, format: email }, password: { type: string, minLength: 8 } }
               required: [email, password]
       responses:
         201:

--- a/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
@@ -86,6 +86,22 @@ final class SchemaMapperTest extends TestCase
         ], $fields);
     }
 
+    public function testFormatAndConstraintsBecomeRules(): void
+    {
+        $body = SchemaType::object([
+            'email' => ['schema' => SchemaType::scalar('string', 'email', false, ['minLength' => 3, 'maxLength' => 80, 'pattern' => '.+@.+']), 'required' => true],
+            'age' => ['schema' => SchemaType::scalar('integer', null, false, ['minimum' => 0, 'maximum' => 120]), 'required' => false],
+        ]);
+        $operation = $this->operation('POST', '/users', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'email', 'type' => 'string', 'rules' => ['required', 'email', 'min:3', 'max:80', 'regex:.+@.+']],
+            ['name' => 'age', 'type' => 'int', 'rules' => ['min:0', 'max:120']],
+        ], $fields);
+    }
+
     public function testNestedObjectInputMapsToRecursiveFields(): void
     {
         $body = SchemaType::object([


### PR DESCRIPTION
Part of #214. **Phase 3 — validation fidelity.** Schema validation keywords now round-trip with `Altair\Validation` rules.

## Import (OpenAPI → Altair)

A scalar's `format` + JSON-Schema constraints become rules (body fields *and* parameters):

| OpenAPI | Altair rule |
|---|---|
| `format: email` / `uri` / `ipv4` / `date-time` | `email` / `url` / `ip` / `datetime` |
| `minLength` / `maxLength` | `min:` / `max:` |
| `minimum` / `maximum` | `min:` / `max:` |
| `pattern: p` | `regex:p` |

`SchemaType` now carries a `constraints` map the parser fills from `minLength`/`maxLength`/`minimum`/`maximum`/`pattern`.

## Export (Altair → OpenAPI)

The inverse — rules become schema constraints on the emitted scalar: `email`→`format: email`, `min`/`max`→`minLength`/`maxLength` (strings) or `minimum`/`maximum` (numbers), `regex`→`pattern`, `in:`→`enum`. So a spec's validation rules surface as real OpenAPI constraints, and the pair round-trips.

```yaml
# create-user.openapi.yaml (golden snapshot, regenerated)
properties:
  email:    { type: string, format: email }
  password: { type: string, minLength: 8 }
```

## Test plan

- [x] Import: `format` + `minLength`/`maxLength`/`minimum`/`maximum`/`pattern` → rules (exact order).
- [x] Export: `email`/`min`/`max`/`regex`/`in:` rules → `format`/`minLength`/`maxLength`/`pattern`/`enum`.
- [x] create-user OpenAPI golden snapshot regenerated.
- [x] Real Petstore round-trip stays clean (19 ops).
- [x] CS + PHPStan + Rector + full Scaffold suite (285) green; `.agent/` stable.