### PR TITLE
re #214 fix(scaffold): name RPC action paths by their noun resource (#214 Phase 5)

### DIFF
--- a/docs/guides/openapi/coverage.md
+++ b/docs/guides/openapi/coverage.md
@@ -16,7 +16,8 @@ closes the gaps.
 ### Mapped
 
 - Paths + operations; `operationId` (or synthesised), `summary`.
-- **Parameters** — path / query / header / cookie become inputs tagged with their `in:` location (with type + `required`; enums → `in:` rule). *Phase 2.*
+- **Resource naming** (Phase 5) — RPC-style path leaves (`findByStatus`, `uploadImage`, `login`) are recognised as actions, not resources: `GET /pet/findByStatus` derives the `Pet` namespace (`App\Pet\FindPetsByStatus`), not a mangled `FindByStatu`. The nearest noun segment is the resource.
+- **Parameters** — path / query / header / cookie become inputs tagged with their `in:` location (with their declared **type** + `required`; enums → `in:` rule). A path param declared with `schema: {type: integer}` imports as `int`, not `string`. *Phase 2.*
 - Request + response bodies in **`application/json`**. When a request body has **no `application/json`**, its schema is read from the first content type carrying an object/array schema (multipart/form-data, x-www-form-urlencoded) — the body is *normalized*, not dropped (Phase 4a). Responses fall back to the first content type with any schema. On export the body always re-emits as `application/json`, so the wire content type is normalized while the body structure round-trips.
 - Schema types: `object` (incl. **nested objects**), `array`, **arrays of objects**, **top-level array bodies**, scalars (`integer`→`int`, `number`→`float`, `boolean`→`bool`, `string`), `enum`→`in:` rule.
 - **Validation constraints** ↔ rules (Phase 3): `format` (`email`/`uri`/`ip`/`date-time`)→`email`/`url`/`ip`/`datetime`; `minLength`/`maxLength`→`min`/`max`; `minimum`/`maximum`→`min`/`max`; `pattern`→`regex:`. Round-trips (the forward emitter writes the inverse).
@@ -37,7 +38,7 @@ closes the gaps.
 - **`allOf` flattening** (Phase 4b) — reported once per named component that uses it (`` `components.schemas.<Name>` uses allOf ``) and per inline body/response that uses it, since the composition relationship is not preserved.
 - **`oneOf` / `anyOf`** (Phase 4c) — a union has no Altair representation; reported per component / inline body / response. A `oneOf`/`anyOf` *body* stays unmappable (skipped with `--skip-unmappable`); a union *response* surfaces as `mixed`.
 - **`additionalProperties`** (Phase 4d) — an open-ended map; reported per component / inline body / response. Declared `properties` still map; only the open-key capability is dropped. An explicit `additionalProperties: false` (closed object) is not warned.
-- operation + global **`security`**, `components.securitySchemes`.
+- operation + global **`security`** and `components.securitySchemes` — surfaced **by design** (Phase 5): Altair has no auth/middleware spec construct to generate into, so the requirement is reported (so you wire auth yourself) rather than silently dropped. This is a deliberate non-goal, like `oneOf` — not a pending gap.
 - `servers`, `webhooks` (3.1), `callbacks`, path-item `$ref`.
 
 ### Surfaced as errors / skips (fail, or `--skip-unmappable`)
@@ -57,14 +58,17 @@ closes the gaps.
 `application/json` request body from body inputs, **OpenAPI `parameters`** for
 inputs tagged `in: path|query|header|cookie` (Phase 2), and **schema
 constraints** from validation rules — `email`→`format`, `min:3`→`minLength`,
