### PR TITLE
re #214 feat(scaffold): map non-JSON object bodies & responses (#214 Phase 4a)

### DIFF
--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -17,7 +17,7 @@ closes the gaps.
 
 - Paths + operations; `operationId` (or synthesised), `summary`.
 - **Parameters** — path / query / header / cookie become inputs tagged with their `in:` location (with type + `required`; enums → `in:` rule). *Phase 2.*
-- Request + response bodies in **`application/json`**.
+- Request + response bodies in **`application/json`**. When a request body has **no `application/json`**, its schema is read from the first content type carrying an object/array schema (multipart/form-data, x-www-form-urlencoded) — the body is *normalized*, not dropped (Phase 4a). Responses fall back to the first content type with any schema. On export the body always re-emits as `application/json`, so the wire content type is normalized while the body structure round-trips.
 - Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
 - **Validation constraints** ↔ rules (Phase 3): `format` (`email`/`uri`/`ip`/`date-time`)→`email`/`url`/`ip`/`datetime`; `minLength`/`maxLength`→`min`/`max`; `minimum`/`maximum`→`min`/`max`; `pattern`→`regex:`. Round-trips (the forward emitter writes the inverse).
 - Internal `$ref` (`#/components/schemas/<Name>`), `properties` + `required`.
@@ -28,7 +28,9 @@ closes the gaps.
 `openapi:import` warns about each of these in its receipt (`warnings[]`) and human output:
 
 - parameter `$ref` (not resolved).
-- **non-`application/json` request bodies** (multipart, form-urlencoded, xml, octet-stream).
+- **non-`application/json` request bodies whose schema is read** — when JSON is present the other representations are ignored; when it is absent an object/array body is normalized (Phase 4a). Either way the importer says which content type(s) it read or ignored.
+- **binary/scalar-only request bodies** (`application/octet-stream`, `text/plain`) — no named-field representation, so still dropped (warned).
+- **non-`application/json` responses whose schema is read** — when a response has no `application/json`, its schema is normalized from the first content type carrying one, and the importer reports the normalization (Phase 4a). When `application/json` is present the other representations are alternative views, not a loss, so they are not warned.
 - requestBody **`$ref`** (body dropped).
 - operation + global **`security`**, `components.securitySchemes`.
 - `servers`, `webhooks` (3.1), `callbacks`, path-item `$ref`.
@@ -36,12 +38,12 @@ closes the gaps.
 ### Surfaced as errors / skips (fail, or `--skip-unmappable`)
 
 - **External / file / URL `$ref`** (only internal component refs resolve).
-- `oneOf` / `anyOf` / `allOf` in a request body; recursive `$ref`; a bare scalar body.
+- `oneOf` / `anyOf` / `allOf` in a request body; recursive `$ref`; a bare scalar body (incl. a normalized non-JSON body that turns out to be a scalar).
 
 ### Not yet mapped or warned (later phases)
 
 - Remaining constraints: `multipleOf`, `min/maxItems`, `uniqueItems` (no Altair rule yet).
-- requestBody `required` flag; `additionalProperties`, `const`, `discriminator`, `not`, `prefixItems`, `nullable`; `deprecated`, `default`, `example(s)`, `title`/`description`; response `headers`/`links`; non-JSON responses.
+- requestBody `required` flag; `additionalProperties`, `const`, `discriminator`, `not`, `prefixItems`, `nullable`; `deprecated`, `default`, `example(s)`, `title`/`description`; response `headers`/`links`.
 
 ## Export (Altair spec → OpenAPI)
 
