### PR TITLE
re #230 feat(scaffold): ship an AGENT.md in the module skeleton

### DIFF
--- a/src/Altair/Bootstrap/resources/module-skeleton/AGENT.md
+++ b/src/Altair/Bootstrap/resources/module-skeleton/AGENT.md
@@ -1,0 +1,90 @@
+# AGENT.md — vendor/module
+
+Agent guide for this package. It is a **Univeros module**: a pluggable, installable
+feature that a host app wires in with one line in `config/modules.php`. This file
+is the orientation an agent should read **before** editing — the human-facing
+README is `README.md`.
+
+## The one rule
+
+Use **this package's own vendor and namespace** everywhere. Never rename things to
+`Altair\*` (the framework's first-party namespace) or to a `univeros/*` package name
+(those are the framework's read-only splits). The scaffolder already set the correct
+name and namespace — keep them.
+
+## What a module is
+
+`src/Module.php` implements `Altair\Module\Contracts\ModuleInterface` (a
+`ConfigurationInterface` + `name()`) and **opts into capabilities by also
+implementing the narrow provider contracts** — implement only what you ship:
+
+| Contract | Method | Contributes |
+|---|---|---|
+| `RoutesProviderInterface` | `routes()` | HTTP routes |
+| `MiddlewareProviderInterface` | `middleware()` | PSR-15 middleware, ordered by priority |
+| `EntityDirectoriesProviderInterface` | `entityDirectories()` | Cycle entity dirs |
+| `MigrationDirectoriesProviderInterface` | `migrationDirectories()` | DB migrations |
+
+Drop a capability by removing its interface from the `implements` list. A
+service-only module needs just `ModuleInterface` and `univeros/module`.
+
+## The HTTP lifecycle
+
+Endpoints follow **Action -> Input(DTO) -> Domain -> Responder**. The generated
+`VendorModule\Http\Actions\SampleAction` + `SampleInput` + `SampleResponder` +
+`VendorModule\Domain\SampleService` are the canonical pattern — copy their shape
+for new endpoints. The Action stays thin: validate via the Input, call the Domain,
+hand the result to the Responder.
+
+## Conventions (non-negotiable)
+
+- `declare(strict_types=1);` in **every** PHP file.
+- **Immutability** — never mutate value objects; return new copies via `withX()`.
+- **Native types** over PHPDoc; add PHPDoc only for `array<K,V>` shapes / unions PHP
+  can't express.
+- **Many small files** (200-400 LOC typical), organized by feature.
+- **Tests first**, 80%+ coverage on new code. No new code without a test.
+
+## Develop and test in isolation (no host app needed)
+
+```bash
+composer install
+vendor/bin/phpunit
+```
+
+`tests/ModuleTest.php` constructs the module and asserts its routes, bindings, and
+directories. Grow it as you add behaviour — the host is never involved to test a
+module in isolation.
+
+## Scaffolding endpoints — important caveat
+
+The `bin/altair spec:scaffold` YAML flow (write a spec, emit the Action/Input/
+Responder/Domain/test) lives in the **framework**, not in this package's
+dependencies. So inside this module:
+
+- The spec YAML **vocabulary is not vendored here** — do not guess it. Confirm with
+  `bin/altair spec:show <spec>` against a framework install before relying on it.
+- If `bin/altair` is unavailable, **hand-write** the Action/Input/Responder triple
+  following `SampleAction` rather than inventing a structure.
+
+## How a host installs this module
+
+```php
+// host app: config/modules.php
+return [
+    new VendorModule\Module(),
+];
+```
+
+Routes, middleware, and migrations are then picked up automatically. Entities need
+one host binding: `SchemaProviderInterface` -> `ModuleAwareSchemaProvider`.
+
+## Publish
+
+An ordinary Composer package — tag a release and submit to Packagist. Keep your own
+vendor/namespace (see "The one rule").
+
+## Canonical docs
+
+- Building a module: <https://github.com/univeros/framework/blob/master/docs/guides/extending.md>
+- Module contract reference: <https://github.com/univeros/framework/blob/master/docs/packages/module.md>

--- a/tests/Bootstrap/MakeModuleCommandTest.php
+++ b/tests/Bootstrap/MakeModuleCommandTest.php
@@ -50,6 +50,14 @@ final class MakeModuleCommandTest extends TestCase
         $migration = (string) file_get_contents($migrations[0]);
         self::assertStringContainsString('namespace Acme\\UserManagement\\Database\\Migrations;', $migration);
 
+        // The agent guide ships rewritten — package name + namespace substituted,
+        // no leftover skeleton placeholders.
+        $agent = (string) file_get_contents($this->target . '/AGENT.md');
+        self::assertStringContainsString('acme/user-management', $agent);
+        self::assertStringContainsString('Acme\\UserManagement\\Module', $agent);
+        self::assertStringNotContainsString('vendor/module', $agent);
+        self::assertStringNotContainsString('VendorModule', $agent);
+
         // The next-steps blurb tells the user exactly what to register.
         self::assertStringContainsString('Acme\\UserManagement\\Module', $output);
     }


### PR DESCRIPTION
Closes #230.

## Problem

`bin/altair module:new` generates a module with only a human-oriented `README.md`. The **host** skeleton ships agent guidance (`.ai/skills/altair/SKILL.md` + `.claude/skills/altair/`), but that skill is `bin/altair`-driven and assumes a running host app — a standalone module has neither. So an agent dropped into a scaffolded module gets zero Univeros-specific orientation.

Observed in a real session building a module: it picked a forbidden `univeros/*` name + `Univeros\*` namespace, guessed at the `spec:scaffold` YAML vocabulary (not vendored in the module), and hand-built from the raw template instead of running `module:new`. A single agent guide would have prevented all three.

## Change

Add a placeholder-templated **`AGENT.md`** to the module skeleton. `SkeletonGenerator` rewrites its `vendor/module` / `VendorModule\` tokens like every other file (the non-`.php` branch replaces `VendorModule\` and `vendor/module`), so the emitted guide carries the module's real package name and namespace.

It covers, module-focused and agent-agnostic:
- **The one rule** — own vendor/namespace, never `Altair\*` or `univeros/*`.
- `ModuleInterface` + the opt-in capability contracts (Routes / Middleware / Entity dirs / Migration dirs) — implement only what you ship.
- The **Action -> Input(DTO) -> Domain -> Responder** lifecycle; follow the generated `Sample*` as the pattern.
- Coding conventions (`declare(strict_types=1)`, immutability, native types, small files, tests-first).
- The isolated dev/test loop (`composer install && vendor/bin/phpunit` — no host needed).
- The **spec:scaffold caveat**: the YAML vocabulary lives in the framework, not in this package — confirm with `bin/altair spec:show`, or hand-write following the sample.
- Host wiring (`config/modules.php` + the one schema binding) and the publish step.
- Links to the canonical `extending.md` / `module.md`.

`MakeModuleCommandTest` now asserts the AGENT.md is generated and fully rewritten (package name + namespace substituted, no leftover `vendor/module` / `VendorModule\`).

## Note (not a bug)

The reported "composer.json still says `vendor/module` / `VendorModule\`" is **not** a scaffolder bug — `module:new` rewrites `composer.json` and source correctly (verified). That mismatch came from hand-building off the raw template; this PR doesn't change that, but the new AGENT.md tells agents to scaffold with `module:new` and keep the generated name/namespace.

## Test plan

- [x] `module:new` emits a rewritten `AGENT.md` (`# AGENT.md — acme/polaris`, `Acme\Polaris\Module`, no placeholders); file count 12 -> 13.
- [x] `MakeModuleCommandTest` — 2 tests / 16 assertions, green.
- [x] `tests/Bootstrap` — 22 tests green.
- [x] `composer cs` / `composer stan` (level 8) / `composer rector` — clean.
- [ ] CI: 8.3 + 8.4, Static Analysis, Determinism gate.