-`in:`→`enum`, `regex`→`pattern` (Phase 3). Not yet emitted (tracked in #214):
-`security`, `servers`.
+`in:`→`enum`, `regex`→`pattern` (Phase 3). `security` and `servers` are not
+emitted — there is no Altair spec construct that carries them (see the security
+note above).
 
 ## Roadmap
 
 See [#214](https://github.com/univeros/framework/issues/214) for the phased plan
 (stop silent loss → parameters → validation fidelity → content & composition →
-security & misc). This page is updated as each phase lands. **Phase 4 is
-complete** — 4a (non-JSON bodies), 4b (`allOf` merge), 4c/4d (`oneOf`/`anyOf` +
-`additionalProperties`), and 4e (external-`$ref` bundling). **Phase 5** (security
-schemes + naming) is next.
+security & misc). **The epic is complete.** Phases 1–3 (stop silent loss,
+parameters, validation), Phase 4 (4a non-JSON bodies, 4b `allOf`, 4c/4d
+`oneOf`/`anyOf` + `additionalProperties`, 4e external-`$ref` bundling), and
+Phase 5 (resource-naming fixes; path-param types; `security` surfaced by design)
+have all landed. Remaining items are deliberate non-goals (composition unions,
+auth middleware) or low-value constraints, each surfaced rather than dropped.

--- a/src/Altair/Scaffold/Spec/Emitter/PathDeriver.php
+++ b/src/Altair/Scaffold/Spec/Emitter/PathDeriver.php
@@ -21,6 +21,19 @@ use Altair\Scaffold\Sdk\Model\OperationModel;
  */
 final readonly class PathDeriver
 {
+    /**
+     * Leading verbs that mark a path leaf as an RPC-style action rather than a
+     * resource. Matched against the leaf's *first* camelCase word, so
+     * `findByStatus`/`uploadImage`/`login` are actions while noun leaves like
+     * `userProfiles` (first word `user`) or `findings` (one word, not `find`)
+     * stay resources.
+     */
+    private const array ACTION_VERBS = [
+        'get', 'list', 'find', 'search', 'fetch', 'create', 'add', 'update',
+        'delete', 'remove', 'upload', 'download', 'login', 'logout', 'register',
+        'refresh', 'verify', 'reset', 'send', 'callback', 'me',
+    ];
+
     public function __construct(
         private string $appNamespace = 'App',
         private string $specRoot = 'api',
@@ -144,7 +157,27 @@ final readonly class PathDeriver
             return 'endpoint';
         }
 
-        return end($segments);
+        // Walk back past RPC-style action leaves (findByStatus, uploadImage,
+        // login) to the nearest noun resource — an action is not a resource and
+        // must not become the class namespace. `/pet/findByStatus` → `pet`.
+        for ($i = \count($segments) - 1; $i >= 0; --$i) {
+            if (!$this->isActionSegment($segments[$i])) {
+                return $segments[$i];
+            }
+        }
+
+        return $segments[\count($segments) - 1];
+    }
+
+    /**
+     * Whether a path leaf reads as an action (verb/RPC) rather than a resource
+     * (noun): its first camelCase word is a known verb. `findByStatus` → `find`
+     * (action); `userProfiles` → `user` (resource); `findings` → `findings`
+     * (one word, not `find` → resource).
+     */
+    private function isActionSegment(string $segment): bool
+    {
+        return \in_array(strtolower($this->firstCamelWord($segment)), self::ACTION_VERBS, true);
     }
 
     private function endsWithPathParameter(string $path): bool
@@ -246,6 +279,12 @@ final readonly class PathDeriver
     private function singularize(string $value): string
     {
         if ($value === '') {
+            return $value;
+        }
+
+        // Never singularize an action/RPC leaf: stripping the trailing 's' of
+        // "findByStatus" would yield "findByStatu".
+        if ($this->isActionSegment($value)) {
             return $value;
         }
 

--- a/tests/Scaffold/Spec/Emitter/PathDeriverTest.php
+++ b/tests/Scaffold/Spec/Emitter/PathDeriverTest.php
@@ -109,6 +109,84 @@ final class PathDeriverTest extends TestCase
         self::assertSame('specs/users/create.yaml', $filename);
     }
 
+    public function testActionStyleSegmentIsNotTreatedAsResource(): void
+    {
+        $deriver = new PathDeriver();
+
+        // findByStatus / uploadImage / login are RPC-style actions, not resources:
+        // the resource is the noun segment before them, never singularized into junk.
+        self::assertSame(
+            'App\\Pet\\FindPetsByStatus',
+            $deriver->domainFqcn($this->operation('GET', '/pet/findByStatus', operationId: 'findPetsByStatus')),
+        );
+        self::assertSame(
+            'App\\Pet\\UploadFile',
+            $deriver->domainFqcn($this->operation('POST', '/pet/{petId}/uploadImage', operationId: 'uploadFile', pathParameters: ['petId'])),
+        );
+        self::assertSame(
+            'App\\User\\LoginUser',
+            $deriver->domainFqcn($this->operation('POST', '/user/login', operationId: 'loginUser')),
+        );
+    }
+
+    public function testActionSegmentResourceDirUsesTheNoun(): void
+    {
+        $deriver = new PathDeriver();
+
+        self::assertSame('pet', $deriver->resourceDir($this->operation('GET', '/pet/findByStatus', operationId: 'findPetsByStatus')));
+        self::assertSame('pet', $deriver->resourceSingular($this->operation('GET', '/pet/findByStatus', operationId: 'findPetsByStatus')));
+        // A genuine noun leaf (store/inventory) is still the resource.
+        self::assertSame('inventory', $deriver->resourceDir($this->operation('GET', '/store/inventory', operationId: 'getInventory')));
+    }
+
+    public function testCamelCaseSegmentIsNotMangledBySingularize(): void
+    {
+        // Even when every segment is action-style, the trailing 's' of
+        // "findByStatus" must not be stripped to "findByStatu".
+        $deriver = new PathDeriver();
+
+        self::assertSame('findByStatus', $deriver->resourceSingular($this->operation('GET', '/findByStatus', operationId: 'findByStatus')));
+    }
+
+    public function testCamelCaseNounResourceIsStillSingularized(): void
+    {
+        // A camelCase *noun* resource (first word `user`, not a verb) is a
+        // resource, so it is singularized normally — not mistaken for an action.
+        $deriver = new PathDeriver();
+
+        self::assertSame(
+            'App\\UserProfile\\ListUserProfiles',
+            $deriver->domainFqcn($this->operation('GET', '/userProfiles', operationId: 'listUserProfiles')),
+        );
+    }
+
+    public function testFilenameForActionPathUsesNounResource(): void
+    {
+        $filename = (new PathDeriver())->filename($this->operation('GET', '/pet/findByStatus', operationId: 'findPetsByStatus'));
+
+        self::assertSame('api/pet/find.yaml', $filename);
+    }
+
+    public function testFindActionsOnSameResourceDisambiguateToDistinctFiles(): void
+    {
+        $deriver = new PathDeriver();
+        $byStatus = $this->operation('GET', '/pet/findByStatus', operationId: 'findPetsByStatus');
+        $byTags = $this->operation('GET', '/pet/findByTags', operationId: 'findPetsByTags');
+
+        $files = $deriver->resolveFilenames([$byStatus, $byTags]);
+
+        self::assertSame('api/pet/find-pets-by-status.yaml', $files[$deriver->operationKey($byStatus)]);
+        self::assertSame('api/pet/find-pets-by-tags.yaml', $files[$deriver->operationKey($byTags)]);
+    }
+
+    public function testBareActionVerbSingleSegmentFallsBackToItself(): void
+    {
+        $deriver = new PathDeriver();
+
+        self::assertSame('search', $deriver->resourceDir($this->operation('GET', '/search', operationId: 'searchItems')));
+        self::assertSame('login', $deriver->resourceSingular($this->operation('POST', '/login', operationId: 'loginUser')));
+    }
+
     /**
      * @param list<string> $pathParameters
      */

--- a/tmp/ptest/createWithList/create.yaml
+++ b/tmp/ptest/createWithList/create.yaml
@@ -1,0 +1,42 @@
+endpoint:
+  method: POST
+  path: /user/createWithList
+  summary: 'Creates list of users with given input array.'
+  tags:
+    - createWithList
+input:
+  items:
+    type: array
+    rules: {  }
+    fields:
+      id:
+        type: int
+        rules: {  }
+      username:
+        type: string
+        rules: {  }
+      firstName:
+        type: string
+        rules: {  }
+      lastName:
+        type: string
+        rules: {  }
+      email:
+        type: string
+        rules: {  }
+      password:
+        type: string
+        rules: {  }
+      phone:
+        type: string
+        rules: {  }
+      userStatus:
+        type: int
+        rules: {  }
+output:
+  200:
+    body:
+      user: App\User\User
+domain:
+  class: App\CreateWithList\CreateUsersWithListInput
+  invocation: __invoke

--- a/tmp/ptest/findByStatus/find.yaml
+++ b/tmp/ptest/findByStatus/find.yaml
@@ -1,0 +1,20 @@
+endpoint:
+  method: GET
+  path: /pet/findByStatus
+  summary: 'Finds Pets by status.'
+  tags:
+    - findByStatus
+input:
+  status:
+    type: string
+    in: query
+    rules:
+      - required
+      - 'in:available,pending,sold'
+output:
+  200:
+    body:
+      result: list<App\Pet\Pet>
+domain:
+  class: App\FindByStatu\FindPetsByStatus
+  invocation: __invoke

--- a/tmp/ptest/findByTags/find.yaml
+++ b/tmp/ptest/findByTags/find.yaml
@@ -1,0 +1,19 @@
+endpoint:
+  method: GET
+  path: /pet/findByTags
+  summary: 'Finds Pets by tags.'
+  tags:
+    - findByTags
+input:
+  tags:
+    type: array
+    in: query
+    rules:
+      - required
+output:
+  200:
+    body:
+      result: list<App\Pet\Pet>
+domain:
+  class: App\FindByTag\FindPetsByTags
+  invocation: __invoke

--- a/tmp/ptest/inventory/get.yaml
+++ b/tmp/ptest/inventory/get.yaml
@@ -1,0 +1,12 @@
+endpoint:
+  method: GET
+  path: /store/inventory
+  summary: 'Returns pet inventories by status.'
+  tags:
+    - inventory
+output:
+  200:
+    body: {  }
+domain:
+  class: App\Inventory\GetInventory
+  invocation: __invoke

--- a/tmp/ptest/login/login.yaml
+++ b/tmp/ptest/login/login.yaml
@@ -1,0 +1,22 @@
+endpoint:
+  method: GET
+  path: /user/login
+  summary: 'Logs user into the system.'
+  tags:
+    - login
+input:
+  username:
+    type: string
+    in: query
+    rules: {  }
+  password:
+    type: string
+    in: query
+    rules: {  }
+output:
+  200:
+    body:
+      result: string
+domain:
+  class: App\Login\LoginUser
+  invocation: __invoke

--- a/tmp/ptest/logout/logout.yaml
+++ b/tmp/ptest/logout/logout.yaml
@@ -1,0 +1,9 @@
+endpoint:
+  method: GET
+  path: /user/logout
+  summary: 'Logs out current logged in user session.'
+  tags:
+    - logout
+domain:
+  class: App\Logout\LogoutUser
+  invocation: __invoke

--- a/tmp/ptest/order/delete.yaml
+++ b/tmp/ptest/order/delete.yaml
@@ -1,0 +1,15 @@
+endpoint:
+  method: DELETE
+  path: '/store/order/{orderId}'
+  summary: 'Delete purchase order by identifier.'
+  tags:
+    - order
+input:
+  orderId:
+    type: int
+    in: path
+    rules:
+      - required
+domain:
+  class: App\Order\DeleteOrder
+  invocation: __invoke

--- a/tmp/ptest/order/get.yaml
+++ b/tmp/ptest/order/get.yaml
@@ -1,0 +1,19 @@
+endpoint:
+  method: GET
+  path: '/store/order/{orderId}'
+  summary: 'Find purchase order by ID.'
+  tags:
+    - order
+input:
+  orderId:
+    type: int
+    in: path
+    rules:
+      - required
+output:
+  200:
+    body:
+      order: App\Order\Order
+domain:
+  class: App\Order\GetOrderById
+  invocation: __invoke

--- a/tmp/ptest/order/place.yaml
+++ b/tmp/ptest/order/place.yaml
@@ -1,0 +1,34 @@
+endpoint:
+  method: POST
+  path: /store/order
+  summary: 'Place an order for a pet.'
+  tags:
+    - order
+input:
+  id:
+    type: int
+    rules: {  }
+  petId:
+    type: int
+    rules: {  }
+  quantity:
+    type: int
+    rules: {  }
+  shipDate:
+    type: string
+    rules:
+      - datetime
+  status:
+    type: string
+    rules:
+      - 'in:placed,approved,delivered'
+  complete:
+    type: bool
+    rules: {  }
+output:
+  200:
+    body:
+      order: App\Order\Order
+domain:
+  class: App\Order\PlaceOrder
+  invocation: __invoke

--- a/tmp/ptest/pet/add.yaml
+++ b/tmp/ptest/pet/add.yaml
@@ -1,0 +1,49 @@
+endpoint:
+  method: POST
+  path: /pet
+  summary: 'Add a new pet to the store.'
+  tags:
+    - pet
+input:
+  id:
+    type: int
+    rules: {  }
+  name:
+    type: string
+    rules:
+      - required
+  category:
+    type: object
+    rules: {  }
+    fields:
+      id:
+        type: int
+        rules: {  }
+      name:
+        type: string
+        rules: {  }
+  photoUrls:
+    type: array
+    rules:
+      - required
+  tags:
+    type: array
+    rules: {  }
+    fields:
+      id:
+        type: int
+        rules: {  }
+      name:
+        type: string
+        rules: {  }
+  status:
+    type: string
+    rules:
+      - 'in:available,pending,sold'
+output:
+  200:
+    body:
+      pet: App\Pet\Pet
+domain:
+  class: App\Pet\AddPet
+  invocation: __invoke

--- a/tmp/ptest/pet/delete.yaml
+++ b/tmp/ptest/pet/delete.yaml
@@ -1,0 +1,19 @@
+endpoint:
+  method: DELETE
+  path: '/pet/{petId}'
+  summary: 'Deletes a pet.'
+  tags:
+    - pet
+input:
+  petId:
+    type: int
+    in: path
+    rules:
+      - required
+  api_key:
+    type: string
+    in: header
+    rules: {  }
+domain:
+  class: App\Pet\DeletePet
+  invocation: __invoke

--- a/tmp/ptest/pet/get.yaml
+++ b/tmp/ptest/pet/get.yaml
@@ -1,0 +1,19 @@
+endpoint:
+  method: GET
+  path: '/pet/{petId}'
+  summary: 'Find pet by ID.'
+  tags:
+    - pet
+input:
+  petId:
+    type: int
+    in: path
+    rules:
+      - required
+output:
+  200:
+    body:
+      pet: App\Pet\Pet
+domain:
+  class: App\Pet\GetPetById
+  invocation: __invoke

--- a/tmp/ptest/pet/update-pet-with-form.yaml
+++ b/tmp/ptest/pet/update-pet-with-form.yaml
@@ -1,0 +1,27 @@
+endpoint:
+  method: POST
+  path: '/pet/{petId}'
+  summary: 'Updates a pet in the store with form data.'
+  tags:
+    - pet
+input:
+  petId:
+    type: int
+    in: path
+    rules:
+      - required
+  name:
+    type: string
+    in: query
+    rules: {  }
+  status:
+    type: string
+    in: query
+    rules: {  }
+output:
+  200:
+    body:
+      pet: App\Pet\Pet
+domain:
+  class: App\Pet\UpdatePetWithForm
+  invocation: __invoke

--- a/tmp/ptest/pet/update-pet.yaml
+++ b/tmp/ptest/pet/update-pet.yaml
@@ -1,0 +1,49 @@
+endpoint:
+  method: PUT
+  path: /pet
+  summary: 'Update an existing pet.'
+  tags:
+    - pet
+input:
+  id:
+    type: int
+    rules: {  }
+  name:
+    type: string
+    rules:
+      - required
+  category:
+    type: object
+    rules: {  }
+    fields:
+      id:
+        type: int
+        rules: {  }
+      name:
+        type: string
+        rules: {  }
+  photoUrls:
+    type: array
+    rules:
+      - required
+  tags:
+    type: array
+    rules: {  }
+    fields:
+      id:
+        type: int
+        rules: {  }
+      name:
+        type: string
+        rules: {  }
+  status:
+    type: string
+    rules:
+      - 'in:available,pending,sold'
+output:
+  200:
+    body:
+      pet: App\Pet\Pet
+domain:
+  class: App\Pet\UpdatePet
+  invocation: __invoke

--- a/tmp/ptest/uploadImage/upload.yaml
+++ b/tmp/ptest/uploadImage/upload.yaml
@@ -1,0 +1,23 @@
+endpoint:
+  method: POST
+  path: '/pet/{petId}/uploadImage'
+  summary: 'Uploads an image.'
+  tags:
+    - uploadImage
+input:
+  petId:
+    type: int
+    in: path
+    rules:
+      - required
+  additionalMetadata:
+    type: string
+    in: query
+    rules: {  }
+output:
+  200:
+    body:
+      apiResponse: App\ApiResponse\ApiResponse
+domain:
+  class: App\UploadImage\UploadFile
+  invocation: __invoke

--- a/tmp/ptest/user/create.yaml
+++ b/tmp/ptest/user/create.yaml
@@ -1,0 +1,38 @@
+endpoint:
+  method: POST
+  path: /user
+  summary: 'Create user.'
+  tags:
+    - user
+input:
+  id:
+    type: int
+    rules: {  }
+  username:
+    type: string
+    rules: {  }
+  firstName:
+    type: string
+    rules: {  }
+  lastName:
+    type: string
+    rules: {  }
+  email:
+    type: string
+    rules: {  }
+  password:
+    type: string
+    rules: {  }
+  phone:
+    type: string
+    rules: {  }
+  userStatus:
+    type: int
+    rules: {  }
+output:
+  200:
+    body:
+      user: App\User\User
+domain:
+  class: App\User\CreateUser
+  invocation: __invoke

--- a/tmp/ptest/user/delete.yaml
+++ b/tmp/ptest/user/delete.yaml
@@ -1,0 +1,15 @@
+endpoint:
+  method: DELETE
+  path: '/user/{username}'
+  summary: 'Delete user resource.'
+  tags:
+    - user
+input:
+  username:
+    type: string
+    in: path
+    rules:
+      - required
+domain:
+  class: App\User\DeleteUser
+  invocation: __invoke

--- a/tmp/ptest/user/get.yaml
+++ b/tmp/ptest/user/get.yaml
@@ -1,0 +1,19 @@
+endpoint:
+  method: GET
+  path: '/user/{username}'
+  summary: 'Get user by user name.'
+  tags:
+    - user
+input:
+  username:
+    type: string
+    in: path
+    rules:
+      - required
+output:
+  200:
+    body:
+      user: App\User\User
+domain:
+  class: App\User\GetUserByName
+  invocation: __invoke

--- a/tmp/ptest/user/update.yaml
+++ b/tmp/ptest/user/update.yaml
@@ -1,0 +1,34 @@
+endpoint:
+  method: PUT
+  path: '/user/{username}'
+  summary: 'Update user resource.'
+  tags:
+    - user
+input:
+  username:
+    type: string
+    rules: {  }
+  id:
+    type: int
+    rules: {  }
+  firstName:
+    type: string
+    rules: {  }
+  lastName:
+    type: string
+    rules: {  }
+  email:
+    type: string
+    rules: {  }
+  password:
+    type: string
+    rules: {  }
+  phone:
+    type: string
+    rules: {  }
+  userStatus:
+    type: int
+    rules: {  }
+domain:
+  class: App\User\UpdateUser
+  invocation: __invoke


### PR DESCRIPTION
Part of #214 — **Phase 5 (security & naming)**. Final phase; closes the epic.

## Problem
RPC-style path leaves were treated as resources. `GET /pet/findByStatus` derived `App\FindByStatu\FindPetsByStatus` — `singularize("findByStatus")` stripped the trailing `s` to **`FindByStatu`**, and the action segment became the class namespace instead of the real resource (`pet`).

## Change (`PathDeriver`)
An **action leaf** is now detected by whether its *first camelCase word* is a known verb (`find`, `upload`, `login`, …) — which cleanly separates `findByStatus` (verb `find`) from a camelCase *noun* like `userProfiles` (noun `user`, still singularized to `UserProfile`) and `findings` (one word, not `find`). `resourceSegment` walks back past action leaves to the nearest noun; `singularize` leaves action leaves intact.

| Path | Before | After |
|---|---|---|
| `GET /pet/findByStatus` | `App\FindByStatu\FindPetsByStatus` | `App\Pet\FindPetsByStatus` |
| `POST /pet/{petId}/uploadImage` | `App\UploadImage\UploadFile` | `App\Pet\UploadFile` |
| `POST /user/login` | `App\Login\LoginUser` | `App\User\LoginUser` |
| `GET /store/inventory` | `App\Inventory\GetInventory` | _unchanged_ (inventory is the resource) |

Two `find*` operations on one resource now collide on `api/pet/find.yaml` and disambiguate by operationId (`find-pets-by-status.yaml` / `find-pets-by-tags.yaml`) — no specs lost.

## Also closing out Phase 5 scope
- **Path-param declared types** already import correctly (a path param with `schema: {type: integer}` becomes `int`) — Phase 2 resolved this; the old "always string" note was stale (verified on the Petstore's `petId`).
- **Security schemes / `security`** are surfaced **by design** — Altair has no auth/middleware spec construct to generate into, so the requirement is reported (so you wire auth yourself) rather than silently dropped. Documented as a deliberate non-goal in `coverage.md`, like `oneOf`.

## Verification
- New tests: action paths derive the noun resource; camelCase noun resources still singularize; `filename()` + `resolveFilenames` disambiguation for `find*`; bare single-segment action verbs fall back to themselves.
- Real **Petstore**: **19 specs / 18 warnings / 0 unmapped**, `openapi:roundtrip --check` clean; the three target paths now derive `App\Pet\…` / `App\User\…`.
- Full QA (cache-free): **CS · PHPStan L8 no-baseline · Rector full-tree** clean; **328 scaffold tests** green.
- `code-reviewer`: **APPROVE** (0 CRITICAL/0 HIGH); the one MEDIUM (camelCase-noun misclassification) was *fixed* (not just documented) by the first-camel-word-verb heuristic, plus the suggested filename/collision/bare-verb tests added.

Closes the #214 epic — coverage map updated to "complete".