### PR TITLE
re #214 feat(scaffold): surface oneOf/anyOf/additionalProperties (#214 Phase 4c+4d)

### DIFF
--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -34,6 +34,8 @@ closes the gaps.
 - **non-`application/json` responses whose schema is read** — when a response has no `application/json`, its schema is normalized from the first content type carrying one, and the importer reports the normalization (Phase 4a). When `application/json` is present the other representations are alternative views, not a loss, so they are not warned.
 - requestBody **`$ref`** (body dropped).
 - **`allOf` flattening** (Phase 4b) — reported once per named component that uses it (`` `components.schemas.<Name>` uses allOf ``) and per inline body/response that uses it, since the composition relationship is not preserved.
+- **`oneOf` / `anyOf`** (Phase 4c) — a union has no Altair representation; reported per component / inline body / response. A `oneOf`/`anyOf` *body* stays unmappable (skipped with `--skip-unmappable`); a union *response* surfaces as `mixed`.
+- **`additionalProperties`** (Phase 4d) — an open-ended map; reported per component / inline body / response. Declared `properties` still map; only the open-key capability is dropped. An explicit `additionalProperties: false` (closed object) is not warned.
 - operation + global **`security`**, `components.securitySchemes`.
 - `servers`, `webhooks` (3.1), `callbacks`, path-item `$ref`.
 
