### PR TITLE
re #214 feat(scaffold): bundle external file $refs on import (#214 Phase 4e)

### DIFF
--- a/.agent/packages/scaffold.md
+++ b/.agent/packages/scaffold.md
@@ -5,6 +5,7 @@
 ## Concrete classes
 
 - `ActionEmitter`
+- `BundleResult` _(final)_
 - `CoverageScanner` _(final)_
 - `DiffCommand` _(final)_
 - `DomainSpec` _(final)_
@@ -68,6 +69,7 @@
 - `PhpHeader` _(final)_
 - `PythonEmitter` _(final)_ — implements `EmitterInterface`
 - `QueueDispatchSpec` _(final)_
+- `RefBundler` _(final)_
 - `ReplayCommand` _(final)_
 - `RepositoryEmitter` _(final)_
 - `ResponderEmitter`
@@ -143,6 +145,7 @@
 - `tests/Scaffold/Sdk/OpenApiParserExtensionsTest.php`
 - `tests/Scaffold/Sdk/OpenApiParserTest.php`
 - `tests/Scaffold/Sdk/PythonEmitterTest.php`
+- `tests/Scaffold/Sdk/RefBundlerTest.php`
 - `tests/Scaffold/Sdk/TypeScriptEmitterTest.php`
 - `tests/Scaffold/Spec/Emitter/EmittedSpecTest.php`
 - `tests/Scaffold/Spec/Emitter/EmitterTest.php`

--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -21,6 +21,7 @@ closes the gaps.
 - Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
 - **Validation constraints** ↔ rules (Phase 3): `format` (`email`/`uri`/`ip`/`date-time`)→`email`/`url`/`ip`/`datetime`; `minLength`/`maxLength`→`min`/`max`; `minimum`/`maximum`→`min`/`max`; `pattern`→`regex:`. Round-trips (the forward emitter writes the inverse).
 - Internal `$ref` (`#/components/schemas/<Name>`), `properties` + `required`.
+- **External relative-file `$ref`** (Phase 4e) — a `$ref` into a sibling file (`./schemas/pet.yaml#/Pet`) is **bundled**: the target schema (and its own nested/internal refs) is inlined into `components/schemas` and the ref rewritten to internal, so multi-file specs import instead of failing. Bounded (file count, per-file size, ref-chase depth; cycles dedupe). **Remote refs are never fetched** and a ref escaping the document's directory is rejected — both are warned and left unresolved.
 - **`allOf` composition** (Phase 4b) — subschemas are resolved (`$ref`s included) and their properties **merged into one object**; a property required in any subschema is required in the merge. Altair has no representation for composition, so the relationship is flattened (warned) while the data is preserved. A subschema that does not resolve to an object is unmappable.
 - `x-altair-*` extensions (domain/persistence/queue/idempotency/webhook round-trip).
 
@@ -41,7 +42,7 @@ closes the gaps.
 
 ### Surfaced as errors / skips (fail, or `--skip-unmappable`)
 
-- **External / file / URL `$ref`** (only internal component refs resolve).
+- **Remote (`http(s)://`) `$ref`, or a file `$ref` escaping the document directory** — warned by the bundler and left unresolved, so the mapper surfaces them as unmappable (never fetched/read).
 - `oneOf` / `anyOf` in a request body; recursive `$ref`; a bare scalar body (incl. a normalized non-JSON body that turns out to be a scalar); an `allOf` whose subschema is not an object.
 
 ### Not yet mapped or warned (later phases)
