### PR TITLE
re #214 feat(scaffold): flatten allOf composition on import (#214 Phase 4b)

### DIFF
--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -21,6 +21,7 @@ closes the gaps.
 - Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
 - **Validation constraints** ↔ rules (Phase 3): `format` (`email`/`uri`/`ip`/`date-time`)→`email`/`url`/`ip`/`datetime`; `minLength`/`maxLength`→`min`/`max`; `minimum`/`maximum`→`min`/`max`; `pattern`→`regex:`. Round-trips (the forward emitter writes the inverse).
 - Internal `$ref` (`#/components/schemas/<Name>`), `properties` + `required`.
+- **`allOf` composition** (Phase 4b) — subschemas are resolved (`$ref`s included) and their properties **merged into one object**; a property required in any subschema is required in the merge. Altair has no representation for composition, so the relationship is flattened (warned) while the data is preserved. A subschema that does not resolve to an object is unmappable.
 - `x-altair-*` extensions (domain/persistence/queue/idempotency/webhook round-trip).
 
 ### Surfaced as warnings (imported, but reported — not silent) — *Phase 1*
@@ -32,18 +33,20 @@ closes the gaps.
 - **binary/scalar-only request bodies** (`application/octet-stream`, `text/plain`) — no named-field representation, so still dropped (warned).
 - **non-`application/json` responses whose schema is read** — when a response has no `application/json`, its schema is normalized from the first content type carrying one, and the importer reports the normalization (Phase 4a). When `application/json` is present the other representations are alternative views, not a loss, so they are not warned.
 - requestBody **`$ref`** (body dropped).
+- **`allOf` flattening** (Phase 4b) — reported once per named component that uses it (`` `components.schemas.<Name>` uses allOf ``) and per inline body/response that uses it, since the composition relationship is not preserved.
 - operation + global **`security`**, `components.securitySchemes`.
 - `servers`, `webhooks` (3.1), `callbacks`, path-item `$ref`.
 
 ### Surfaced as errors / skips (fail, or `--skip-unmappable`)
 
 - **External / file / URL `$ref`** (only internal component refs resolve).
-- `oneOf` / `anyOf` / `allOf` in a request body; recursive `$ref`; a bare scalar body (incl. a normalized non-JSON body that turns out to be a scalar).
+- `oneOf` / `anyOf` in a request body; recursive `$ref`; a bare scalar body (incl. a normalized non-JSON body that turns out to be a scalar); an `allOf` whose subschema is not an object.
 
 ### Not yet mapped or warned (later phases)
 
 - Remaining constraints: `multipleOf`, `min/maxItems`, `uniqueItems` (no Altair rule yet).
 - requestBody `required` flag; `additionalProperties`, `const`, `discriminator`, `not`, `prefixItems`, `nullable`; `deprecated`, `default`, `example(s)`, `title`/`description`; response `headers`/`links`.
+- A bare `required` *sibling* on an `allOf` node (marking inherited properties required without re-declaring them) — `required` **inside** an `allOf` subschema is honored; a top-level `required` alongside `allOf` with no sibling `properties` is not yet applied (the flat field model has no slot for a required name without a property).
 
 ## Export (Altair spec → OpenAPI)
 