@@ -62,5 +64,5 @@ constraints** from validation rules — `email`→`format`, `min:3`→`minLength
 See [#214](https://github.com/univeros/framework/issues/214) for the phased plan
 (stop silent loss → parameters → validation fidelity → content & composition →
 security & misc). This page is updated as each phase lands. **Phases 4a** (non-JSON
-object bodies, normalized) and **4b** (`allOf` merge) have landed; `oneOf`/`anyOf`,
-`additionalProperties`, and external-`$ref` bundling remain.
+object bodies), **4b** (`allOf` merge), and **4c/4d** (`oneOf`/`anyOf` +
+`additionalProperties`, surfaced) have landed; external-`$ref` bundling remains.

--- a/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
+++ b/src/Altair/Scaffold/Sdk/Model/CoverageScanner.php
@@ -11,6 +11,8 @@ declare(strict_types=1);
 
 namespace Altair\Scaffold\Sdk\Model;
 
+use LogicException;
+
 /**
  * Walks a raw OpenAPI document and reports every construct `openapi:import`
  * does not map — so the import warns instead of silently dropping.
@@ -27,7 +29,7 @@ final readonly class CoverageScanner
     private const array HTTP_METHODS = ['get', 'put', 'post', 'delete', 'options', 'head', 'patch', 'trace'];
 
     /**
-     * Inline-schema recursion ceiling for {@see usesAllOf} — a hostile, deeply
+     * Inline-schema recursion ceiling for {@see compositionKeywords} — a hostile, deeply
      * nested document stops being walked rather than exhausting the stack.
      */
     private const int MAX_SCAN_DEPTH = 64;
@@ -56,9 +58,10 @@ final readonly class CoverageScanner
     }
 
     /**
-     * A named component schema that uses `allOf` (anywhere within it) is
-     * flattened to a single merged object on import — the composition
-     * relationship is not preserved — so it is reported once, in document order.
+     * A named component schema that uses a composition / open-map keyword
+     * (anywhere within it) is reported once per keyword, in document order:
+     * `allOf` is flattened, `oneOf`/`anyOf` are unions with no Altair
+     * representation, and `additionalProperties` is an open-ended map.
      *
      * @param array<string, mixed> $document
      * @param list<string>         $warnings
@@ -69,41 +72,138 @@ final readonly class CoverageScanner
         $schemas = \is_array($components) && \is_array($components['schemas'] ?? null) ? $components['schemas'] : [];
 
         foreach ($schemas as $name => $schema) {
-            if (\is_string($name) && \is_array($schema) && $this->usesAllOf($schema)) {
-                $warnings[] = \sprintf('`components.schemas.%s` uses allOf; its subschemas are merged into one object on import (composition not preserved).', $name);
+            if (\is_string($name) && \is_array($schema)) {
+                $this->warnCompositionKeywords($schema, \sprintf('`components.schemas.%s`', $name), $warnings);
             }
         }
     }
 
     /**
-     * Recursively detects an `allOf` anywhere within a single inline schema
-     * tree (its `properties` and array `items`). `$ref`s are not followed, so
-     * this cannot cycle; nesting is bounded by {@see MAX_SCAN_DEPTH}.
+     * Appends one warning per composition / open-map keyword found anywhere in
+     * the schema tree, in a fixed keyword order so receipts stay byte-stable.
      *
      * @param array<string, mixed> $schema
+     * @param list<string>         $warnings
      */
-    private function usesAllOf(array $schema, int $depth = 0): bool
+    private function warnCompositionKeywords(array $schema, string $subject, array &$warnings): void
+    {
+        foreach ($this->compositionKeywords($schema) as $keyword) {
+            $warnings[] = $this->compositionWarning($keyword, $subject);
+        }
+    }
+
+    private function compositionWarning(string $keyword, string $subject): string
+    {
+        return match ($keyword) {
+            'allOf' => \sprintf('%s uses allOf; its subschemas are merged into one object on import (composition not preserved).', $subject),
+            'oneOf' => \sprintf('%s uses oneOf; a union has no Altair representation, so it is not imported.', $subject),
+            'anyOf' => \sprintf('%s uses anyOf; a union has no Altair representation, so it is not imported.', $subject),
+            'additionalProperties' => \sprintf('%s uses additionalProperties; open-ended map keys are not imported.', $subject),
+            // compositionKeywords only ever yields the four keywords above; a new
+            // one must add its arm here rather than fall through to a wrong message.
+            default => throw new LogicException(\sprintf('unhandled composition keyword: %s', $keyword)),
+        };
+    }
+
+    /**
+     * Recursively collects which composition / open-map keywords
+     * (`allOf`, `oneOf`, `anyOf`, `additionalProperties`) appear anywhere within
+     * a single inline schema tree — its `properties`, array `items`, and the
+     * `allOf`/`oneOf`/`anyOf` subschema lists. `$ref`s are not followed, so this
+     * cannot cycle; nesting is bounded by {@see MAX_SCAN_DEPTH}. Returns the
+     * present keywords in the canonical order above (deterministic output).
+     *
+     * @param  array<string, mixed> $schema
+     * @return list<string>
+     */
+    private function compositionKeywords(array $schema, int $depth = 0): array
     {
         if ($depth >= self::MAX_SCAN_DEPTH) {
-            return false;
+            return [];
         }
 
-        if (\is_array($schema['allOf'] ?? null)) {
-            return true;
+        $found = [];
+        foreach (['allOf', 'oneOf', 'anyOf'] as $keyword) {
+            $subschemas = $schema[$keyword] ?? null;
+            if (\is_array($subschemas)) {
+                $found[$keyword] = true;
+                foreach ($subschemas as $subschema) {
+                    if (\is_array($subschema)) {
+                        $this->collectKeywords($subschema, $depth + 1, $found);
+                    }
+                }
+            }
         }
 
+        if ($this->hasOpenAdditionalProperties($schema)) {
+            $found['additionalProperties'] = true;
+        }
+
+        $additional = $schema['additionalProperties'] ?? null;
+        if (\is_array($additional)) {
+            $this->collectKeywords($additional, $depth + 1, $found);
+        }
+
+        $this->collectFromChildren($schema, $depth, $found);
+
+        return array_values(array_filter(
+            ['allOf', 'oneOf', 'anyOf', 'additionalProperties'],
+            static fn(string $keyword): bool => isset($found[$keyword]),
+        ));
+    }
+
+    /**
+     * Merges the keywords of a nested schema into the running set.
+     *
+     * @param array<string, mixed> $schema
+     * @param array<string, true>  $found
+     */
+    private function collectKeywords(array $schema, int $depth, array &$found): void
+    {
+        foreach ($this->compositionKeywords($schema, $depth) as $keyword) {
+            $found[$keyword] = true;
+        }
+    }
+
+    /**
+     * Recurses into a schema's `properties` and array `items`.
+     *
+     * @param array<string, mixed> $schema
+     * @param array<string, true>  $found
+     */
+    private function collectFromChildren(array $schema, int $depth, array &$found): void
+    {
         $properties = $schema['properties'] ?? null;
         if (\is_array($properties)) {
             foreach ($properties as $property) {
-                if (\is_array($property) && $this->usesAllOf($property, $depth + 1)) {
-                    return true;
+                if (\is_array($property)) {
+                    $this->collectKeywords($property, $depth + 1, $found);
                 }
             }
         }
 
         $items = $schema['items'] ?? null;
+        if (\is_array($items)) {
+            $this->collectKeywords($items, $depth + 1, $found);
+        }
+    }
 
-        return \is_array($items) && $this->usesAllOf($items, $depth + 1);
+    /**
+     * `additionalProperties` is lossy only when it permits extra keys — `true`
+     * or a schema. An explicit `false` (closed object) is the safe default and
+     * is not warned.
+     *
+     * @param array<string, mixed> $schema
+     */
+    private function hasOpenAdditionalProperties(array $schema): bool
+    {
+        if (!\array_key_exists('additionalProperties', $schema)) {
+            return false;
+        }
+
+        $value = $schema['additionalProperties'];
+
+        return $value === true || \is_array($value);
     }
 
     /**
@@ -298,8 +398,8 @@ final readonly class CoverageScanner
     private function scanComposition(mixed $media, string $subject, string $where, array &$warnings): void
     {
         $schema = $this->schemaOf($media);
-        if ($schema !== null && $this->usesAllOf($schema)) {
-            $warnings[] = \sprintf('%s on %s uses allOf; its subschemas are merged into one object on import (composition not preserved).', $subject, $where);
+        if ($schema !== null) {
+            $this->warnCompositionKeywords($schema, \sprintf('%s on %s', $subject, $where), $warnings);
         }
     }
 

--- a/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
+++ b/tests/Scaffold/Sdk/Model/CoverageScannerTest.php
@@ -137,6 +137,63 @@ final class CoverageScannerTest extends TestCase
         ], $warnings);
     }
 
+    public function testWarnsOnOneOfAnyOfAndAdditionalPropertiesComponents(): void
+    {
+        // Unions (oneOf/anyOf) have no Altair representation; additionalProperties
+        // is an open-ended map whose extra keys are not imported. All surfaced.
+        $warnings = (new CoverageScanner())->scan([
+            'components' => ['schemas' => [
+                'Choice' => ['oneOf' => [['type' => 'object'], ['type' => 'string']]],
+                'Mix' => ['anyOf' => [['type' => 'object'], ['type' => 'integer']]],
+                'Map' => ['type' => 'object', 'additionalProperties' => ['type' => 'integer']],
+                'OpenMap' => ['type' => 'object', 'additionalProperties' => true],
+                'Closed' => ['type' => 'object', 'additionalProperties' => false],
+            ]],
+            'paths' => [],
+        ]);
+
+        self::assertSame([
+            '`components.schemas.Choice` uses oneOf; a union has no Altair representation, so it is not imported.',
+            '`components.schemas.Mix` uses anyOf; a union has no Altair representation, so it is not imported.',
+            '`components.schemas.Map` uses additionalProperties; open-ended map keys are not imported.',
+            '`components.schemas.OpenMap` uses additionalProperties; open-ended map keys are not imported.',
+        ], $warnings);
+    }
+
+    public function testDetectsCompositionKeywordsNestedInProperties(): void
+    {
+        // A union buried inside a property is found by the recursive descent.
+        $warnings = (new CoverageScanner())->scan([
+            'components' => ['schemas' => [
+                'Wrapper' => ['type' => 'object', 'properties' => [
+                    'payload' => ['oneOf' => [['type' => 'string'], ['type' => 'integer']]],
+                ]],
+            ]],
+            'paths' => [],
+        ]);
+
+        self::assertSame([
+            '`components.schemas.Wrapper` uses oneOf; a union has no Altair representation, so it is not imported.',
+        ], $warnings);
+    }
+
+    public function testWarnsOnInlineOneOfResponseBody(): void
+    {
+        $warnings = (new CoverageScanner())->scan([
+            'paths' => [
+                '/x' => ['get' => ['responses' => [
+                    '200' => ['content' => ['application/json' => ['schema' => [
+                        'oneOf' => [['type' => 'object'], ['type' => 'string']],
+                    ]]]],
+                ]]],
+            ],
+        ]);
+
+        self::assertSame([
+            'response 200 on GET /x uses oneOf; a union has no Altair representation, so it is not imported.',
+        ], $warnings);
+    }
+
     public function testWarnsOnInlineAllOfRequestBody(): void
     {
         // An inline allOf body (not via $ref) is flattened too, so it is surfaced


### PR DESCRIPTION
Part of #214 — **Phase 4c + 4d (content & composition: unions + open maps)**.

## Problem
`oneOf` / `anyOf` (unions) and `additionalProperties` (open-ended maps) were dropped on import without any warning. They have **no clean Altair representation** (the input layer is a named scalar/object field list), so this is honest-surfacing work, not mapping.

## Change (CoverageScanner-only — no parser/mapper change)
The allOf detector is generalized into `compositionKeywords`: a recursive, `$ref`-free, depth-bounded (`MAX_SCAN_DEPTH`) collector that returns which of `allOf` / `oneOf` / `anyOf` / `additionalProperties` appear anywhere in a schema tree (`properties`, `items`, and the composition subschema lists), in a fixed canonical order. One warning is emitted per keyword, per named component and per inline body/response:
- `oneOf`/`anyOf` → "a union has no Altair representation, so it is not imported". (A union **body** stays unmappable / `--skip-unmappable`; a union **response** surfaces as `mixed`.)
- `additionalProperties` → "open-ended map keys are not imported". `true` or a schema warns; an explicit `additionalProperties: false` (closed object) does not. Declared `properties` still map normally.
- `allOf` keeps its existing wording byte-for-byte.

A `$ref`-to-a-union-component warns at the component, not the body (no double-warning).

## Verification
- New tests: components (oneOf/anyOf/additionalProperties incl. `true` and `false`), nested-in-properties descent, inline `oneOf` response.
- Real **Swagger Petstore**: now surfaces `GET /store/inventory`'s `additionalProperties` map (status→quantity), previously imported as an empty body — warnings **17 → 18**; still **19 specs / 0 unmapped**, `openapi:roundtrip --check` clean.
- Full QA gauntlet (cache-free): **CS clean · PHPStan L8 no-baseline clean · Rector full-tree clean · 308 scaffold tests green**.
- `code-reviewer`: **APPROVE** (0 CRITICAL/0 HIGH); its findings applied (future-proof `match` with throwing default + added nested-descent and `additionalProperties: true` tests). No security review needed — read-only scanner, no new I/O.

## Remaining
**Phase 4e** (external/relative-file `$ref` bundling) and **Phase 5** (security schemes + naming).