### PR TITLE
re #228 fix(dist): allow psr/http-message ^1.1 in univeros/http and univeros/cookie

### DIFF
--- a/src/Altair/Cookie/composer.json
+++ b/src/Altair/Cookie/composer.json
@@ -9,7 +9,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "univeros/structure": "^2.0"
     },
     "autoload": {

--- a/src/Altair/Http/composer.json
+++ b/src/Altair/Http/composer.json
@@ -16,7 +16,7 @@
         "nikic/fast-route": "^1.3",
         "psr/cache": "^3.0",
         "psr/http-factory": "^1.1",
-        "psr/http-message": "^2.0",
+        "psr/http-message": "^1.1 || ^2.0",
         "psr/http-server-handler": "^1.0",
         "psr/http-server-middleware": "^1.0",
         "relay/relay": "^2.1",


### PR DESCRIPTION
Closes #228.

## Problem

`composer require univeros/http` — and therefore any module scaffolded by `bin/altair module:new` (it requires the split `univeros/http`) — fails to resolve:

```
- neomerx/cors-psr7 require psr/http-message ^1.0
- univeros/http require neomerx/cors-psr7 ^3.0 AND psr/http-message ^2.0
- You can only install one version of psr/http-message[1.0, 1.0.1, 1.1, 2.0]
```

## Root cause

`univeros/http` and `univeros/cookie` pin `psr/http-message: ^2.0`, but their own transitive deps cap the graph at PSR-7 **v1**:
- `neomerx/cors-psr7` → `psr/http-message ^1.0`
- `relay/relay` → `psr/http-message ~1.0`

The framework genuinely runs on **psr/http-message 1.1** (`MessageInterface::getProtocolVersion()` has no return type → v1.x; CI green). The monorepo root, `laminas/laminas-diactoros 3.8`, guzzle, and the sibling Altair packages (`Idempotency`/`Webhooks`/`Observatory`/`Observability`) already use `^1.1 || ^2.0` — **http and cookie were the only outliers.** The bug was hidden because the monorepo `replace`s the splits (their constraints ignored) and host apps depend on the `univeros/framework` *bundle* (root constraint already `^1.1 || ^2.0`); a module that requires the split `univeros/http` directly is the first consumer to hit it.

## Fix

```diff
- "psr/http-message": "^2.0"
+ "psr/http-message": "^1.1 || ^2.0"
```

in `src/Altair/Http/composer.json` and `src/Altair/Cookie/composer.json`. **No code change** — resolution is unchanged (neomerx/relay still pin the graph to 1.1), proven by `composer update --dry-run` (no psr/http-message movement) and a green cache-free `cs`/`stan`/`rector` locally.

Distinct from #209's longer-term work to replace/fork `neomerx/cors-psr7` and move fully to psr/http-message ^2.0.

## Test plan

- [x] Both composer.json schema-valid; monorepo resolution unchanged (still 1.1).
- [x] cache-free `composer cs` / `composer stan` (level 8) / `composer rector` — clean.
- [ ] CI: tests 8.3 + 8.4, Static Analysis, Determinism gate.
- [ ] Post-release (v2.5.1 + split): `composer require univeros/http` resolves in a fresh project; `bin/altair module:new` → `composer install` succeeds.