@@ -56,4 +58,6 @@ constraints** from validation rules — `email`→`format`, `min:3`→`minLength
 
 See [#214](https://github.com/univeros/framework/issues/214) for the phased plan
 (stop silent loss → parameters → validation fidelity → content & composition →
-security & misc). This page is updated as each phase lands.
+security & misc). This page is updated as each phase lands. **Phase 4a** (non-JSON
+object bodies, normalized) has landed; `allOf` merge, `oneOf`/`anyOf`,
+`additionalProperties`, and external-`$ref` bundling remain.

--- a/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
+++ b/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
@@ -102,6 +102,7 @@ final readonly class CoverageScanner
     {
         $this->scanParameters($operation['parameters'] ?? null, $where, $warnings);
         $this->scanRequestBody($operation['requestBody'] ?? null, $where, $warnings);
+        $this->scanResponses($operation['responses'] ?? null, $where, $warnings);
 
         if ($this->nonEmptyArray($operation['security'] ?? null)) {
             $warnings[] = \sprintf('operation `security` on %s is not imported.', $where);
@@ -132,6 +133,12 @@ final readonly class CoverageScanner
     }
 
     /**
+     * Mirrors {@see OpenApiParser::bodySchemaFromContent}: `application/json`
+     * (with a schema) is read and the other representations dropped; with no
+     * JSON, the first content type carrying an object/array schema is read
+     * (normalized to the request body), and a binary/scalar-only body has no
+     * Altair representation and is dropped.
+     *
      * @param list<string> $warnings
      */
     private function scanRequestBody(mixed $requestBody, string $where, array &$warnings): void
@@ -151,17 +158,155 @@ final readonly class CoverageScanner
             return;
         }
 
-        $otherTypes = array_values(array_filter(
-            array_keys($content),
-            static fn(int|string $type): bool => \is_string($type) && $type !== 'application/json',
-        ));
-        if ($otherTypes === []) {
+        if ($this->hasSchema($content['application/json'] ?? null)) {
+            $otherTypes = array_values(array_filter(
+                array_keys($content),
+                static fn(int|string $type): bool => \is_string($type) && $type !== 'application/json',
+            ));
+            if ($otherTypes !== []) {
+                $warnings[] = \sprintf('request body content type(s) %s on %s are not imported (only application/json is read).', implode(', ', $otherTypes), $where);
+            }
+
             return;
         }
 
-        $warnings[] = isset($content['application/json'])
-            ? \sprintf('request body content type(s) %s on %s are not imported (only application/json is read).', implode(', ', $otherTypes), $where)
-            : \sprintf('request body on %s uses %s; only application/json is imported, so the body is dropped.', $where, implode(', ', $otherTypes));
+        $normalizedFrom = $this->firstMappableContentType($content);
+        if ($normalizedFrom !== null) {
+            $warnings[] = \sprintf('request body on %s has no application/json; its schema is read from %s (normalized).', $where, $normalizedFrom);
+
+            return;
+        }
+
+        $types = array_values(array_filter(array_keys($content), \is_string(...)));
+        if ($types !== []) {
+            $warnings[] = \sprintf('request body on %s uses %s with no mappable object schema; not imported.', $where, implode(', ', $types));
+        }
+    }
+
+    /**
+     * Mirrors {@see OpenApiParser::responseSchemaFromContent}: a response whose
+     * schema comes from a non-JSON content type is read (normalized) rather than
+     * dropped, so the importer surfaces the normalization — `output:` blocks
+     * always re-emit as `application/json`. When `application/json` carries the
+     * schema the other representations are alternative views, not a loss, so
+     * they are not warned (unlike a request body, which the client must choose
+     * one representation to send).
+     *
+     * @param list<string> $warnings
+     */
+    private function scanResponses(mixed $responses, string $where, array &$warnings): void
+    {
+        if (!\is_array($responses)) {
+            return;
+        }
+
+        foreach ($responses as $status => $response) {
+            if (!\is_array($response)) {
+                continue;
+            }
+
+            $content = $response['content'] ?? null;
+            if (!\is_array($content)) {
+                continue;
+            }
+
+            if ($this->hasSchema($content['application/json'] ?? null)) {
+                continue;
+            }
+
+            $normalizedFrom = $this->firstContentTypeWithSchema($content);
+            if ($normalizedFrom !== null) {
+                $warnings[] = \sprintf('response %s on %s has no application/json; its schema is read from %s (normalized).', (string) $status, $where, $normalizedFrom);
+            }
+        }
+    }
+
+    /**
+     * First content type whose schema is an object/array/`$ref` root — the one
+     * {@see OpenApiParser} would normalize the body from when no JSON is present.
+     *
+     * @param array<int|string, mixed> $content
+     */
+    private function firstMappableContentType(array $content): ?string
+    {
+        foreach ($content as $type => $media) {
+            if ($type === 'application/json') {
+                continue;
+            }
+
+            if (\is_string($type) && \is_array($media) && $this->isMappableRootSchema($media['schema'] ?? null)) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * First non-JSON content type carrying any schema — the response counterpart
+     * to {@see firstMappableContentType} (responses map scalar schemas too).
+     *
+     * @param array<int|string, mixed> $content
+     */
+    private function firstContentTypeWithSchema(array $content): ?string
+    {
+        foreach ($content as $type => $media) {
+            if ($type === 'application/json') {
+                continue;
+            }
+
+            if (\is_string($type) && $this->hasSchema($media)) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+
+    private function isMappableRootSchema(mixed $schema): bool
+    {
+        if (!\is_array($schema)) {
+            return false;
+        }
+
+        if (isset($schema['$ref'])) {
+            return true;
+        }
+
+        if (\is_array($schema['properties'] ?? null)) {
+            return true;
+        }
+
+        $type = $schema['type'] ?? null;
+        if (\is_array($type)) {
+            $type = $this->firstNonNullType($type);
+        }
+
+        return $type === 'object' || $type === 'array';
+    }
+
+    /**
+     * Mirrors {@see OpenApiParser}'s `firstNonNull`: the first non-`null`,
+     * string entry of an OpenAPI 3.1 `type: [..]` union (so `[object, "null"]`
+     * resolves to `object`). Identical contract keeps the parser and scanner
+     * from disagreeing about which bodies are mappable.
+     *
+     * @param array<mixed> $types
+     */
+    private function firstNonNullType(array $types): ?string
+    {
+        foreach ($types as $type) {
+            if ($type !== 'null' && \is_string($type)) {
+                return $type;
+            }
+        }
+
+        return null;
+    }
+
+    private function hasSchema(mixed $media): bool
+    {
+        return \is_array($media) && \is_array($media['schema'] ?? null);
     }
 
     private function nonEmptyArray(mixed $value): bool

--- a/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
+++ b/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
@@ -269,12 +269,75 @@ final readonly class OpenApiParser
             return null;
         }
 
+        return $this->bodySchemaFromContent($content);
+    }
+
+    /**
+     * Selects the request-body schema from a `content` map. `application/json`
+     * wins when it carries a schema; otherwise the first content type whose
+     * schema is an object or array (multipart/form-data, x-www-form-urlencoded)
+     * is read, so non-JSON *object* bodies map instead of being dropped. A
+     * binary/scalar body (`application/octet-stream`) has no named-field
+     * representation, so it yields null and the {@see CoverageScanner} reports
+     * it. The chosen schema re-emits as `application/json` on export — the
+     * wire content type is normalized, the body structure round-trips.
+     *
+     * @param  array<string, mixed>      $content
+     * @return array<string, mixed>|null
+     */
+    private function bodySchemaFromContent(array $content): ?array
+    {
         $json = $content['application/json'] ?? null;
-        if (!\is_array($json) || !\is_array($json['schema'] ?? null)) {
-            return null;
+        if (\is_array($json) && \is_array($json['schema'] ?? null)) {
+            return $json['schema'];
         }
 
-        return $json['schema'];
+        foreach ($content as $type => $media) {
+            if ($type === 'application/json') {
+                continue;
+            }
+
+            if (!\is_array($media)) {
+                continue;
+            }
+
+            if (!\is_array($media['schema'] ?? null)) {
+                continue;
+            }
+
+            if ($this->isMappableRootSchema($media['schema'])) {
+                return $media['schema'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Whether a raw schema node maps to an Altair input body — an object
+     * (named fields), an array (a single named list field), or a `$ref`
+     * (resolved downstream). Scalars/binaries are excluded so an
+     * `application/octet-stream` body stays unmapped rather than producing a
+     * nameless scalar field.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private function isMappableRootSchema(array $schema): bool
+    {
+        if (isset($schema['$ref'])) {
+            return true;
+        }
+
+        if (\is_array($schema['properties'] ?? null)) {
+            return true;
+        }
+
+        $type = $schema['type'] ?? null;
+        if (\is_array($type)) {
+            $type = $this->firstNonNull($type);
+        }
+
+        return $type === 'object' || $type === 'array';
     }
 
     /**
@@ -284,8 +347,11 @@ final readonly class OpenApiParser
     {
         $schema = null;
         $content = $response['content'] ?? null;
-        if (\is_array($content) && \is_array($content['application/json'] ?? null) && \is_array($content['application/json']['schema'] ?? null)) {
-            $schema = $this->parseSchema($content['application/json']['schema']);
+        if (\is_array($content)) {
+            $schemaArray = $this->responseSchemaFromContent($content);
+            if ($schemaArray !== null) {
+                $schema = $this->parseSchema($schemaArray);
+            }
         }
 
         return new ResponseModel(
@@ -293,6 +359,35 @@ final readonly class OpenApiParser
             schema: $schema,
             description: isset($response['description']) && \is_string($response['description']) ? $response['description'] : '',
         );
+    }
+
+    /**
+     * Like {@see bodySchemaFromContent} but for responses, which Altair's
+     * `output:` block can render from any schema kind (including scalars), so
+     * the fallback accepts the first content type carrying a schema rather than
+     * restricting to object/array roots.
+     *
+     * @param  array<string, mixed>      $content
+     * @return array<string, mixed>|null
+     */
+    private function responseSchemaFromContent(array $content): ?array
+    {
+        $json = $content['application/json'] ?? null;
+        if (\is_array($json) && \is_array($json['schema'] ?? null)) {
+            return $json['schema'];
+        }
+
+        foreach ($content as $type => $media) {
+            if ($type === 'application/json') {
+                continue;
+            }
+
+            if (\is_array($media) && \is_array($media['schema'] ?? null)) {
+                return $media['schema'];
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -60,6 +60,50 @@ final class OpenApiImportRunnerTest extends TestCase
         self::assertArrayHasKey('email', $createSpec['input']);
     }
 
+    public function testMapsMultipartOnlyObjectBodyAndWarnsNormalized(): void
+    {
+        // Phase 4a: a request body declared only as multipart/form-data (no
+        // application/json) is normalized into spec inputs rather than dropped,
+        // and the receipt surfaces the normalization.
+        $path = $this->sandbox . '/openapi.yaml';
+        file_put_contents($path, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Upload API, version: 1.0.0 }
+            paths:
+              /uploads:
+                post:
+                  operationId: createUpload
+                  summary: Create an upload
+                  requestBody:
+                    required: true
+                    content:
+                      multipart/form-data:
+                        schema:
+                          type: object
+                          required: [title]
+                          properties:
+                            title: { type: string }
+                            size: { type: integer }
+                  responses:
+                    '201': { description: Created }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $path,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok);
+        $spec = Yaml::parseFile($this->sandbox . '/api/uploads/create.yaml');
+        self::assertArrayHasKey('title', $spec['input']);
+        self::assertArrayHasKey('size', $spec['input']);
+        self::assertContains('required', $spec['input']['title']['rules']);
+        self::assertStringContainsString(
+            'normalized',
+            implode("\n", $receipt->warnings),
+        );
+    }
+
     public function testRespectsCustomOutDir(): void
     {
         $documentPath = $this->writeOpenApi();

--- a/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
+++ b/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Altair\Tests\Scaffold\Sdk\Model;
 
 use Altair\Scaffold\Sdk\Model\CoverageScanner;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
+#[CoversClass(CoverageScanner::class)]
 final class CoverageScannerTest extends TestCase
 {
     public function testMinimalDocumentHasNoWarnings(): void
@@ -53,20 +55,65 @@ final class CoverageScannerTest extends TestCase
         ], $warnings);
     }
 
-    public function testWarnsOnRequestBodyRefAndNonJsonBody(): void
+    public function testWarnsOnRequestBodyRefAndNormalizesNonJsonBody(): void
     {
+        // Phase 4a: a non-JSON *object* body is now read (normalized), not dropped;
+        // a binary/scalar-only body (octet-stream) and a schema-less body still are.
         $warnings = (new CoverageScanner())->scan([
             'paths' => [
                 '/a' => ['post' => ['requestBody' => ['$ref' => '#/components/requestBodies/X'], 'responses' => []]],
                 '/b' => ['post' => ['requestBody' => ['content' => ['multipart/form-data' => ['schema' => ['type' => 'object']]]], 'responses' => []]],
                 '/c' => ['post' => ['requestBody' => ['content' => ['application/json' => ['schema' => ['type' => 'object']], 'application/xml' => ['schema' => ['type' => 'object']]]], 'responses' => []]],
+                '/d' => ['post' => ['requestBody' => ['content' => ['application/octet-stream' => ['schema' => ['type' => 'string', 'format' => 'binary']]]], 'responses' => []]],
+                '/e' => ['post' => ['requestBody' => ['content' => ['text/plain' => []]], 'responses' => []]],
             ],
         ]);
 
         self::assertSame([
             'requestBody `$ref` on POST /a is not imported (body dropped).',
-            'request body on POST /b uses multipart/form-data; only application/json is imported, so the body is dropped.',
+            'request body on POST /b has no application/json; its schema is read from multipart/form-data (normalized).',
             'request body content type(s) application/xml on POST /c are not imported (only application/json is read).',
+            'request body on POST /d uses application/octet-stream with no mappable object schema; not imported.',
+            'request body on POST /e uses text/plain with no mappable object schema; not imported.',
+        ], $warnings);
+    }
+
+    public function testSchemalessJsonFallsBackToMappableNonJsonBody(): void
+    {
+        // A schema-less application/json stub alongside a multipart object body:
+        // the parser reads the multipart schema, so the scanner reports the
+        // normalization rather than claiming JSON was read.
+        $warnings = (new CoverageScanner())->scan([
+            'paths' => [
+                '/b' => ['post' => ['requestBody' => ['content' => [
+                    'application/json' => [],
+                    'application/x-www-form-urlencoded' => ['schema' => ['type' => 'object']],
+                ]], 'responses' => []]],
+            ],
+        ]);
+
+        self::assertSame([
+            'request body on POST /b has no application/json; its schema is read from application/x-www-form-urlencoded (normalized).',
+        ], $warnings);
+    }
+
+    public function testWarnsWhenResponseSchemaNormalizedFromNonJson(): void
+    {
+        // A response carried only as application/xml is read (normalized), so
+        // the importer surfaces it; a JSON response with extra representations
+        // is not warned (the others are alternative views, not a loss).
+        $warnings = (new CoverageScanner())->scan([
+            'paths' => [
+                '/x' => ['get' => ['responses' => [
+                    '200' => ['content' => ['application/xml' => ['schema' => ['type' => 'object']]]],
+                    '201' => ['content' => ['application/json' => ['schema' => ['type' => 'object']], 'application/xml' => ['schema' => ['type' => 'object']]]],
+                    '204' => ['description' => 'no content'],
+                ]]],
+            ],
+        ]);
+
+        self::assertSame([
+            'response 200 on GET /x has no application/json; its schema is read from application/xml (normalized).',
         ], $warnings);
     }
 

--- a/tests/Scaffold/Sdk/OpenApiParserTest.php
+++ b/tests/Scaffold/Sdk/OpenApiParserTest.php
@@ -93,4 +93,142 @@ class OpenApiParserTest extends TestCase
         // A bare scalar parses to a string, not a map → rejected.
         (new OpenApiParser())->parseYaml('just-a-scalar-string');
     }
+
+    public function testMapsNonJsonObjectRequestBodyWhenJsonAbsent(): void
+    {
+        // multipart/form-data object body with no application/json: Phase 4a
+        // reads its schema instead of dropping the whole body.
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/upload' => [
+                    'post' => [
+                        'operationId' => 'upload',
+                        'requestBody' => ['content' => ['multipart/form-data' => ['schema' => [
+                            'type' => 'object',
+                            'properties' => ['title' => ['type' => 'string']],
+                            'required' => ['title'],
+                        ]]]],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $operation = $doc->operations[0];
+        $this->assertTrue($operation->hasRequestBody());
+        $this->assertNotNull($operation->requestBody);
+        $this->assertTrue($operation->requestBody->isObject());
+        $this->assertArrayHasKey('title', $operation->requestBody->properties);
+    }
+
+    public function testPrefersJsonRequestBodyOverOtherContentTypes(): void
+    {
+        // application/json wins even when listed after another content type.
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/things' => [
+                    'post' => [
+                        'operationId' => 'createThing',
+                        'requestBody' => ['content' => [
+                            'application/xml' => ['schema' => ['type' => 'object', 'properties' => ['fromXml' => ['type' => 'string']]]],
+                            'application/json' => ['schema' => ['type' => 'object', 'properties' => ['fromJson' => ['type' => 'string']]]],
+                        ]],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $body = $doc->operations[0]->requestBody;
+        $this->assertNotNull($body);
+        $this->assertArrayHasKey('fromJson', $body->properties);
+        $this->assertArrayNotHasKey('fromXml', $body->properties);
+    }
+
+    public function testSchemalessJsonFallsBackToMappableBody(): void
+    {
+        // application/json present but with no schema (a stub): the parser falls
+        // back to the x-www-form-urlencoded object body instead of returning null.
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/things' => [
+                    'post' => [
+                        'operationId' => 'createThing',
+                        'requestBody' => ['content' => [
+                            'application/json' => [],
+                            'application/x-www-form-urlencoded' => ['schema' => ['type' => 'object', 'properties' => ['fromForm' => ['type' => 'string']]]],
+                        ]],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $body = $doc->operations[0]->requestBody;
+        $this->assertNotNull($body);
+        $this->assertArrayHasKey('fromForm', $body->properties);
+    }
+
+    public function testBinaryOctetStreamBodyStaysUnmapped(): void
+    {
+        // A scalar/binary octet-stream body has no named-field representation,
+        // so it must NOT be picked up (it stays surfaced by the CoverageScanner).
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/pet/{petId}/uploadImage' => [
+                    'post' => [
+                        'operationId' => 'uploadFile',
+                        'requestBody' => ['content' => ['application/octet-stream' => ['schema' => ['type' => 'string', 'format' => 'binary']]]],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($doc->operations[0]->hasRequestBody());
+    }
+
+    public function testMapsNonJsonResponseSchemaWhenJsonAbsent(): void
+    {
+        // A response carried only as application/xml is read rather than dropped.
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/report' => [
+                    'get' => [
+                        'operationId' => 'getReport',
+                        'responses' => ['200' => ['description' => 'ok', 'content' => ['application/xml' => ['schema' => [
+                            'type' => 'object',
+                            'properties' => ['id' => ['type' => 'integer']],
+                        ]]]]],
+                    ],
+                ],
+            ],
+        ]);
+
+        $response = $doc->operations[0]->responses[0];
+        $this->assertInstanceOf(SchemaType::class, $response->schema);
+        $this->assertTrue($response->schema->isObject());
+    }
+
+    public function testPrefersJsonResponseOverOtherContentTypes(): void
+    {
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/report' => [
+                    'get' => [
+                        'operationId' => 'getReport',
+                        'responses' => ['200' => ['description' => 'ok', 'content' => [
+                            'application/xml' => ['schema' => ['type' => 'object', 'properties' => ['fromXml' => ['type' => 'string']]]],
+                            'application/json' => ['schema' => ['type' => 'object', 'properties' => ['fromJson' => ['type' => 'string']]]],
+                        ]]],
+                    ],
+                ],
+            ],
+        ]);
+
+        $schema = $doc->operations[0]->responses[0]->schema;
+        $this->assertInstanceOf(SchemaType::class, $schema);
+        $this->assertArrayHasKey('fromJson', $schema->properties);
+        $this->assertArrayNotHasKey('fromXml', $schema->properties);
+    }
 }


### PR DESCRIPTION
Part of #214 — **Phase 4a (content & composition: non-JSON bodies)**.

## Problem
`openapi:import` read request/response bodies **only** from `application/json`. A real-world spec that declares a body as `multipart/form-data` or `application/x-www-form-urlencoded` (with no JSON variant) had its whole body silently dropped — and non-JSON responses were dropped with no warning at all.

## Change (bidirectional + round-trip-stable)
**Import (`OpenApiParser`)**
- `bodySchemaFromContent()` — prefer `application/json` (when it carries a schema), otherwise read the first content type whose schema is an **object/array root** (`isMappableRootSchema`). Non-JSON *object* bodies now map instead of dropping.
- A binary/scalar body (`application/octet-stream`, `text/plain`) has no named-field representation, so it stays **unmapped** (surfaced by the scanner) — it never produces a nameless scalar field, so the Petstore's `uploadImage` is unaffected.
- `responseSchemaFromContent()` — responses fall back to the first content type with *any* schema (responses may be scalar).
- The chosen schema re-emits as `application/json` on export: the **wire content type is normalized**, the body **structure round-trips**. `openapi:roundtrip` never compares body content types, so the gate stays clean.

**Honesty (`CoverageScanner`)**
- A normalized non-JSON object body is now reported `"schema is read from X (normalized)"` instead of `"dropped"`; binary/scalar-only bodies stay warned as not imported.
- New `scanResponses()` surfaces the same normalization for responses, so a non-JSON response is **no longer mapped silently** (closes the gap the parser change would otherwise open). JSON-present responses keep their alternative representations unwarned (alternative views, not a loss).
- Parser and scanner share an identical first-non-null-type contract so they never disagree about which bodies are mappable.

## Verification
- New unit tests: parser (non-JSON object body, JSON-preference, schemaless-JSON fallback, octet-stream stays unmapped, non-JSON + JSON-preference responses) + scanner (normalized vs dropped, response normalization) + an end-to-end import-runner test (multipart-only body → spec inputs + normalized warning).
- Real **Swagger Petstore**: still **19 specs / 17 warnings / 0 unmapped**, `openapi:roundtrip --check` **clean** (its bodies all co-exist with `application/json`; `uploadImage`'s octet-stream body stays unmapped).
- Full QA gauntlet (cache-free): **CS clean · PHPStan L8 no-baseline clean · Rector full-tree clean · 294 scaffold tests green**.
- `code-reviewer` + `security-reviewer` run; all HIGH findings addressed (response-normalization warning, parser/scanner contract alignment, explicit JSON-skip in fallback loops, `#[CoversClass]`, edge-case tests). Security: no CRITICAL/HIGH (external `$ref` confirmed not enabled; `$ref`/cycle handling stays a clean `UnmappableSchemaException`).

## Coverage doc
`docs/guides/openapi/coverage.md` updated for Phase 4a.

## Remaining Phase 4 (separate PRs)
`allOf` merge, `oneOf`/`anyOf`, `additionalProperties`, external-`$ref` bundling — then Phase 5 (security & naming).