@@ -63,6 +64,7 @@ constraints** from validation rules — `email`→`format`, `min:3`→`minLength
 
 See [#214](https://github.com/univeros/framework/issues/214) for the phased plan
 (stop silent loss → parameters → validation fidelity → content & composition →
-security & misc). This page is updated as each phase lands. **Phases 4a** (non-JSON
-object bodies), **4b** (`allOf` merge), and **4c/4d** (`oneOf`/`anyOf` +
-`additionalProperties`, surfaced) have landed; external-`$ref` bundling remains.
+security & misc). This page is updated as each phase lands. **Phase 4 is
+complete** — 4a (non-JSON bodies), 4b (`allOf` merge), 4c/4d (`oneOf`/`anyOf` +
+`additionalProperties`), and 4e (external-`$ref` bundling). **Phase 5** (security
+schemes + naming) is next.

--- a/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
+++ b/src/Altair/Scaffold/Cli/OpenApiImportRunner.php
@@ -23,9 +23,11 @@ use Altair\Scaffold\Emitter\EmittedFileKind;
 use Altair\Scaffold\Journal\Journal;
 use Altair\Scaffold\Journal\JournalEntry;
 use Altair\Scaffold\Journal\SnapshotCollector;
+use Altair\Scaffold\Sdk\Exception\SdkException;
 use Altair\Scaffold\Sdk\Model\CoverageScanner;
 use Altair\Scaffold\Sdk\Model\OpenApiDocument;
 use Altair\Scaffold\Sdk\Model\OpenApiParser;
+use Altair\Scaffold\Sdk\Model\RefBundler;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
 use Altair\Scaffold\Spec\Emitter\OperationMapper;
 use Altair\Scaffold\Spec\Emitter\PathDeriver;
@@ -37,6 +39,7 @@ use Altair\Scaffold\Writer\WriteStatus;
 use function array_values;
 use function microtime;
 
+use Symfony\Component\Yaml\Exception\ParseException;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
 
@@ -103,7 +106,8 @@ final readonly class OpenApiImportRunner
         }
 
         try {
-            $document = $this->parser->parseYaml($sourceContents);
+            $bundle = (new RefBundler($this->baseDir($options->documentPath)))->bundle($this->decodeDocument($sourceContents));
+            $document = $this->parser->parse($bundle->document);
             $plan = $this->planSpecs($document, $options);
         } catch (UnmappableSchemaException $unmappableSchemaException) {
             return $this->failure(
@@ -116,7 +120,7 @@ final readonly class OpenApiImportRunner
             return $this->failure($options, $throwable->getMessage(), $startedAt);
         }
 
-        $coverageWarnings = $this->coverageWarnings($sourceContents);
+        $coverageWarnings = [...$bundle->warnings, ...$this->coverageScanner->scan($bundle->document)];
 
         if ($options->dryRun) {
             return $this->dryRunReceipt($options, $plan, $document, $coverageWarnings);
@@ -465,21 +469,37 @@ final readonly class OpenApiImportRunner
     }
 
     /**
-     * Warnings for every OpenAPI construct the importer drops — so nothing is
-     * lost silently. Best-effort: a document that no longer parses as YAML
-     * simply yields no coverage warnings (the parse failure surfaces elsewhere).
+     * Decodes the raw document, mirroring {@see OpenApiParser::parseYaml}'s
+     * error handling so an invalid document fails the same way whether or not
+     * it carries external refs.
      *
-     * @return list<string>
+     * @return array<string, mixed>
      */
-    private function coverageWarnings(string $sourceContents): array
+    private function decodeDocument(string $sourceContents): array
     {
         try {
-            $raw = Yaml::parse($sourceContents);
-        } catch (Throwable) {
-            return [];
+            $decoded = Yaml::parse($sourceContents);
+        } catch (ParseException $parseException) {
+            throw new SdkException('Invalid OpenAPI YAML: ' . $parseException->getMessage(), 0, $parseException);
         }
 
-        return \is_array($raw) ? $this->coverageScanner->scan($raw) : [];
+        if (!\is_array($decoded)) {
+            throw new SdkException('OpenAPI document must be a YAML map at the top level.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * Directory the document's external `$ref`s resolve against, with the
+     * document path canonicalized first so a symlinked spec still resolves its
+     * siblings against their real directory.
+     */
+    private function baseDir(string $documentPath): string
+    {
+        $real = realpath($documentPath);
+
+        return \dirname($real !== false ? $real : $documentPath);
     }
 
     /**

--- a/src/Altair/Scaffold/Cli/OpenApiRoundtripRunner.php
+++ b/src/Altair/Scaffold/Cli/OpenApiRoundtripRunner.php
@@ -13,6 +13,7 @@ namespace Altair\Scaffold\Cli;
 
 use Altair\Scaffold\Emitter\OpenApiEmitter;
 use Altair\Scaffold\Sdk\Model\OpenApiParser;
+use Altair\Scaffold\Sdk\Model\RefBundler;
 use Altair\Scaffold\Spec\Emitter\EmittedSpec;
 use Altair\Scaffold\Spec\Emitter\Emitter as SpecEmitter;
 use Altair\Scaffold\Spec\Emitter\Exception\UnmappableSchemaException;
@@ -66,10 +67,23 @@ final readonly class OpenApiRoundtripRunner
         $sourceYaml = (string) @file_get_contents($options->documentPath);
 
         try {
-            $source = $this->openApiParser->parseYaml($sourceYaml);
+            $decoded = Yaml::parse($sourceYaml);
+            if (!\is_array($decoded)) {
+                return new RoundtripReceipt(
+                    clean: false,
+                    input: $options->documentPath,
+                    operationsCompared: 0,
+                    differences: [],
+                    error: 'OpenAPI document must be a YAML map at the top level.',
+                );
+            }
+
+            $real = realpath($options->documentPath);
+            $bundled = (new RefBundler(\dirname($real !== false ? $real : $options->documentPath)))->bundle($decoded)->document;
+            $source = $this->openApiParser->parse($bundled);
             $emittedSpecs = $this->specEmitter->emit($source);
             $rebuilt = $this->reemit($emittedSpecs);
-            $sourceProjection = $this->projectFromDocument(Yaml::parse($sourceYaml) ?: []);
+            $sourceProjection = $this->projectFromDocument($bundled);
             $rebuiltProjection = $this->projectFromDocument($rebuilt);
             $differences = $this->compare($sourceProjection, $rebuiltProjection);
         } catch (UnmappableSchemaException $unmappableSchemaException) {

--- a/src/Altair/Scaffold/Sdk/Model/BundleResult.php
+++ b/src/Altair/Scaffold/Sdk/Model/BundleResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Sdk\Model;
+
+/**
+ * Outcome of {@see RefBundler::bundle()}: the document with every resolvable
+ * external `$ref` inlined into `components/schemas` (and rewritten to an
+ * internal ref), plus one warning per ref that could not be safely bundled.
+ */
+final readonly class BundleResult
+{
+    /**
+     * @param array<string, mixed> $document
+     * @param list<string>         $warnings
+     */
+    public function __construct(
+        public array $document,
+        public array $warnings,
+    ) {}
+}

--- a/src/Altair/Scaffold/Sdk/Model/RefBundler.php
+++ b/src/Altair/Scaffold/Sdk/Model/RefBundler.php
@@ -1,0 +1,396 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the univeros/framework
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Altair\Scaffold\Sdk\Model;
+
+use const DIRECTORY_SEPARATOR;
+use const PATHINFO_FILENAME;
+
+use Symfony\Component\Yaml\Yaml;
+use Throwable;
+
+/**
+ * Inlines external (relative-file) `$ref`s into a single self-contained
+ * document so {@see OpenApiParser} can resolve them like internal component
+ * refs. The classic multi-file pattern — a spec that splits its schemas across
+ * sibling files (`$ref: './schemas/pet.yaml#/Pet'`) — bundles instead of
+ * failing with "ref not defined in components/schemas".
+ *
+ * Security (the document and the files it references may be untrusted):
+ *
+ * - **No remote fetch.** A `http(s)://`, protocol-relative (`//host`), or any
+ *   other URI-scheme ref is rejected (warned, left unresolved). Only local
+ *   files are read.
+ * - **No path escape.** A file ref is resolved relative to the referring file's
+ *   directory, canonicalized with `realpath`, and must stay inside the base
+ *   directory subtree (the root document's directory). Absolute paths and `..`
+ *   that escapes the base are rejected.
+ * - **Bounded.** Caps on distinct files ({@see MAX_FILES}), per-file size
+ *   ({@see MAX_FILE_BYTES}), and ref-chase depth ({@see MAX_DEPTH}); cyclic and
+ *   repeated refs reuse the first synthesized name instead of looping.
+ *
+ * A ref that cannot be bundled is left untouched, so the downstream
+ * {@see \Altair\Scaffold\Spec\Emitter\SchemaMapper} still surfaces it as an
+ * unmappable schema — bundling never silences a ref, it only resolves the safe
+ * ones.
+ */
+final class RefBundler
+{
+    private const int MAX_FILES = 32;
+
+    private const int MAX_DEPTH = 32;
+
+    private const int MAX_FILE_BYTES = 1_000_000;
+
+    /** Structural-walk ceiling — bounds nested-mapping depth so a pathological document cannot exhaust the call stack. */
+    private const int MAX_WALK_DEPTH = 64;
+
+    private readonly string $baseDir;
+
+    /** @var array<string, array<string, mixed>> Canonical path => decoded document (load cache). */
+    private array $documents = [];
+
+    /** @var array<string, string> "canonicalPath\0pointer" => synthesized component name. */
+    private array $names = [];
+
+    /** @var array<string, array<string, mixed>> Synthesised name => bundled schema. */
+    private array $schemas = [];
+
+    /** @var array<string, true> Component names already in use (root + synthesized). */
+    private array $used = [];
+
+    /** @var list<string> */
+    private array $warnings = [];
+
+    public function __construct(string $baseDir)
+    {
+        $real = realpath($baseDir);
+        $this->baseDir = $real !== false ? $real : rtrim($baseDir, DIRECTORY_SEPARATOR);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     */
+    public function bundle(array $document): BundleResult
+    {
+        $this->documents = [];
+        $this->names = [];
+        $this->schemas = [];
+        $this->used = $this->existingComponentNames($document);
+        $this->warnings = [];
+
+        /** @var array<string, mixed> $rewritten */
+        $rewritten = $this->rewrite($document, null, 0);
+
+        if ($this->schemas !== []) {
+            $rewritten = $this->mergeSynthesised($rewritten);
+        }
+
+        return new BundleResult($rewritten, $this->warnings);
+    }
+
+    /**
+     * @param array<string, mixed> $document
+     *
+     * @return array<string, true>
+     */
+    private function existingComponentNames(array $document): array
+    {
+        $components = $document['components'] ?? null;
+        $schemas = \is_array($components) && \is_array($components['schemas'] ?? null) ? $components['schemas'] : [];
+
+        $used = [];
+        foreach (array_keys($schemas) as $name) {
+            if (\is_string($name)) {
+                $used[$name] = true;
+            }
+        }
+
+        return $used;
+    }
+
+    /**
+     * @param  array<string, mixed> $document
+     * @return array<string, mixed>
+     */
+    private function mergeSynthesised(array $document): array
+    {
+        $components = \is_array($document['components'] ?? null) ? $document['components'] : [];
+        $schemas = \is_array($components['schemas'] ?? null) ? $components['schemas'] : [];
+
+        foreach ($this->schemas as $name => $schema) {
+            $schemas[$name] = $schema;
+        }
+
+        $components['schemas'] = $schemas;
+        $document['components'] = $components;
+
+        return $document;
+    }
+
+    /**
+     * Returns a copy of $node with every external `$ref` rewritten to an
+     * internal one. $contextFile is the canonical path of the file the node
+     * came from, or null for the root document (whose internal refs stay
+     * internal). $depth bounds external-ref chasing, not the structural walk.
+     *
+     * @phpstan-impure accumulates inlined schemas/warnings into instance state.
+     */
+    private function rewrite(mixed $node, ?string $contextFile, int $depth, int $walkDepth = 0): mixed
+    {
+        if (!\is_array($node)) {
+            return $node;
+        }
+
+        if ($walkDepth >= self::MAX_WALK_DEPTH) {
+            $this->warn('document nesting exceeds the maximum walk depth; left unprocessed.');
+
+            return $node;
+        }
+
+        $ref = $node['$ref'] ?? null;
+        if (\is_string($ref)) {
+            $internal = $this->resolveRef($ref, $contextFile, $depth);
+
+            // Per JSON Reference, sibling keys of a `$ref` are ignored, so a
+            // resolved ref collapses to a single internal pointer.
+            return $internal !== null ? ['$ref' => $internal] : $node;
+        }
+
+        $out = [];
+        foreach ($node as $key => $value) {
+            $out[$key] = $this->rewrite($value, $contextFile, $depth, $walkDepth + 1);
+        }
+
+        return $out;
+    }
+
+    /**
+     * Resolves one `$ref` to an internal `#/components/schemas/<name>` pointer,
+     * inlining the target schema as a side effect. Returns null when the ref is
+     * internal-to-root (left as-is) or cannot be safely bundled (warned).
+     *
+     * @phpstan-impure inlines the resolved schema into instance state.
+     */
+    private function resolveRef(string $ref, ?string $contextFile, int $depth): ?string
+    {
+        [$file, $pointer] = $this->splitRef($ref);
+
+        if ($file === '') {
+            if ($contextFile === null) {
+                return null; // internal ref in the root document — already resolvable.
+            }
+
+            $canonical = $contextFile; // internal ref inside an external file → that file.
+        } else {
+            $dir = $contextFile !== null ? \dirname($contextFile) : $this->baseDir;
+            $canonical = $this->safeResolve($file, $dir, $ref);
+            if ($canonical === null) {
+                return null;
+            }
+        }
+
+        $key = $canonical . "\0" . $pointer;
+        if (isset($this->names[$key])) {
+            return '#/components/schemas/' . $this->names[$key]; // dedupe / cycle.
+        }
+
+        if ($depth >= self::MAX_DEPTH) {
+            $this->warn(\sprintf('external `$ref` chain exceeded depth %d at `%s`; not bundled.', self::MAX_DEPTH, $ref));
+
+            return null;
+        }
+
+        $document = $this->load($canonical, $ref);
+        if ($document === null) {
+            return null;
+        }
+
+        $target = $this->pointer($document, $pointer);
+        if (!\is_array($target)) {
+            $this->warn(\sprintf('external `$ref` `%s` does not resolve to a schema; not bundled.', $ref));
+
+            return null;
+        }
+
+        $name = $this->synthesizeName($pointer, $canonical);
+        $this->names[$key] = $name;
+        $this->used[$name] = true;
+        // Register the name before recursing so a cyclic ref reuses it.
+        /** @var array<string, mixed> $bundled */
+        $bundled = $this->rewrite($target, $canonical, $depth + 1);
+        $this->schemas[$name] = $bundled;
+
+        return '#/components/schemas/' . $name;
+    }
+
+    /**
+     * @return array{0: string, 1: string} [file, pointer] — pointer keeps its leading slash, e.g. `/components/schemas/Pet`.
+     */
+    private function splitRef(string $ref): array
+    {
+        $hash = strpos($ref, '#');
+        if ($hash === false) {
+            return [$ref, ''];
+        }
+
+        return [substr($ref, 0, $hash), substr($ref, $hash + 1)];
+    }
+
+    /**
+     * Validates and canonicalizes a relative file ref, returning the absolute
+     * path only when it is a readable local file inside the base subtree.
+     */
+    private function safeResolve(string $file, string $dir, string $ref): ?string
+    {
+        if (preg_match('#^[a-zA-Z][a-zA-Z0-9+.\-]*://#', $file) === 1 || str_starts_with($file, '//')) {
+            $this->warn(\sprintf('remote `$ref` `%s` is not fetched; not bundled.', $ref));
+
+            return null;
+        }
+
+        if ($this->isAbsolute($file)) {
+            $this->warn(\sprintf('absolute `$ref` path `%s` is not allowed; not bundled.', $ref));
+
+            return null;
+        }
+
+        $real = realpath($dir . DIRECTORY_SEPARATOR . $file);
+        if ($real === false || !is_file($real)) {
+            $this->warn(\sprintf('external `$ref` file `%s` was not found; not bundled.', $ref));
+
+            return null;
+        }
+
+        if ($real !== $this->baseDir && !str_starts_with($real, $this->baseDir . DIRECTORY_SEPARATOR)) {
+            $this->warn(\sprintf('external `$ref` `%s` escapes the document directory; not bundled.', $ref));
+
+            return null;
+        }
+
+        return $real;
+    }
+
+    private function isAbsolute(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || str_starts_with($path, '\\')
+            || preg_match('#^[A-Za-z]:[\\\\/]#', $path) === 1;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function load(string $canonical, string $ref): ?array
+    {
+        if (isset($this->documents[$canonical])) {
+            return $this->documents[$canonical];
+        }
+
+        if (\count($this->documents) >= self::MAX_FILES) {
+            $this->warn(\sprintf('external `$ref` file budget (%d) exceeded at `%s`; not bundled.', self::MAX_FILES, $ref));
+
+            return null;
+        }
+
+        $size = filesize($canonical);
+        if ($size === false || $size > self::MAX_FILE_BYTES) {
+            $this->warn(\sprintf('external `$ref` file `%s` is too large; not bundled.', $ref));
+
+            return null;
+        }
+
+        $contents = @file_get_contents($canonical);
+        if ($contents === false) {
+            $this->warn(\sprintf('external `$ref` file `%s` is not readable; not bundled.', $ref));
+
+            return null;
+        }
+
+        try {
+            $decoded = Yaml::parse($contents);
+        } catch (Throwable) {
+            $this->warn(\sprintf('external `$ref` file `%s` is not valid YAML/JSON; not bundled.', $ref));
+
+            return null;
+        }
+
+        if (!\is_array($decoded)) {
+            $this->warn(\sprintf('external `$ref` file `%s` is not a map; not bundled.', $ref));
+
+            return null;
+        }
+
+        $this->documents[$canonical] = $decoded;
+
+        return $decoded;
+    }
+
+    /**
+     * Resolves a JSON Pointer (RFC 6901) within a decoded document. An empty
+     * pointer is the whole document.
+     *
+     * @param array<string, mixed> $document
+     */
+    private function pointer(array $document, string $pointer): mixed
+    {
+        if ($pointer === '') {
+            return $document; // a whole-file ref (`file.yaml` with no fragment).
+        }
+
+        $node = $document;
+        foreach (explode('/', ltrim($pointer, '/')) as $rawSegment) {
+            $segment = str_replace(['~1', '~0'], ['/', '~'], rawurldecode($rawSegment));
+            if (!\is_array($node) || !\array_key_exists($segment, $node)) {
+                return null;
+            }
+
+            $node = $node[$segment];
+        }
+
+        return $node;
+    }
+
+    /**
+     * A clean, collision-free PascalCase component name derived from the ref's
+     * last pointer segment (or the file name when the whole file is referenced).
+     */
+    private function synthesizeName(string $pointer, string $canonical): string
+    {
+        $segments = array_values(array_filter(explode('/', $pointer), static fn(string $s): bool => $s !== ''));
+        $last = $segments === [] ? pathinfo($canonical, PATHINFO_FILENAME) : end($segments);
+        $base = $this->pascalCase(str_replace(['~1', '~0'], ['/', '~'], rawurldecode((string) $last)));
+        if ($base === '') {
+            $base = 'External';
+        }
+
+        $name = $base;
+        $suffix = 2;
+        while (isset($this->used[$name])) {
+            $name = $base . $suffix;
+            ++$suffix;
+        }
+
+        return $name;
+    }
+
+    private function pascalCase(string $value): string
+    {
+        $words = array_filter(preg_split('/[^a-zA-Z0-9]+/', $value) ?: []);
+
+        return implode('', array_map(ucfirst(...), $words));
+    }
+
+    private function warn(string $message): void
+    {
+        $this->warnings[] = $message;
+    }
+}

--- a/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiImportRunnerTest.php
@@ -104,6 +104,76 @@ final class OpenApiImportRunnerTest extends TestCase
         );
     }
 
+    public function testBundlesExternalFileRefIntoSpecInputs(): void
+    {
+        // Phase 4e: a body whose schema lives in a sibling file is bundled and
+        // imported instead of failing with "ref not defined".
+        mkdir($this->sandbox . '/schemas', 0o755, true);
+        file_put_contents($this->sandbox . '/schemas/pet.yaml', <<<'YAML'
+            Pet:
+              type: object
+              required: [name]
+              properties:
+                name: { type: string }
+                tag: { type: string }
+            YAML);
+        $path = $this->sandbox . '/openapi.yaml';
+        file_put_contents($path, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: Pets API, version: 1.0.0 }
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  summary: Create a pet
+                  requestBody:
+                    required: true
+                    content:
+                      application/json:
+                        schema: { $ref: './schemas/pet.yaml#/Pet' }
+                  responses:
+                    '201': { description: Created }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $path,
+            projectRoot: $this->sandbox,
+        ));
+
+        self::assertTrue($receipt->ok);
+        $spec = Yaml::parseFile($this->sandbox . '/api/pets/create.yaml');
+        self::assertSame(['name', 'tag'], array_keys($spec['input']));
+        self::assertContains('required', $spec['input']['name']['rules']);
+    }
+
+    public function testRejectsRemoteExternalRefWithWarning(): void
+    {
+        $path = $this->sandbox . '/openapi.yaml';
+        file_put_contents($path, <<<'YAML'
+            openapi: 3.1.0
+            info: { title: API, version: 1.0.0 }
+            paths:
+              /pets:
+                post:
+                  operationId: createPet
+                  requestBody:
+                    content:
+                      application/json:
+                        schema: { $ref: 'https://evil.example/pet.yaml#/Pet' }
+                  responses:
+                    '201': { description: Created }
+            YAML);
+
+        $receipt = (new OpenApiImportRunner())->run(new OpenApiImportOptions(
+            documentPath: $path,
+            projectRoot: $this->sandbox,
+            skipUnmappable: true,
+        ));
+
+        self::assertTrue($receipt->ok);
+        self::assertStringContainsString('remote', implode("\n", $receipt->warnings));
+    }
+
     public function testFlattensAllOfBodyIntoSpecInputs(): void
     {
         // Phase 4b: a request body composed with allOf (inheritance via $ref +

--- a/tests/Scaffold/Cli/OpenApiRoundtripRunnerTest.php
+++ b/tests/Scaffold/Cli/OpenApiRoundtripRunnerTest.php
@@ -60,6 +60,17 @@ final class OpenApiRoundtripRunnerTest extends TestCase
         self::assertSame([], $receipt->differences);
     }
 