@@ -58,6 +61,6 @@ constraints** from validation rules — `email`→`format`, `min:3`→`minLength
 
 See [#214](https://github.com/univeros/framework/issues/214) for the phased plan
 (stop silent loss → parameters → validation fidelity → content & composition →
-security & misc). This page is updated as each phase lands. **Phase 4a** (non-JSON
-object bodies, normalized) has landed; `allOf` merge, `oneOf`/`anyOf`,
+security & misc). This page is updated as each phase lands. **Phases 4a** (non-JSON
+object bodies, normalized) and **4b** (`allOf` merge) have landed; `oneOf`/`anyOf`,
 `additionalProperties`, and external-`$ref` bundling remain.

--- a/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
+++ b/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
@@ -27,6 +27,12 @@ final readonly class CoverageScanner
     private const array HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
     /**
+     * Inline-schema recursion ceiling for {@see usesAllOf} — a hostile, deeply
+     * nested document stops being walked rather than exhausting the stack.
+     */
+    private const int MAX_SCAN_DEPTH = 64;
+
+    /**
      * @param  array<string, mixed> $document Raw decoded OpenAPI document.
      * @return list<string>
      */
@@ -35,6 +41,7 @@ final readonly class CoverageScanner
         $warnings = [];
 
         $this->scanDocument($document, $warnings);
+        $this->scanComponentSchemas($document, $warnings);
 
         $paths = $document['paths'] ?? null;
         if (\is_array($paths)) {
@@ -46,6 +53,57 @@ final readonly class CoverageScanner
         }
 
         return $warnings;
+    }
+
+    /**
+     * A named component schema that uses `allOf` (anywhere within it) is
+     * flattened to a single merged object on import — the composition
+     * relationship is not preserved — so it is reported once, in document order.
+     *
+     * @param array<string, mixed> $document
+     * @param list<string>         $warnings
+     */
+    private function scanComponentSchemas(array $document, array &$warnings): void
+    {
+        $components = $document['components'] ?? null;
+        $schemas = \is_array($components) && \is_array($components['schemas'] ?? null) ? $components['schemas'] : [];
+
+        foreach ($schemas as $name => $schema) {
+            if (\is_string($name) && \is_array($schema) && $this->usesAllOf($schema)) {
+                $warnings[] = \sprintf('`components.schemas.%s` uses allOf; its subschemas are merged into one object on import (composition not preserved).', $name);
+            }
+        }
+    }
+
+    /**
+     * Recursively detects an `allOf` anywhere within a single inline schema
+     * tree (its `properties` and array `items`). `$ref`s are not followed, so
+     * this cannot cycle; nesting is bounded by {@see MAX_SCAN_DEPTH}.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private function usesAllOf(array $schema, int $depth = 0): bool
+    {
+        if ($depth >= self::MAX_SCAN_DEPTH) {
+            return false;
+        }
+
+        if (\is_array($schema['allOf'] ?? null)) {
+            return true;
+        }
+
+        $properties = $schema['properties'] ?? null;
+        if (\is_array($properties)) {
+            foreach ($properties as $property) {
+                if (\is_array($property) && $this->usesAllOf($property, $depth + 1)) {
+                    return true;
+                }
+            }
+        }
+
+        $items = $schema['items'] ?? null;
+
+        return \is_array($items) && $this->usesAllOf($items, $depth + 1);
     }
 
     /**
@@ -167,12 +225,15 @@ final readonly class CoverageScanner
                 $warnings[] = \sprintf('request body content type(s) %s on %s are not imported (only application/json is read).', implode(', ', $otherTypes), $where);
             }
 
+            $this->scanComposition($content['application/json'] ?? null, 'request body', $where, $warnings);
+
             return;
         }
 
         $normalizedFrom = $this->firstMappableContentType($content);
         if ($normalizedFrom !== null) {
             $warnings[] = \sprintf('request body on %s has no application/json; its schema is read from %s (normalized).', $where, $normalizedFrom);
+            $this->scanComposition($content[$normalizedFrom] ?? null, 'request body', $where, $warnings);
 
             return;
         }
@@ -210,15 +271,48 @@ final readonly class CoverageScanner
                 continue;
             }
 
+            $subject = \sprintf('response %s', (string) $status);
+
             if ($this->hasSchema($content['application/json'] ?? null)) {
+                $this->scanComposition($content['application/json'] ?? null, $subject, $where, $warnings);
+
                 continue;
             }
 
             $normalizedFrom = $this->firstContentTypeWithSchema($content);
             if ($normalizedFrom !== null) {
-                $warnings[] = \sprintf('response %s on %s has no application/json; its schema is read from %s (normalized).', (string) $status, $where, $normalizedFrom);
+                $warnings[] = \sprintf('%s on %s has no application/json; its schema is read from %s (normalized).', $subject, $where, $normalizedFrom);
+                $this->scanComposition($content[$normalizedFrom] ?? null, $subject, $where, $warnings);
             }
         }
+    }
+
+    /**
+     * Warns when the schema actually read for a body/response is itself an
+     * inline `allOf` (flattened to a merged object on import). A `$ref` body's
+     * composition lives in the named component and is reported by
+     * {@see scanComponentSchemas}, so only inline composition surfaces here.
+     *
+     * @param list<string> $warnings
+     */
+    private function scanComposition(mixed $media, string $subject, string $where, array &$warnings): void
+    {
+        $schema = $this->schemaOf($media);
+        if ($schema !== null && $this->usesAllOf($schema)) {
+            $warnings[] = \sprintf('%s on %s uses allOf; its subschemas are merged into one object on import (composition not preserved).', $subject, $where);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function schemaOf(mixed $media): ?array
+    {
+        if (\is_array($media) && \is_array($media['schema'] ?? null)) {
+            return $media['schema'];
+        }
+
+        return null;
     }
 
     /**
@@ -270,6 +364,10 @@ final readonly class CoverageScanner
         }
 
         if (isset($schema['$ref'])) {
+            return true;
+        }
+
+        if (\is_array($schema['allOf'] ?? null)) {
             return true;
         }
 

--- a/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
+++ b/src/Altair/Scaffold/Sdk/Model/OpenApiParser.php
@@ -328,6 +328,10 @@ final readonly class OpenApiParser
             return true;
         }
 
+        if (\is_array($schema['allOf'] ?? null)) {
+            return true;
+        }
+
         if (\is_array($schema['properties'] ?? null)) {
             return true;
         }
@@ -407,6 +411,10 @@ final readonly class OpenApiParser
             return SchemaType::enum($values, $nullable);
         }
 
+        if (isset($schema['allOf']) && \is_array($schema['allOf'])) {
+            return $this->parseAllOf($schema, $nullable);
+        }
+
         $type = $schema['type'] ?? null;
         // OpenAPI 3.1 allows `type: [string, "null"]`.
         if (\is_array($type)) {
@@ -426,6 +434,31 @@ final readonly class OpenApiParser
             'string' => SchemaType::scalar('string', $this->formatOf($schema), $nullable, $this->constraintsOf($schema)),
             default => $this->fallbackSchema($schema, $nullable),
         };
+    }
+
+    /**
+     * Parses an `allOf` node into an {@see SchemaType::ALLOF} carrying its
+     * subschemas (refs kept unresolved). The mapper merges them into one
+     * object — Altair has no representation for composition. Sibling keywords
+     * on the `allOf` node itself (`properties`/`required`) are a valid extra
+     * constraint, so they ride along as an additional inline object subschema.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private function parseAllOf(array $schema, bool $nullable): SchemaType
+    {
+        $subschemas = [];
+        foreach ($schema['allOf'] as $sub) {
+            if (\is_array($sub)) {
+                $subschemas[] = $this->parseSchema($sub);
+            }
+        }
+
+        if (\is_array($schema['properties'] ?? null)) {
+            $subschemas[] = SchemaType::object($this->parseProperties($schema));
+        }
+
+        return SchemaType::allOf($subschemas, $nullable);
     }
 
     /**

--- a/src/Altair/Scaffold/Sdk/Model/SchemaType.php
+++ b/src/Altair/Scaffold/Sdk/Model/SchemaType.php
@@ -34,11 +34,14 @@ final readonly class SchemaType
 
     public const string MIXED = 'mixed';
 
+    public const string ALLOF = 'allOf';
+
     /**
      * @param array<string, PropertyShape>      $properties  Object properties (OBJECT kind).
      * @param list<string>                       $enumValues  Allowed values (ENUM kind).
      * @param array<string, int|float|string>    $constraints JSON-Schema validation keywords kept verbatim
      *                                                        (`minLength`, `maxLength`, `pattern`, `minimum`, `maximum`).
+     * @param list<SchemaType>                   $allOf       Subschemas of an `allOf` composition (ALLOF kind), merged downstream.
      */
     public function __construct(
         public string $kind,
@@ -50,6 +53,7 @@ final readonly class SchemaType
         public ?string $format = null,
         public bool $nullable = false,
         public array $constraints = [],
+        public array $allOf = [],
     ) {}
 
     /**
@@ -89,6 +93,18 @@ final readonly class SchemaType
     public static function enum(array $values, bool $nullable = false): self
     {
         return new self(kind: self::ENUM, scalarType: 'string', enumValues: $values, nullable: $nullable);
+    }
+
+    /**
+     * An `allOf` composition. The subschemas are kept unresolved here; the
+     * mapper merges their (resolved) object properties into one object, since
+     * Altair has no representation for schema composition.
+     *
+     * @param list<SchemaType> $subschemas
+     */
+    public static function allOf(array $subschemas, bool $nullable = false): self
+    {
+        return new self(kind: self::ALLOF, nullable: $nullable, allOf: $subschemas);
     }
 
     public function isObject(): bool

--- a/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
+++ b/src/Altair/Scaffold/Spec/Emitter/SchemaMapper.php
@@ -30,8 +30,12 @@ use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
  */
 final readonly class SchemaMapper
 {
-    /** Refs we have followed during the current resolution — guards against cycles. */
-    private const int MAX_REF_DEPTH = 8;
+    /**
+     * Resolution-depth ceiling shared by `$ref` chains and `allOf` composition
+     * (both flow through {@see resolveRef}) — guards against cyclic `$ref`s and
+     * cyclic/pathological `allOf` nesting by raising a clean exception.
+     */
+    private const int MAX_RESOLUTION_DEPTH = 8;
 
     /**
      * Inline object-nesting ceiling. `resolveRef` already bounds `$ref` chains;
@@ -383,7 +387,8 @@ final readonly class SchemaMapper
             SchemaType::SCALAR => $this->outputScalarType((string) $schema->scalarType),
             SchemaType::ENUM => 'string',
             SchemaType::ARRAY => $this->outputArrayType($document, $schema, $pointer),
-            SchemaType::OBJECT => 'array<string, mixed>',
+            // A flattened allOf is an object, so it surfaces as the same loose map.
+            SchemaType::OBJECT, SchemaType::ALLOF => 'array<string, mixed>',
             SchemaType::MIXED => 'mixed',
             default => throw new UnmappableSchemaException(
                 $pointer,
@@ -439,11 +444,19 @@ final readonly class SchemaMapper
         string $pointer,
         int $depth = 0,
     ): SchemaType {
+        if ($schema->kind === SchemaType::ALLOF) {
+            if ($depth >= self::MAX_RESOLUTION_DEPTH) {
+                throw new UnmappableSchemaException($pointer, 'allOf composition exceeded resolution depth.');
+            }
+
+            return $this->mergeAllOf($document, $schema, $pointer, $depth + 1);
+        }
+
         if ($schema->kind !== SchemaType::REF) {
             return $schema;
         }
 
-        if ($depth >= self::MAX_REF_DEPTH) {
+        if ($depth >= self::MAX_RESOLUTION_DEPTH) {
             throw new UnmappableSchemaException($pointer, 'ref cycle exceeded resolution depth.');
         }
 
@@ -453,6 +466,35 @@ final readonly class SchemaMapper
         }
 
         return $this->resolveRef($document, $document->namedSchemas[$refName], $pointer, $depth + 1);
+    }
+
+    /**
+     * Flattens an `allOf` composition into one object by merging the resolved
+     * properties of every subschema (later subschemas win on name collision; a
+     * property required in any subschema is required in the result). Altair has
+     * no representation for composition, so the relationship is dropped while
+     * the data is preserved. A subschema that does not resolve to an object is
+     * unmappable.
+     */
+    private function mergeAllOf(OpenApiDocument $document, SchemaType $schema, string $pointer, int $depth): SchemaType
+    {
+        $properties = [];
+        foreach ($schema->allOf as $subschema) {
+            $resolved = $this->resolveRef($document, $subschema, $pointer, $depth);
+            if ($resolved->kind !== SchemaType::OBJECT) {
+                throw new UnmappableSchemaException(
+                    $pointer,
+                    \sprintf('allOf subschema is not an object (got %s); composition cannot be flattened.', $resolved->kind),
+                );
+            }
+
+            foreach ($resolved->properties as $name => $property) {
+                $required = ($property['required'] ?? false) || ($properties[(string) $name]['required'] ?? false);
+                $properties[(string) $name] = ['schema' => $property['schema'], 'required' => $required];
+            }
+        }
+
+        return SchemaType::object($properties, $schema->nullable);
     }
 
     private function requestBodyPointer(OperationModel $operation): string

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -104,6 +104,57 @@ final class OpenApiImportRunnerTest extends TestCase
         );
     }
 
+    public function testFlattensAllOfBodyIntoSpecInputs(): void
+    {
+        // Phase 4b: a request body composed with allOf (inheritance via $ref +
+        // an inline object) is flattened into a single merged input set.
+        $path = $this->sandbox . '/openapi.yaml';
+        file_put_contents($path, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets API, version: 1.0.0 }
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  summary: Create a pet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema:
+                          $ref: '#/components/schemas/Pet'
+                  responses:
+                    '201': { description: Created }
+            components:
+              schemas:
+                NewPet:
+                  type: object
+                  required: [name]
+                  properties:
+                    name: { type: string }
+                    tag: { type: string }
+                Pet:
+                  allOf:
+                    - $ref: '#/components/schemas/NewPet'
+                    - type: object
+                      required: [id]
+                      properties:
+                        id: { type: integer }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $path,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok);
+        $spec = Yaml::parseFile($this->sandbox . '/api/pets/create.yaml');
+        self::assertSame(['name', 'tag', 'id'], array_keys($spec['input']));
+        self::assertContains('required', $spec['input']['name']['rules']);
+        self::assertContains('required', $spec['input']['id']['rules']);
+        self::assertStringContainsString('allOf', implode("\n", $receipt->warnings));
+    }
+
     public function testRespectsCustomOutDir(): void
     {
         $documentPath = $this->writeOpenApi();

--- a/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
+++ b/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
@@ -117,6 +117,46 @@ final class CoverageScannerTest extends TestCase
         ], $warnings);
     }
 
+    public function testWarnsWhenComponentSchemaUsesAllOf(): void
+    {
+        // allOf is flattened to a merged object on import; the composition
+        // relationship is not preserved, so it is surfaced.
+        $warnings = (new CoverageScanner())->scan([
+            'components' => ['schemas' => [
+                'NewPet' => ['type' => 'object', 'properties' => ['name' => ['type' => 'string']]],
+                'Pet' => ['allOf' => [
+                    ['$ref' => '#/components/schemas/NewPet'],
+                    ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']]],
+                ]],
+            ]],
+            'paths' => [],
+        ]);
+
+        self::assertSame([
+            '`components.schemas.Pet` uses allOf; its subschemas are merged into one object on import (composition not preserved).',
+        ], $warnings);
+    }
+
+    public function testWarnsOnInlineAllOfRequestBody(): void
+    {
+        // An inline allOf body (not via $ref) is flattened too, so it is surfaced
+        // at the operation rather than relying on a named-component warning.
+        $warnings = (new CoverageScanner())->scan([
+            'paths' => [
+                '/things' => ['post' => ['requestBody' => ['content' => ['application/json' => ['schema' => [
+                    'allOf' => [
+                        ['type' => 'object', 'properties' => ['a' => ['type' => 'string']]],
+                        ['type' => 'object', 'properties' => ['b' => ['type' => 'integer']]],
+                    ],
+                ]]]], 'responses' => []]],
+            ],
+        ]);
+
+        self::assertSame([
+            'request body on POST /things uses allOf; its subschemas are merged into one object on import (composition not preserved).',
+        ], $warnings);
+    }
+
     public function testWarnsOnDocumentLevelAndOperationLevelConstructs(): void
     {
         $warnings = (new CoverageScanner())->scan([

--- a/tests/Scaffold/Sdk/OpenApiParserTest.php
+++ b/tests/Scaffold/Sdk/OpenApiParserTest.php
@@ -145,6 +145,36 @@ class OpenApiParserTest extends TestCase
         $this->assertArrayNotHasKey('fromXml', $body->properties);
     }
 
+    public function testParsesAllOfIntoAllOfNode(): void
+    {
+        $doc = (new OpenApiParser())->parse([
+            'paths' => [
+                '/pets' => [
+                    'post' => [
+                        'operationId' => 'createPet',
+                        'requestBody' => ['content' => ['application/json' => ['schema' => [
+                            'allOf' => [
+                                ['$ref' => '#/components/schemas/NewPet'],
+                                ['type' => 'object', 'properties' => ['id' => ['type' => 'integer']], 'required' => ['id']],
+                            ],
+                        ]]]],
+                        'responses' => ['200' => ['description' => 'ok']],
+                    ],
+                ],
+            ],
+            'components' => ['schemas' => [
+                'NewPet' => ['type' => 'object', 'properties' => ['name' => ['type' => 'string']], 'required' => ['name']],
+            ]],
+        ]);
+
+        $body = $doc->operations[0]->requestBody;
+        $this->assertNotNull($body);
+        $this->assertSame(SchemaType::ALLOF, $body->kind);
+        $this->assertCount(2, $body->allOf);
+        $this->assertSame(SchemaType::REF, $body->allOf[0]->kind);
+        $this->assertTrue($body->allOf[1]->isObject());
+    }
+
     public function testSchemalessJsonFallsBackToMappableBody(): void
     {
         // application/json present but with no schema (a stub): the parser falls

--- a/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
+++ b/tests/Scaffold/Spec/Emitter/SchemaMapperTest.php
@@ -380,6 +380,127 @@ final class SchemaMapperTest extends TestCase
         }
     }
 
+    public function testMergesAllOfBodyIntoSingleObject(): void
+    {
+        // allOf composition has no Altair representation, so the subschema
+        // properties are merged into one flat object (composition flattened).
+        $body = SchemaType::allOf([
+            SchemaType::object(['a' => ['schema' => SchemaType::scalar('string'), 'required' => true]]),
+            SchemaType::object(['b' => ['schema' => SchemaType::scalar('integer'), 'required' => false]]),
+        ]);
+        $operation = $this->operation('POST', '/things', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'a', 'type' => 'string', 'rules' => ['required']],
+            ['name' => 'b', 'type' => 'int', 'rules' => []],
+        ], $fields);
+    }
+
+    public function testMergesAllOfWithRefSubschemaResolvingComponents(): void
+    {
+        // The classic inheritance shape: allOf [ $ref Base, inline {id} ].
+        $body = SchemaType::allOf([
+            SchemaType::ref('Base'),
+            SchemaType::object(['id' => ['schema' => SchemaType::scalar('integer'), 'required' => true]]),
+        ]);
+        $operation = $this->operation('POST', '/pets', requestBody: $body);
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [],
+            namedSchemas: [
+                'Base' => SchemaType::object(['name' => ['schema' => SchemaType::scalar('string'), 'required' => true]]),
+            ],
+        );
+
+        $fields = (new SchemaMapper())->inputFields($document, $operation);
+
+        self::assertSame([
+            ['name' => 'name', 'type' => 'string', 'rules' => ['required']],
+            ['name' => 'id', 'type' => 'int', 'rules' => ['required']],
+        ], $fields);
+    }
+
+    public function testAllOfRequiredIsUnionedAcrossSubschemas(): void
+    {
+        // The same property required in any subschema is required in the merge.
+        $body = SchemaType::allOf([
+            SchemaType::object(['x' => ['schema' => SchemaType::scalar('string'), 'required' => false]]),
+            SchemaType::object(['x' => ['schema' => SchemaType::scalar('string'), 'required' => true]]),
+        ]);
+        $operation = $this->operation('POST', '/things', requestBody: $body);
+
+        $fields = (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+
+        self::assertSame([
+            ['name' => 'x', 'type' => 'string', 'rules' => ['required']],
+        ], $fields);
+    }
+
+    public function testAllOfWithNonObjectSubschemaRaises(): void
+    {
+        $body = SchemaType::allOf([
+            SchemaType::object(['a' => ['schema' => SchemaType::scalar('string'), 'required' => true]]),
+            SchemaType::scalar('string'),
+        ]);
+        $operation = $this->operation('POST', '/things', requestBody: $body);
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('allOf');
+        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+    }
+
+    public function testCyclicAllOfViaRefTerminatesWithException(): void
+    {
+        // A self-referential allOf (Pet: allOf [$ref Pet]) must terminate via the
+        // resolution-depth guard, not recurse forever / overflow the stack.
+        $document = new OpenApiDocument(
+            title: 'X',
+            version: '1.0',
+            operations: [],
+            namedSchemas: ['Pet' => SchemaType::allOf([SchemaType::ref('Pet')])],
+        );
+        $operation = $this->operation('POST', '/pets', requestBody: SchemaType::ref('Pet'));
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('resolution depth');
+        (new SchemaMapper())->inputFields($document, $operation);
+    }
+
+    public function testDeeplyNestedInlineAllOfRaises(): void
+    {
+        // A pathological inline allOf nesting bomb is bounded by the same guard.
+        $schema = SchemaType::object(['a' => ['schema' => SchemaType::scalar('string'), 'required' => false]]);
+        for ($i = 0; $i < 9; ++$i) {
+            $schema = SchemaType::allOf([$schema]);
+        }
+
+        $operation = $this->operation('POST', '/things', requestBody: $schema);
+
+        $this->expectException(UnmappableSchemaException::class);
+        $this->expectExceptionMessage('allOf composition exceeded resolution depth');
+        (new SchemaMapper())->inputFields($this->emptyDocument(), $operation);
+    }
+
+    public function testNestedAllOfPropertyInResponseMapsToLooseMap(): void
+    {
+        // A response object whose property is itself an allOf exercises the
+        // ALLOF arm of outputType (property schemas are not pre-resolved).
+        $operation = $this->operation('GET', '/things', responses: [
+            new ResponseModel(status: '200', schema: SchemaType::object([
+                'meta' => ['schema' => SchemaType::allOf([
+                    SchemaType::object(['a' => ['schema' => SchemaType::scalar('string'), 'required' => false]]),
+                ]), 'required' => false],
+            ])),
+        ]);
+
+        $outputs = (new SchemaMapper())->outputs($this->emptyDocument(), $operation);
+
+        self::assertSame([200 => ['meta' => 'array<string, mixed>']], $outputs);
+    }
+
     /**
      * @param list<string>          $pathParameters
      * @param list<ResponseModel>   $responses


### PR DESCRIPTION
Part of #214 — **Phase 4b (content & composition: `allOf` merge)**.

## Problem
An OpenAPI `allOf` schema (composition / inheritance, e.g. `Pet: allOf [ $ref NewPet, { id } ]`) parsed to a `mixed` node, so an `allOf` request body was **unmappable** and the whole operation was skipped/errored. Altair has no representation for schema composition.

## Change
**Import**
- New `SchemaType::ALLOF` kind + `allOf()` factory. `OpenApiParser::parseAllOf` produces an ALLOF node carrying the parsed subschemas (`$ref`s kept unresolved; sibling `properties` ride along as an extra inline object).
- `SchemaMapper::resolveRef` flattens ALLOF via new `mergeAllOf`: every subschema is resolved (component `$ref`s included) and its properties **merged into one object**; a property required in **any** subschema is required in the merge; a subschema that doesn't resolve to an object raises `UnmappableSchemaException`.
- Resolution depth is bounded by `MAX_RESOLUTION_DEPTH` (renamed from `MAX_REF_DEPTH`, now shared by `$ref` chains **and** `allOf`), so cyclic (`Pet: allOf [$ref Pet]`) or pathological nesting terminates with a clean exception — never a stack overflow.
- Composition is flattened (data fully preserved) and normalized to a plain object on export, so the **round-trip stays stable** (the gate doesn't compare composition).

**Honesty (`CoverageScanner`)**
- `scanComponentSchemas` warns once per named component that uses `allOf` (recursive `usesAllOf`, bounded by `MAX_SCAN_DEPTH`, does **not** follow `$ref`s); inline `allOf` in a body/response is warned at the operation. No double-warning: a `$ref`-to-`allOf`-component is reported at the component, not the body.

## Known limitation (documented)
A bare `required` *sibling* on an `allOf` node with **no** sibling `properties` is not yet applied (the flat field model has no slot for a required name without a property). `required` **inside** a subschema is honored. Noted in `coverage.md`.

## Verification
- New tests: parser (allOf → ALLOF node), SchemaMapper (merge two objects, merge via `$ref`, required union, non-object subschema raises, **cyclic-allOf terminates**, **deeply-nested inline allOf raises**, **nested-allOf-in-response output**), scanner (component warning, inline-body warning), e2e import-runner (inheritance via `$ref` → merged spec inputs + warning).
- Real **Swagger Petstore** unchanged: **19 specs / 17 warnings / 0 unmapped**, `openapi:roundtrip --check` clean (it uses no `allOf`).
- Hand-built `allOf` doc imports (1 spec, 0 unmapped, composition warned) and round-trips clean.
- Full QA gauntlet (cache-free): **CS clean · PHPStan L8 no-baseline clean · Rector full-tree clean · 305 scaffold tests green**.
- `code-reviewer` + `security-reviewer` run; cyclic-`allOf` termination verified + regression-tested, depth constant renamed for its dual role. Security: no CRITICAL/HIGH (cycle guard terminates cleanly; external `$ref` still not fetched).

## Remaining Phase 4 (separate PRs)
`oneOf`/`anyOf`, `additionalProperties`, external-`$ref` bundling — then Phase 5 (security & naming).