+    public function testNonMapDocumentIsAnErrorNotASilentCleanPass(): void
+    {
+        $documentPath = $this->writeDocument("just-a-scalar-string\n");
+
+        $receipt = (new OpenApiRoundtripRunner())->run(new OpenApiRoundtripOptions($documentPath));
+
+        self::assertFalse($receipt->clean);
+        self::assertNotNull($receipt->error);
+        self::assertStringContainsString('YAML map', $receipt->error);
+    }
+
     public function testDescriptionOnlyStatusesDoNotCountAsDrift(): void
     {
         // 204 No Content and 404 Not Found carry no schema; the round-trip

--- a/tests/Scaffold/Sdk/RefBundlerTest.php
+++ b/tests/Scaffold/Sdk/RefBundlerTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Altair\Tests\Scaffold\Sdk;
+
+use Altair\Scaffold\Sdk\Model\RefBundler;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+
+use function bin2hex;
+use function random_bytes;
+
+use Altair\Scaffold\Sdk\Model\BundleResult;
+
+#[CoversClass(RefBundler::class)]
+#[CoversClass(BundleResult::class)]
+final class RefBundlerTest extends TestCase
+{
+    private string $sandbox = '';
+
+    protected function setUp(): void
+    {
+        $this->sandbox = sys_get_temp_dir() . '/altair-bundler-' . bin2hex(random_bytes(4));
+        mkdir($this->sandbox, 0o755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->sandbox)) {
+            $this->removeRecursively($this->sandbox);
+        }
+    }
+
+    public function testDocumentWithoutExternalRefsIsUnchanged(): void
+    {
+        $document = ['openapi' => '3.1.0', 'components' => ['schemas' => ['Pet' => ['type' => 'object']]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertSame($document, $result->document);
+        self::assertSame([], $result->warnings);
+    }
+
+    public function testInlinesExternalSchemaAndRewritesRef(): void
+    {
+        $this->write('pet.yaml', "Pet:\n  type: object\n  required: [name]\n  properties:\n    name: { type: string }\n");
+        $body = ['content' => ['application/json' => ['schema' => ['$ref' => './pet.yaml#/Pet']]]];
+        $document = ['paths' => ['/pets' => ['post' => ['requestBody' => $body]]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertSame([], $result->warnings);
+        $schema = $result->document['paths']['/pets']['post']['requestBody']['content']['application/json']['schema'];
+        self::assertSame(['$ref' => '#/components/schemas/Pet'], $schema);
+        self::assertSame('object', $result->document['components']['schemas']['Pet']['type']);
+        self::assertSame(['name'], $result->document['components']['schemas']['Pet']['required']);
+    }
+
+    public function testResolvesNestedExternalRefAcrossFiles(): void
+    {
+        $this->write('pet.yaml', "Pet:\n  type: object\n  properties:\n    category: { \$ref: './category.yaml#/Category' }\n");
+        $this->write('category.yaml', "Category:\n  type: object\n  properties:\n    name: { type: string }\n");
+        $document = ['components' => ['schemas' => ['PetRef' => ['$ref' => './pet.yaml#/Pet']]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertSame([], $result->warnings);
+        $schemas = $result->document['components']['schemas'];
+        self::assertSame(['$ref' => '#/components/schemas/Pet'], $schemas['PetRef']);
+        self::assertSame(['$ref' => '#/components/schemas/Category'], $schemas['Pet']['properties']['category']);
+        self::assertSame('string', $schemas['Category']['properties']['name']['type']);
+    }
+
+    public function testRewritesInternalRefInsideExternalFile(): void
+    {
+        // pet.yaml#/Pet references pet.yaml#/Tag via a same-file internal ref.
+        $this->write('pet.yaml', "Pet:\n  type: object\n  properties:\n    tag: { \$ref: '#/Tag' }\nTag:\n  type: object\n  properties:\n    label: { type: string }\n");
+        $document = ['components' => ['schemas' => ['PetRef' => ['$ref' => './pet.yaml#/Pet']]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertSame([], $result->warnings);
+        $schemas = $result->document['components']['schemas'];
+        self::assertSame(['$ref' => '#/components/schemas/Tag'], $schemas['Pet']['properties']['tag']);
+        self::assertSame('string', $schemas['Tag']['properties']['label']['type']);
+    }
+
+    public function testCyclicExternalRefsTerminate(): void
+    {
+        $this->write('a.yaml', "A:\n  type: object\n  properties:\n    b: { \$ref: './b.yaml#/B' }\n");
+        $this->write('b.yaml', "B:\n  type: object\n  properties:\n    a: { \$ref: './a.yaml#/A' }\n");
+        $document = ['components' => ['schemas' => ['Root' => ['$ref' => './a.yaml#/A']]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertSame([], $result->warnings);
+        $schemas = $result->document['components']['schemas'];
+        self::assertSame(['$ref' => '#/components/schemas/B'], $schemas['A']['properties']['b']);
+        self::assertSame(['$ref' => '#/components/schemas/A'], $schemas['B']['properties']['a']);
+    }
+
+    public function testDedupesNameAgainstExistingComponent(): void
+    {
+        $this->write('pet.yaml', "Pet:\n  type: object\n  properties:\n    external: { type: boolean }\n");
+        $document = ['components' => ['schemas' => [
+            'Pet' => ['type' => 'object', 'properties' => ['local' => ['type' => 'string']]],
+            'Ref' => ['$ref' => './pet.yaml#/Pet'],
+        ]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        $schemas = $result->document['components']['schemas'];
+        // Existing Pet is untouched; the external one is bundled as Pet2.
+        self::assertArrayHasKey('local', $schemas['Pet']['properties']);
+        self::assertSame(['$ref' => '#/components/schemas/Pet2'], $schemas['Ref']);
+        self::assertArrayHasKey('external', $schemas['Pet2']['properties']);
+    }
+
+    public function testRejectsRemoteRef(): void
+    {
+        $document = ['components' => ['schemas' => ['R' => ['$ref' => 'https://evil.example/p.yaml#/Pet']]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertCount(1, $result->warnings);
+        self::assertStringContainsString('remote', $result->warnings[0]);
+        // Left untouched so the mapper still surfaces it.
+        self::assertSame(['$ref' => 'https://evil.example/p.yaml#/Pet'], $result->document['components']['schemas']['R']);
+    }
+
+    public function testRejectsPathTraversalEscapingBaseDir(): void
+    {
+        // A file that physically exists outside the base dir must not be read.
+        $outside = \dirname($this->sandbox) . '/altair-bundler-secret-' . bin2hex(random_bytes(4)) . '.yaml';
+        file_put_contents($outside, "Secret:\n  type: object\n");
+        try {
+            $document = ['components' => ['schemas' => ['R' => ['$ref' => '../' . basename($outside) . '#/Secret']]]];
+
+            $result = (new RefBundler($this->sandbox))->bundle($document);
+
+            self::assertCount(1, $result->warnings);
+            self::assertStringContainsString('escapes the document directory', $result->warnings[0]);
+            self::assertArrayNotHasKey('Secret', $result->document['components']['schemas']);
+        } finally {
+            @unlink($outside);
+        }
+    }
+
+    public function testRejectsAbsolutePath(): void
+    {
+        $document = ['components' => ['schemas' => ['R' => ['$ref' => '/etc/passwd#/x']]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertCount(1, $result->warnings);
+        self::assertStringContainsString('absolute', $result->warnings[0]);
+    }
+
+    public function testWarnsOnMissingFileAndUnknownPointer(): void
+    {
+        $this->write('pet.yaml', "Pet:\n  type: object\n");
+        $document = ['components' => ['schemas' => [
+            'Gone' => ['$ref' => './missing.yaml#/Pet'],
+            'NoPointer' => ['$ref' => './pet.yaml#/Nope'],
+        ]]];
+
+        $result = (new RefBundler($this->sandbox))->bundle($document);
+
+        self::assertCount(2, $result->warnings);
+        self::assertStringContainsString('was not found', $result->warnings[0]);
+        self::assertStringContainsString('does not resolve to a schema', $result->warnings[1]);
+    }
+
+    private function write(string $name, string $contents): void
+    {
+        file_put_contents($this->sandbox . '/' . $name, $contents);
+    }
+
+    private function removeRecursively(string $dir): void
+    {
+        foreach (scandir($dir) ?: [] as $entry) {
+            if ($entry === '.') {
+                continue;
+            }
+
+            if ($entry === '..') {
+                continue;
+            }
+
+            $path = $dir . '/' . $entry;
+            is_dir($path) ? $this->removeRecursively($path) : @unlink($path);
+        }
+
+        @rmdir($dir);
+    }
+}


### PR DESCRIPTION
Part of #214 — **Phase 4e (content & composition: external `$ref` bundling)**. Completes Phase 4.

## Problem
A `$ref` into a sibling file (`./schemas/pet.yaml#/Pet`) failed with "ref not defined in components/schemas" — multi-file specs (a very common real-world layout) couldn't be imported.

## Change
New `RefBundler` inlines external relative-file refs into one self-contained document before parsing: the target schema (plus its own nested and same-file internal refs) is copied into `components/schemas` under a collision-free PascalCase name and the ref rewritten to internal, so `OpenApiParser` resolves it like any component ref. Wired into `OpenApiImportRunner` and `OpenApiRoundtripRunner` (decode → bundle → parse); the document path is `realpath`'d first so a symlinked spec resolves its siblings against their real directory.

## Security (spec + referenced files may be untrusted)
- **No remote fetch** — `http(s)://`, `//host`, `file://`, any `scheme://` is rejected, warned, left unresolved.
- **No path escape** — a file ref is resolved relative to the referring file's dir, `realpath`-canonicalized, and must stay inside the base subtree (the document's directory); absolute paths and `..` escapes are rejected. The trailing-separator containment check prevents sibling-prefix bypass; symlinks resolve before the check.
- **Bounded** — caps on distinct files (32), per-file size (1 MB, checked before read), ref-chase depth (32), structural-walk depth (64); cyclic/repeated refs dedupe. `symfony/yaml` caps alias expansion → billion-laughs is a clean parse error.
- A ref that can't be safely bundled is **warned and left untouched**, so the mapper still surfaces it — bundling never silences a ref.

## Verification
- New `RefBundler` unit tests: bundling, cross-file nesting, same-file internal refs, cycles, name dedupe vs existing components, and every rejection path (remote, traversal-to-a-real-outside-file, absolute, missing file, unknown pointer).
- e2e import tests: a multi-file spec imports its external schema into spec inputs; a remote ref is rejected with a warning.
- Roundtrip runner now errors (not silent-clean) on a non-map document.
- Real **Petstore** unchanged (no external refs): **19 specs / 18 warnings / 0 unmapped**, `openapi:roundtrip --check` clean.
- Full QA (cache-free): **CS · PHPStan L8 no-baseline · Rector full-tree** clean; **321 scaffold tests** green; `.agent` manifest regenerated.
- `security-reviewer`: **0 CRITICAL/0 HIGH** — path-escape, SSRF, symlink, billion-laughs, cycle, absolute-path defenses each verified. `code-reviewer`: 1 HIGH (roundtrip silent-pass) fixed + MEDIUM/LOW (RFC-6901 `/`, naming, caps, realpath, walk-depth, test assert) all applied.

## Remaining
**Phase 5** — security schemes → auth/middleware hints; `singularize("findByStatus")` + action-y resource naming; path-param declared types. Then the epic closes.